### PR TITLE
[Assist] Only summarize recent emails (no older than 7 days)

### DIFF
--- a/packages/assist/frontend/src/lib/flowerUtils.ts
+++ b/packages/assist/frontend/src/lib/flowerUtils.ts
@@ -241,7 +241,7 @@ export async function summarizeOnReceive(
 ) {
   if (await getFlwrApiKey()) {
     for (const message of messages.messages) {
-      if ((message.date as Date).getTime() < Date.now() - ONE_WEEK_MS) {
+      if ((message.date as Date).getTime() > Date.now() - ONE_WEEK_MS) {
         await getSummaryById(message.id, false);
       }
     }


### PR DESCRIPTION
We want to prevent users that are syncing all of their emails to send thousands of concurrent requests for summarization. The 7 days are arbitrary, but it seems like older emails can always be summarized manually (using the button)