### PR TITLE
can delete share links + coverage

### DIFF
--- a/packages/send/backend/src/models/sharing.ts
+++ b/packages/send/backend/src/models/sharing.ts
@@ -819,6 +819,17 @@ export async function burnFolder(
   };
 }
 
+export async function deleteAccessLink(linkId: string) {
+  return await prisma.accessLink.delete({
+    where: {
+      id: linkId,
+    },
+    select: {
+      id: true,
+    },
+  });
+}
+
 export async function burnEphemeralConversation(containerId: string) {
   return await burnFolder(containerId);
 }

--- a/packages/send/backend/src/trpc/sharing.ts
+++ b/packages/send/backend/src/trpc/sharing.ts
@@ -1,10 +1,12 @@
 import {
+  deleteAccessLink,
   getAccessLinkRetryCount,
   incrementAccessLinkRetryCount,
   updateAccessLink,
 } from '@/models/sharing';
 import { z } from 'zod';
 import { router, publicProcedure as t } from '../trpc';
+import { isAuthed } from './middlewares';
 
 export const sharingRouter = router({
   /**
@@ -153,5 +155,65 @@ export const sharingRouter = router({
         console.error('Error getting password retry count', error);
       }
       return { id, retryCount };
+    }),
+
+  /**
+   * @openapi
+   * /trpc/deleteAccessLink:
+   *   post:
+   *     tags:
+   *       - Sharing
+   *     summary: Delete access link
+   *     description: Deletes an existing access link
+   *     security:
+   *       - bearerAuth: []
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             properties:
+   *               linkId:
+   *                 type: string
+   *                 description: ID of the access link to delete
+   *     responses:
+   *       200:
+   *         description: Access link deleted successfully
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 success:
+   *                   type: boolean
+   *                   description: Whether the deletion was successful
+   *                 message:
+   *                   type: string
+   *                   description: Success or error message
+   *                 id:
+   *                   type: string
+   *                   description: ID of the deleted access link
+   *       401:
+   *         description: Unauthorized - Authentication required
+   *       500:
+   *         description: Internal server error
+   */
+  deleteAccessLink: t
+    .use(isAuthed)
+    .input(z.object({ linkId: z.string() }))
+    .mutation(async ({ input }) => {
+      try {
+        // Assuming there's a function to delete the access link
+        const { id } = await deleteAccessLink(input.linkId);
+        return {
+          success: true,
+          message: 'Access link deleted successfully',
+          id,
+        };
+      } catch (error) {
+        console.error('Error deleting access link', error);
+        return { success: false, message: error.message };
+      }
     }),
 });

