### PR TITLE
Upgrade tb_pulumi to v0.0.15, build StackAccessPolicies

### DIFF
--- a/packages/send/pulumi/__main__.py
+++ b/packages/send/pulumi/__main__.py
@@ -8,6 +8,7 @@ import tb_pulumi.ci
 import tb_pulumi.cloudfront
 import tb_pulumi.cloudwatch
 import tb_pulumi.fargate
+import tb_pulumi.iam
 import tb_pulumi.network
 import tb_pulumi.rds
 import tb_pulumi.secrets
@@ -209,4 +210,9 @@ monitoring = tb_pulumi.cloudwatch.CloudWatchMonitoringGroup(
     project=project,
     notify_emails=monitoring_opts['notify_emails'],
     config=monitoring_opts,
+)
+
+sap = tb_pulumi.iam.StackAccessPolicies(
+    f'{project.name_prefix}-sap',
+    project=project,
 )

--- a/packages/send/pulumi/config.prod.yaml
+++ b/packages/send/pulumi/config.prod.yaml
@@ -98,7 +98,7 @@ resources:
           - FARGATE
         container_definitions:
           backend:
-            image: 768512802988.dkr.ecr.us-east-1.amazonaws.com/send:2.1.9
+            image: 768512802988.dkr.ecr.us-east-1.amazonaws.com/send:4.4.0
             portMappings:
               - name: send-suite
                 containerPort: 8080

--- a/packages/send/pulumi/config.stage.yaml
+++ b/packages/send/pulumi/config.stage.yaml
@@ -97,7 +97,7 @@ resources:
           - FARGATE
         container_definitions:
           backend:
-            image: 768512802988.dkr.ecr.us-east-1.amazonaws.com/send:e6cb884800934e399286a426ea87532e363f4a62
+            image: 768512802988.dkr.ecr.us-east-1.amazonaws.com/send:b0f8aa115ce9ad68ed6c98dce8ec4b0bd137f5d2
             portMappings:
               - name: send-suite
                 containerPort: 8080

--- a/packages/send/pulumi/requirements.txt
+++ b/packages/send/pulumi/requirements.txt
@@ -1,2 +1,2 @@
-tb_pulumi @ git+https://github.com/thunderbird/pulumi.git@main
+tb_pulumi @ git+https://github.com/thunderbird/pulumi.git@v0.0.15
 pulumi_cloudflare==5.48.0


### PR DESCRIPTION
This is a step toward securing our CI processes by creating a permissions boundary between environment. In a later change, we will swap the existing CI auth data with these new accounts.

Also pins the tb_pulumi version to 0.0.15 (inclusive of the changes that we were dependent on the special branch for).

Also updates the images to what's actually deployed right now.