### PR TITLE
Adds dark mode styles, tweaks light mode styles

### DIFF
--- a/packages/assist/frontend/src/App.vue
+++ b/packages/assist/frontend/src/App.vue
@@ -437,6 +437,7 @@ textarea.api-key {
   background: none;
   padding-left: 0;
   margin-left: 0;
+  color: var(--color-text);
 
   &:hover {
     cursor: pointer;

--- a/packages/assist/frontend/src/assets/base.css
+++ b/packages/assist/frontend/src/assets/base.css
@@ -34,6 +34,7 @@
   --color-text: var(--vt-c-text-light-1);
 
   --section-gap: 160px;
+  --link: #1565c0;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -47,6 +48,7 @@
 
     --color-heading: var(--vt-c-text-dark-1);
     --color-text: var(--vt-c-text-dark-2);
+    --link: #90caf9;
   }
 }
 
@@ -81,4 +83,8 @@ body {
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+a {
+  color: var(--link);
 }

--- a/packages/assist/frontend/src/options.ts
+++ b/packages/assist/frontend/src/options.ts
@@ -1,3 +1,5 @@
+import './assets/main.css';
+
 import { createApp, watch } from 'vue';
 import { createPinia } from 'pinia';
 


### PR DESCRIPTION
Closes #35 

* This affects Daily Brief and Options page
* Adds dark mode for Options page
* Improves [dark mode font colors](https://github.com/thunderbird/assist/issues/129) for Daily Brief
* Improves light mode fonts for both

## Dark mode

![image](https://github.com/user-attachments/assets/db6171d9-519b-47fa-85bf-ba0707b68d1d)

![image](https://github.com/user-attachments/assets/13812f4f-893c-404a-a43f-6471cdfddea4)


## Light mode 

![image](https://github.com/user-attachments/assets/a362d557-b865-49ad-84dd-c63e51557ac0)

![image](https://github.com/user-attachments/assets/f4efa790-015d-4c59-adc8-2d1450656ea5)