--- a/packages/send/e2e/testUtils.ts
+++ b/packages/send/e2e/testUtils.ts
@@ -15,6 +15,7 @@ export const playwrightConfig = {
   email: `myemail${Date.now()}@tb.pro`,
   timeout: 3_000,
   shareLinks: [] as string[],
+  fileLinks: [] as string[],
 };
 
 export async function downloadFirstFile(page: Page) {

--- a/packages/send/frontend/src/apps/send/components/CreateAccessLink.vue
+++ b/packages/send/frontend/src/apps/send/components/CreateAccessLink.vue
@@ -23,6 +23,7 @@ const showPassword = ref(false);
 const tooltipText = ref('Copied to clipboard');
 const clipboard = useClipboard();
 const accessUrlInput = ref<HTMLInputElement | null>(null);
+const isLoading = ref(false);
 
 const { mutate } = useMutation({
   mutationKey: ['getAccessLink'],
@@ -48,6 +49,7 @@ function copyToClipboard(url: string) {
 }
 
 async function newAccessLink() {
+  isLoading.value = true;
   const url = await sharingStore.createAccessLink(
     props.folderId,
     password.value,
@@ -72,6 +74,7 @@ async function newAccessLink() {
   accessUrlInput.value?.focus();
 
   await refreshAccessLinks();
+  isLoading.value = false;
 }
 
 watch(
@@ -120,9 +123,16 @@ watch(
   <Btn
     class="create-button"
     data-testid="create-share-link"
+    :disabled="isLoading"
     @click="newAccessLink"
   >
-    Create Share Link <IconLink class="icon" />
+    <div v-if="isLoading">
+      <p>Creating...</p>
+    </div>
+    <div v-else class="flex justify-center items-center gap-2">
+      <span>Create Access Link</span>
+      <IconLink class="icon" />
+    </div>
   </Btn>
 </template>
 

--- a/packages/send/frontend/src/apps/send/components/FileInfo.vue
+++ b/packages/send/frontend/src/apps/send/components/FileInfo.vue
@@ -5,9 +5,9 @@ import { trpc } from '@/lib/trpc';
 import { useMutation } from '@tanstack/vue-query';
 import { ref } from 'vue';
 
-import FileNameForm from '@/apps/send/elements/FileNameForm.vue';
 import FileAccessLinksList from '@/apps/send/components/FileAccessLinksList.vue';
 import Btn from '@/apps/send/elements/BtnComponent.vue';
+import FileNameForm from '@/apps/send/elements/FileNameForm.vue';
 import { formatBytes } from '@/lib/utils';
 import { IconDownload, IconEye, IconEyeOff, IconLink } from '@tabler/icons-vue';
 import { useClipboard, useDebounceFn } from '@vueuse/core';
@@ -25,6 +25,7 @@ const showPassword = ref(false);
 const tooltipText = ref('Copied to clipboard');
 const clipboard = useClipboard();
 const accessUrlInput = ref<HTMLInputElement | null>(null);
+const isLoading = ref(false);
 
 const { mutate } = useMutation({
   mutationKey: ['getAccessLink'],
@@ -50,6 +51,7 @@ function copyToClipboard(url: string) {
 }
 
 async function shareIndividualFile() {
+  isLoading.value = true;
   const url = await sharingStore.shareItems(
     [folderStore.selectedFile],
     password.value
@@ -73,6 +75,7 @@ async function shareIndividualFile() {
   accessUrlInput.value?.focus();
 
   await refreshAccessLinks();
+  isLoading.value = false;
 }
 
 /*
@@ -141,8 +144,13 @@ Note about shareOnly containers.
       data-testid="create-share-link"
       @click="shareIndividualFile"
     >
-      Create Share Link
-      <IconLink class="icon" />
+      <div v-if="isLoading">
+        <p>Creating...</p>
+      </div>
+      <div v-else class="flex justify-center items-center gap-2">
+        <span>Create Share Link</span>
+        <IconLink class="icon" />
+      </div>
     </Btn>
 
     <FileAccessLinksList

--- a/packages/send/frontend/src/apps/send/components/FolderAccessLinksList.vue
+++ b/packages/send/frontend/src/apps/send/components/FolderAccessLinksList.vue
@@ -1,7 +1,12 @@
 <script setup lang="ts">
 import { BASE_URL } from '@/apps/common/constants';
 import useSharingStore from '@/apps/send/stores/sharing-store';
-import { getDaysUntilDate } from '@/lib/utils';
+import { trpc } from '@/lib/trpc';
+import {
+  getAccessLinkWithoutPasswordHash,
+  getDaysUntilDate,
+} from '@/lib/utils';
+import { useMutation } from '@tanstack/vue-query';
 import { ExpiryBadge, ExpiryUnitTypes } from '@thunderbirdops/services-ui';
 import { useClipboard } from '@vueuse/core';
 import { vTooltip } from 'floating-vue';
@@ -14,6 +19,7 @@ type Props = {
 const sharingStore = useSharingStore();
 const props = defineProps<Props>();
 const clipboard = useClipboard();
+const linkToDelete = ref<string | null>(null);
 
 const tooltipText = ref('Click to copy');
 
@@ -27,6 +33,29 @@ function copyToClipboard(id: string) {
   setTimeout(() => {
     tooltipText.value = 'Click to copy';
   }, 3000);
+}
+
+const { mutate } = useMutation({
+  mutationFn: async () => {
+    const formattedAccessLink = getAccessLinkWithoutPasswordHash(
+      linkToDelete.value
+    );
+    const deleteMutation = await trpc.deleteAccessLink.mutate({
+      linkId: formattedAccessLink,
+    });
+
+    if (deleteMutation.success) {
+      await sharingStore.fetchFolderAccessLinks(props.folderId);
+      linkToDelete.value = null;
+      return true;
+    }
+    return false;
+  },
+});
+
+function handleDeleteLink(linkId: string) {
+  linkToDelete.value = linkId;
+  return mutate();
 }
 
 /*
@@ -52,14 +81,25 @@ TODO: implement "regeneration" of links
     class="flex flex-col gap-3"
     :data-testid="`access-link-item-${index}`"
   >
-    <input
-      v-tooltip="tooltipText"
-      type="text"
-      :value="`${BASE_URL}/share/${link.id}`"
-      :data-testid="`link-${index}`"
-      @click="copyToClipboard(link.id)"
-    />
     <div class="flex gap-2">
+      <input
+        v-tooltip="tooltipText"
+        type="text"
+        :value="`${BASE_URL}/share/${link.id}`"
+        :data-testid="`link-${index}`"
+        class="flex-1"
+        @click="copyToClipboard(link.id)"
+      />
+      <button
+        v-tooltip="'Delete link'"
+        class="text-red-500 hover:text-red-700 px-2"
+        :data-testid="`delete-link-button-${index}`"
+        @click="handleDeleteLink(link.id)"
+      >
+        🗑️
+      </button>
+    </div>
+    <div class="flex gap-2" data-testid="link-status">
       <div>
         <ExpiryBadge
           v-if="link.expiryDate"

--- a/packages/send/frontend/src/apps/send/components/FolderView.vue
+++ b/packages/send/frontend/src/apps/send/components/FolderView.vue
@@ -254,9 +254,10 @@ function handleFolderClick(uuid: string) {
         <!-- FILES -->
         <template v-if="folderStore.rootFolder">
           <tr
-            v-for="item in folderStore.rootFolder.items"
+            v-for="(item, index) in folderStore.rootFolder.items"
             :key="item.id"
             class="group cursor-pointer"
+            :data-testid="'file-' + index"
             @click="handleFileClick(item.id)"
           >
             <FolderTableRowCell>

--- a/packages/send/frontend/src/apps/send/stores/sharing-store.ts
+++ b/packages/send/frontend/src/apps/send/stores/sharing-store.ts
@@ -52,9 +52,6 @@ const useSharingStore = defineStore('sharingManager', () => {
       url = `${url}#${password}`;
     }
 
-    // refetch access links
-    // TODO: consider just updating sharer.requestAccessLink so that it returns the whole link and then pushing it to _links
-    await fetchFolderAccessLinks(folderId);
     return url;
   }
 

--- a/packages/send/frontend/src/apps/send/views/HomeView.vue
+++ b/packages/send/frontend/src/apps/send/views/HomeView.vue
@@ -7,9 +7,16 @@ import FileInfo from '@/apps/send/components/FileInfo.vue';
 import FolderInfo from '@/apps/send/components/FolderInfo.vue';
 import FolderNavigation from '@/apps/send/components/FolderNavigation.vue';
 import NewFolder from '@/apps/send/components/NewFolder.vue';
+import { computed } from 'vue';
+import { useRouter } from 'vue-router';
 
 const { user } = useUserStore();
 const folderStore = useFolderStore();
+const { currentRoute } = useRouter();
+
+const showFileComponents = computed(() => {
+  return currentRoute.value.path.includes('/folder');
+});
 </script>
 
 <template>
@@ -32,7 +39,10 @@ const folderStore = useFolderStore();
       <FeedbackBox />
     </main>
 
-    <aside class="w-64 border border-gray-300 bg-gray-50 p-2.5">
+    <aside
+      v-if="showFileComponents"
+      class="w-64 border border-gray-300 bg-gray-50 p-2.5"
+    >
       <FileInfo v-if="folderStore.selectedFile" />
       <FolderInfo v-if="folderStore.selectedFolder" />
     </aside>

--- a/packages/send/frontend/src/lib/utils.ts
+++ b/packages/send/frontend/src/lib/utils.ts
@@ -344,3 +344,10 @@ export const getDaysUntilDate = (date: Date | string): number => {
   const result = Math.ceil(diff / (1000 * 3600 * 24));
   return !result || result < 0 ? 0 : result;
 };
+
+export const getAccessLinkWithoutPasswordHash = (link: string): string => {
+  if (link.includes('#')) {
+    return link.split('#')[0];
+  }
+  return link;
+};


### PR DESCRIPTION
Closes https://github.com/thunderbird/tbpro-add-on/issues/88

This pull request introduces functionality for deleting access links, updates the backend and frontend to support this feature, and enhances end-to-end tests for file sharing workflows. The changes include adding a new API endpoint, updating Vue components to handle link deletion, and expanding test coverage for file and folder sharing.

- Updated e2e tests to cover individual file share links
- Added coverage for removing share links on files and folders

## Screenshots
Beautiful trash icons next to access links
![Screenshot 2025-07-09 at 9 09 56 AM](https://github.com/user-attachments/assets/8772b99b-8079-4afc-b548-8a29f6e64360)
