### PR TITLE
make default container the new root

### DIFF
--- a/packages/send/backend/src/models/containers.ts
+++ b/packages/send/backend/src/models/containers.ts
@@ -104,6 +104,16 @@ export async function getContainerWithAncestors(id: string) {
   return container;
 }
 
+export async function getContainerWithoutAncestors(userId: string) {
+  const topLevelContainers = prisma.container.findFirst({
+    where: {
+      parent: { is: null },
+      owner: { id: userId },
+    },
+  });
+  return topLevelContainers;
+}
+
 export async function getAccessLinksForContainer(containerId: string) {
   const shares = await fromPrismaV2(prisma.share.findMany, {
     where: {

--- a/packages/send/e2e/pages/dashboard.ts
+++ b/packages/send/e2e/pages/dashboard.ts
@@ -74,6 +74,9 @@ export async function log_out_restore_keys({ page }: PlaywrightProps) {
   // look for folder (only shows when keys are restored)
   await secondPage.goto("/send");
 
+  // Create a new folder
+  await secondPage.getByTestId("new-folder-button").click();
+
   // Check that default folder exists
   await secondPage.waitForSelector(folderRowSelector);
   let folder = secondPage.getByTestId(folderRowTestID);

--- a/packages/send/frontend/src/apps/send/components/BreadCrumb.vue
+++ b/packages/send/frontend/src/apps/send/components/BreadCrumb.vue
@@ -5,7 +5,6 @@ import { useRouter } from 'vue-router';
 const folderStore = useFolderStore();
 
 const path = ref([]);
-
 const router = useRouter();
 
 watchEffect(() => {
@@ -19,33 +18,75 @@ watchEffect(() => {
 </script>
 
 <template>
-  <ul>
-    <li class="inline-block pl-1">
-      <button data-testid="home-button" @click="router.push('/send')">
-        🏠
-      </button>
-    </li>
-    <li
-      v-for="node of path"
-      v-if="folderStore.rootFolder"
-      :key="node.id"
-      class="inline-block pl-1"
-    >
-      &nbsp;&gt;&nbsp;
-      <button
-        @click.prevent="
-          router.push({ name: 'folder', params: { id: node.id } })
-        "
-      >
-        {{ node.name }}
-      </button>
-    </li>
-  </ul>
+  <nav aria-label="Breadcrumb navigation">
+    <ol class="breadcrumb-list">
+      <template v-if="folderStore.rootFolder">
+        <li
+          v-for="(folder, index) of path"
+          :key="folder.id"
+          class="breadcrumb-item"
+        >
+          <!-- We just want to show the separator with more than one item -->
+          <span class="breadcrumb-separator" aria-hidden="true">{{
+            index !== 0 ? '&gt;' : ''
+          }}</span>
+          <button
+            :aria-label="`Go to ${folder.name} folder`"
+            :aria-current="index === path.length - 1 ? 'page' : undefined"
+            class="breadcrumb-button"
+            :data-testid="index !== 0 ? 'breadcrumb-item' : 'home-button'"
+            @click.prevent="
+              router.push({ name: 'folder', params: { id: folder.id } })
+            "
+          >
+            {{ folder.id === folderStore.rootFolderId ? '🏠' : folder.name }}
+          </button>
+        </li>
+      </template>
+    </ol>
+  </nav>
 </template>
 
 <style scoped>
-li,
-button {
+.breadcrumb-list {
+  display: flex;
+  align-items: center;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.breadcrumb-list li {
+  display: flex;
+  align-items: center;
+}
+
+.breadcrumb-button {
   user-select: none;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 0.25rem;
+  border-radius: 0.25rem;
+  transition: background-color 0.2s;
+}
+
+.breadcrumb-button:hover {
+  background-color: rgba(0, 0, 0, 0.1);
+}
+
+.breadcrumb-button:focus {
+  outline: 2px solid #007acc;
+  outline-offset: 2px;
+}
+
+.breadcrumb-separator {
+  margin: 0 0.5rem;
+  color: #666;
+}
+
+.breadcrumb-item {
+  display: flex;
+  align-items: center;
 }
 </style>

--- a/packages/send/frontend/src/apps/send/components/FolderNavigation.vue
+++ b/packages/send/frontend/src/apps/send/components/FolderNavigation.vue
@@ -4,32 +4,72 @@ import useFolderStore from '@/apps/send/stores/folder-store';
 import DragAndDropUpload from '@/apps/send/components/DragAndDropUpload.vue';
 
 const folderStore = useFolderStore();
+
+const handleUploadKeydown = (event: KeyboardEvent) => {
+  if (event.key === 'Enter' || event.key === ' ') {
+    event.preventDefault();
+    (event.target as HTMLElement).click();
+  }
+};
 </script>
 
 <template>
-  <div class="flex flex-col gap-6 h-full">
+  <aside
+    class="flex flex-col gap-6 h-full"
+    role="complementary"
+    aria-label="File management sidebar"
+  >
     <!-- actions -->
-    <header class="flex items-center justify-between pt-2 px-2.5"></header>
+    <header class="flex items-center justify-between pt-2 px-2.5">
+      <h2 class="sr-only">File Management Actions</h2>
+    </header>
+
     <!-- upload zone -->
-    <section class="px-2.5">
+    <section class="px-2.5" aria-labelledby="upload-heading">
+      <h3 id="upload-heading" class="sr-only">Upload Files</h3>
       <DragAndDropUpload v-if="folderStore.rootFolder">
         <div
           class="h-36 flex justify-center items-center text-center font-bold text-lg text-gray-500 border-4 border-dashed border-gray-300 rounded-lg"
+          role="button"
+          tabindex="0"
+          aria-label="Drag and drop files here to upload, or click to select files"
+          @keydown="handleUploadKeydown"
         >
           Drag &amp; Drop<br />
           files here to upload
         </div>
       </DragAndDropUpload>
     </section>
-    <section class="flex flex-col gap-2 p-2.5">
-      <ul>
+
+    <!-- navigation -->
+    <nav class="flex flex-col gap-2 p-2.5" aria-labelledby="nav-heading">
+      <h3 id="nav-heading" class="sr-only">Navigation</h3>
+      <ul role="list">
         <li data-tesid="my-files-link">
-          <router-link to="/send">My Files</router-link>
+          <router-link
+            to="/send"
+            class="block py-2 px-3 rounded hover:bg-gray-100 focus:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-colors"
+            aria-describedby="my-files-desc"
+          >
+            My Files
+            <span id="my-files-desc" class="sr-only"
+              >Navigate to your uploaded files</span
+            >
+          </router-link>
         </li>
         <li data-tesid="profile-link">
-          <router-link to="/send/profile">Profile</router-link>
+          <router-link
+            to="/send/profile"
+            class="block py-2 px-3 rounded hover:bg-gray-100 focus:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-colors"
+            aria-describedby="profile-desc"
+          >
+            Profile
+            <span id="profile-desc" class="sr-only"
+              >View and edit your profile settings</span
+            >
+          </router-link>
         </li>
       </ul>
-    </section>
-  </div>
+    </nav>
+  </aside>
 </template>

--- a/packages/send/frontend/src/apps/send/components/NewFolder.vue
+++ b/packages/send/frontend/src/apps/send/components/NewFolder.vue
@@ -10,7 +10,11 @@ const folderStore = useFolderStore();
 <template>
   <!-- Only show button outside of profile page -->
   <div v-if="isInProfileView">
-    <Btn primary @click="folderStore.createFolder()">
+    <Btn
+      primary
+      data-testid="new-folder-button"
+      @click="folderStore.createFolder()"
+    >
       <IconPlus class="w-5 h-5 stroke-2" />
       New Folder
     </Btn>

--- a/packages/send/frontend/src/apps/send/router.ts
+++ b/packages/send/frontend/src/apps/send/router.ts
@@ -15,6 +15,7 @@ import useKeychainStore from '@/stores/keychain-store';
 import { IS_DEV } from '@/lib/clientConfig';
 import { getCanRetry } from '@/lib/validations';
 
+import { useFolderStore } from '@/stores';
 import useMetricsStore from '@/stores/metrics';
 import NotFoundPage from '../common/NotFoundPage.vue';
 import ExtensionPage from './ExtensionPage.vue';
@@ -29,6 +30,7 @@ enum META_OPTIONS {
   autoRestoresKeys = 'autoRestoresKeys',
   requiresBackedUpKeys = 'requiresBackedUpKeys',
   requiresRetryCountCheck = 'requiresRetryCountCheck',
+  resolveDefaultFolder = 'resolveDefaultFolder',
 }
 
 export const routes: RouteRecordRaw[] = [
@@ -47,11 +49,21 @@ export const routes: RouteRecordRaw[] = [
     children: [
       {
         path: '',
+        redirect: '/send/folder/root',
+        meta: {
+          [META_OPTIONS.requiresValidToken]: true,
+          [META_OPTIONS.autoRestoresKeys]: true,
+          [META_OPTIONS.requiresBackedUpKeys]: true,
+        },
+      },
+      {
+        path: 'folder/root',
         component: FolderView,
         meta: {
           [META_OPTIONS.requiresValidToken]: true,
           [META_OPTIONS.autoRestoresKeys]: true,
           [META_OPTIONS.requiresBackedUpKeys]: true,
+          [META_OPTIONS.resolveDefaultFolder]: true,
         },
       },
       {
@@ -131,6 +143,8 @@ const router = createRouter({
 });
 
 router.beforeEach(async (to, from, next) => {
+  const folderStore = useFolderStore();
+
   const { keychain } = useKeychainStore();
   const { api } = useApiStore();
   const { validators } = useStatusStore();
@@ -142,6 +156,7 @@ router.beforeEach(async (to, from, next) => {
     to,
     META_OPTIONS.redirectOnValidSession
   );
+  const resolveDefaultFolder = matchMeta(to, META_OPTIONS.resolveDefaultFolder);
   const requiresValidToken = matchMeta(to, META_OPTIONS.requiresValidToken);
   const autoRestoresKeys = matchMeta(to, META_OPTIONS.autoRestoresKeys);
   const requiresBackedUpKeys = matchMeta(to, META_OPTIONS.requiresBackedUpKeys);
@@ -173,6 +188,10 @@ router.beforeEach(async (to, from, next) => {
     } catch (error) {
       console.error('Error restoring keys', error);
     }
+  }
+
+  if (resolveDefaultFolder) {
+    return next(`/send/folder/${folderStore.rootFolderId}`);
   }
 
   // If a file has exceeded the maximum number of retries, it will be locked.

--- a/packages/send/frontend/src/lib/share.ts
+++ b/packages/send/frontend/src/lib/share.ts
@@ -91,7 +91,7 @@ export default class Sharer {
 
     const itemsToShare = [...items];
 
-    let currentContainer = { name: 'untitled' };
+    let currentContainer = { name: 'default' };
     if (containerId) {
       currentContainer = await this.api.call(`containers/${containerId}/info`);
       // TODO: future enhancement


### PR DESCRIPTION
Closes https://github.com/thunderbird/tbpro-add-on/issues/73

This PR removes the "root folder" from the UI and opens the default folder as the new root. This allows the user to upload files and create folders from any view.

Additionally this PR contains
- A trpc route to get the default folder
- A field in the folder store to store the default folder value
- Updated e2e tests