### PR TITLE
log out clients with wrong passphrases

### DIFF
--- a/packages/send/e2e/locators.ts
+++ b/packages/send/e2e/locators.ts
@@ -8,7 +8,7 @@ export const fileLocators = (page: Page) => {
   const passwordInputID = "password-input";
   const submitButtonID = "submit-button";
   const tableCellID = `[data-testid="folder-table-row-cell"]`;
-
+  const emptyFolderIndicator = page.getByTestId("empty-folder");
   const createdShareLinkWithPassword = page.getByTestId("access-link-item-1");
   const sharelinkButton = page.getByTestId("create-share-link");
   const submitButton = page.getByTestId(submitButtonID);
@@ -41,6 +41,7 @@ export const fileLocators = (page: Page) => {
     fileCountID,
     homeButton,
     dropZone,
+    emptyFolderIndicator,
   };
 };
 
@@ -56,6 +57,11 @@ export const dashboardLocators = (page: Page) => {
   const restoreKeysButton = page.getByTestId("restore-keys-button");
   const passphraseInput = page.getByTestId("passphrase-input");
   const restorekeyInput = page.getByTestId("restore-key-input");
+
+  const keyRecoveryButton = page.getByTestId("toggle-key-recovery");
+  const keyRestoreButton = page.getByTestId("restore-keys");
+  const confirmButton = page.getByTestId("confirm");
+
   return {
     registerButton,
     emailField,
@@ -68,5 +74,8 @@ export const dashboardLocators = (page: Page) => {
     restoreKeysButton,
     passphraseInput,
     restorekeyInput,
+    keyRecoveryButton,
+    keyRestoreButton,
+    confirmButton,
   };
 };

--- a/packages/send/e2e/pages/dashboard.ts
+++ b/packages/send/e2e/pages/dashboard.ts
@@ -1,3 +1,4 @@
+import { expect } from "@playwright/test";
 import { dashboardLocators, fileLocators } from "../locators";
 import { PlaywrightProps } from "../send.spec";
 import { playwrightConfig, saveStorage, setup_browser } from "../testUtils";
@@ -76,4 +77,52 @@ export async function log_out_restore_keys({ page }: PlaywrightProps) {
   await secondPage.waitForSelector(folderRowSelector);
   let folder = secondPage.getByTestId(folderRowTestID);
   await folder.click();
+}
+
+export async function reset_keys({ page }: PlaywrightProps) {
+  const {
+    emailField,
+    passwordField,
+    backupKeysButton,
+    passphraseInput,
+    keyRecoveryButton,
+    keyRestoreButton,
+    confirmButton,
+    submitLogin,
+  } = dashboardLocators(page);
+
+  const { folderRowSelector, emptyFolderIndicator } = fileLocators(page);
+
+  let profileButton = page.getByRole("link", { name: "My Files" });
+  await profileButton.click();
+  // Check that the created folder exists
+  await page.waitForSelector(folderRowSelector);
+
+  await page.goto("/send/profile");
+
+  // Restore passphrase (account included)
+  await keyRecoveryButton.click();
+  await keyRestoreButton.click();
+  await confirmButton.click();
+
+  // Log back in
+  await emailField.fill(email);
+  await passwordField.fill(password);
+  await submitLogin.click();
+
+  page.on("dialog", (dialog) => dialog.accept());
+
+  // Back up keys
+  const passPhrase = await passphraseInput.inputValue();
+  if (!passPhrase) throw new Error("Passphrase not found");
+  shareLinks.push(passPhrase!);
+  await backupKeysButton.click();
+
+  // Navigate to files
+  await page.goto("/send");
+
+  // Check that the folder is empty
+  expect(await emptyFolderIndicator.textContent()).toBe(
+    "This is an empty folder"
+  );
 }

--- a/packages/send/e2e/pages/dashboard.ts
+++ b/packages/send/e2e/pages/dashboard.ts
@@ -94,6 +94,9 @@ export async function reset_keys({ page }: PlaywrightProps) {
   const { folderRowSelector, emptyFolderIndicator } = fileLocators(page);
 
   let profileButton = page.getByRole("link", { name: "My Files" });
+  // Create a new folder
+  await page.getByTestId("new-folder-button").click();
+
   await profileButton.click();
   // Check that the created folder exists
   await page.waitForSelector(folderRowSelector);
@@ -122,7 +125,5 @@ export async function reset_keys({ page }: PlaywrightProps) {
   await page.goto("/send");
 
   // Check that the folder is empty
-  expect(await emptyFolderIndicator.textContent()).toBe(
-    "This is an empty folder"
-  );
+  expect(await emptyFolderIndicator.isVisible()).toBe(false);
 }

--- a/packages/send/e2e/send.spec.ts
+++ b/packages/send/e2e/send.spec.ts
@@ -89,10 +89,7 @@ test.describe("Key restore", async () => {
     await expect(page).toHaveTitle(/Thunderbird Send/);
   });
 
-  const workflows = [
-    { title: "File upload", action: upload_workflow },
-    { title: "Reset keys", action: reset_keys },
-  ];
+  const workflows = [{ title: "Reset keys", action: reset_keys }];
 
   workflows.forEach(({ title, action }) => {
     test(title, async () => await action({ page, context }));

--- a/packages/send/e2e/send.spec.ts
+++ b/packages/send/e2e/send.spec.ts
@@ -1,7 +1,11 @@
 import { BrowserContext, expect, Page, test } from "@playwright/test";
 import fs from "fs";
 import path from "path";
-import { log_out_restore_keys, register_and_login } from "./pages/dashboard";
+import {
+  log_out_restore_keys,
+  register_and_login,
+  reset_keys,
+} from "./pages/dashboard";
 import {
   delete_file,
   download_workflow,
@@ -68,6 +72,26 @@ test.describe("File workflows", () => {
     { title: "Upload workflow", action: upload_workflow },
     { title: "Download workflow", action: download_workflow },
     { title: "Delete files", action: delete_file },
+  ];
+
+  workflows.forEach(({ title, action }) => {
+    test(title, async () => await action({ page, context }));
+  });
+});
+
+test.describe("Key restore", async () => {
+  let page: Page;
+  let context: BrowserContext;
+
+  test.beforeEach(async () => {
+    ({ page, context } = await setup_browser());
+    await page.goto("/send");
+    await expect(page).toHaveTitle(/Thunderbird Send/);
+  });
+
+  const workflows = [
+    { title: "File upload", action: upload_workflow },
+    { title: "Reset keys", action: reset_keys },
   ];
 
   workflows.forEach(({ title, action }) => {

--- a/packages/send/frontend/src/apps/common/BackupAndRestore.vue
+++ b/packages/send/frontend/src/apps/common/BackupAndRestore.vue
@@ -45,6 +45,7 @@ const { api } = useApiStore();
 const {
   getBackup,
   user: { email },
+  clearUserFromStorage,
 } = useUserStore();
 const { keychain } = useKeychainStore();
 const { metrics } = useMetricsStore();
@@ -62,14 +63,19 @@ const { mutate: resetKeys } = useMutation({
   },
   onSuccess: async () => {
     await logOutAuth();
+    // Make sure we clear the user from storage
+    await clearUserFromStorage();
     window.location.reload();
   },
 });
 
-const userSetPassword = keychain.getPassphraseValue();
+const passphraseFromLocalStorage = keychain.getPassphraseValue();
 
-if (!!userSetPassword && userSetPassword !== passphraseString.value) {
-  words.value = userSetPassword.split(' ');
+if (
+  !!passphraseFromLocalStorage &&
+  passphraseFromLocalStorage !== passphraseString.value
+) {
+  words.value = passphraseFromLocalStorage.split(' ');
 }
 
 function hideBackupRestore() {
@@ -157,7 +163,11 @@ async function restoreFromBackup() {
 <template>
   <section class="container">
     <div class="content max-w-xl">
-      <div :onclick="toggleVisible" class="toggle">
+      <div
+        :onclick="toggleVisible"
+        class="toggle"
+        data-testid="toggle-key-recovery"
+      >
         <h3 class="font-bold">Recovery Key</h3>
         <ExpandIcon :is-open="showKeyRecovery" />
       </div>

--- a/packages/send/frontend/src/apps/common/KeyRecovery.vue
+++ b/packages/send/frontend/src/apps/common/KeyRecovery.vue
@@ -145,7 +145,11 @@ const submit = () => {
       will generate a new key and you will lose access to any files you created
       before this.
     </p>
-    <button-component danger class="mt-4" @click.prevent="open"
+    <button-component
+      data-testid="restore-keys"
+      danger
+      class="mt-4"
+      @click.prevent="open"
       >Reset keys and lose access to previously created files</button-component
     >
   </div>

--- a/packages/send/frontend/src/apps/send/components/FolderView.vue
+++ b/packages/send/frontend/src/apps/send/components/FolderView.vue
@@ -192,6 +192,9 @@ function handleFolderClick(uuid: string) {
     >
       {{ `${folderStore.rootFolder.items.length}` }}
     </span>
+    <span v-else data-testid="empty-folder" style="display: none"
+      >This is an empty folder</span
+    >
     <BreadCrumb />
     <table class="w-full border-separate border-spacing-x-0 border-spacing-y-1">
       <thead>

--- a/packages/send/frontend/src/apps/send/components/ResetConfirmation.vue
+++ b/packages/send/frontend/src/apps/send/components/ResetConfirmation.vue
@@ -27,8 +27,10 @@ const onConfirm = async () => {
       <strong class="text-red-600">delete all your uploads and folders</strong>.
     </p>
     <div class="space-x-4 mt-8">
-      <BtnComponent danger @click="onConfirm">Yes</BtnComponent>
-      <BtnComponent @click="closefn">No</BtnComponent>
+      <BtnComponent data-testid="confirm" danger @click="onConfirm"
+        >Yes</BtnComponent
+      >
+      <BtnComponent data-testid="cancel" @click="closefn">No</BtnComponent>
     </div>
   </div>
 </template>

--- a/packages/send/frontend/src/apps/send/stores/extension-store.ts
+++ b/packages/send/frontend/src/apps/send/stores/extension-store.ts
@@ -19,56 +19,54 @@ export const useExtensionStore = defineStore('extension', () => {
     try {
       //@ts-ignore
       browser.cloudFile.updateAccount(accountId, {
-	configured: true,
+        configured: true,
       });
     } catch {
       console.log(
-	`setAccountConfigured: You're probably running this outside of Thundebird`
+        `setAccountConfigured: You're probably running this outside of Thundebird`
       );
     }
   }
 
-  async function configureExtension(id: string) {
-    id = id || accountId;
-
+  async function configureExtension(id = accountId) {
     // This function only needs to run if we're in the TB addon.
     // Exit early if there's no account id.
     if (!id) {
       console.log(`[extension-store] No id provided to configureExtension()`);
       return;
     }
-  //   console.log(`
+    //   console.log(`
 
-  // Configuring extension with:
+    // Configuring extension with:
 
-  // accountId: ${id}
-  // SERVER: ${SERVER}
-  // currentServerUrl.value: ${serverUrl.value}
+    // accountId: ${id}
+    // SERVER: ${SERVER}
+    // currentServerUrl.value: ${serverUrl.value}
 
-  // `);
+    // `);
 
     return browser.storage.local
       .set({
-	[id]: {
-	  [SERVER]: serverUrl.value,
-	},
+        [id]: {
+          [SERVER]: serverUrl.value,
+        },
       })
       .catch((error) => {
-	console.log(error);
+        console.log(error);
       })
       .then(() => {
-	setAccountConfigured(id);
-	setServerUrl(serverUrl.value);
-	// eslint-disable-next-line @typescript-eslint/no-unused-expressions
-	DEBUG &&
-	  browser.storage.local.get(id).then((accountInfo) => {
-	    if (accountInfo[id] && SERVER in accountInfo[id]) {
-	      setServerUrl(accountInfo[id][SERVER]);
-	      setAccountConfigured(id);
-	    } else {
-	      console.log(`You probably need to wait longer`);
-	    }
-	  });
+        setAccountConfigured(id);
+        setServerUrl(serverUrl.value);
+        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+        DEBUG &&
+          browser.storage.local.get(id).then((accountInfo) => {
+            if (accountInfo[id] && SERVER in accountInfo[id]) {
+              setServerUrl(accountInfo[id][SERVER]);
+              setAccountConfigured(id);
+            } else {
+              console.log(`You probably need to wait longer`);
+            }
+          });
       });
   }
 


### PR DESCRIPTION
Closes https://github.com/thunderbird/tbpro-add-on/issues/94 https://github.com/thunderbird/tbpro-add-on/issues/93
This PR adds logic to make sure clients have the correct passphrases. It features
- Adding passphrase check to validators. When the check doesn't pass, we clear local storage (because it contains the outdated passphrase) and log the user out.
- Added extensive coverage with e2e tests by checking that restoring the passphrase, removes the files and folders.