### PR TITLE
Update workflows (and stage image)

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -45,6 +45,7 @@ jobs:
 
   # When backend changes are merged in, build and push a new Docker image
   backend-merge:
+    environment: send-stage
     needs: detect-changes
     if: needs.detect-changes.outputs.backend-changed == 'true'
     runs-on: ubuntu-latest
@@ -154,6 +155,7 @@ jobs:
             --target-dependents
 
   frontend-merge:
+    environment: send-stage
     needs: detect-changes
     if: needs.detect-changes.outputs.frontend-changed == 'true'
     runs-on: ubuntu-latest
@@ -308,6 +310,7 @@ jobs:
         run: |
           cd packages/send/frontend
           pnpm deploy-xpi $(find .. -name 'send-suite-stage-*.xpi')
+
   addon-changes:
     needs: detect-changes
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ permissions:
 
 jobs:
   deploy-backend:
+    environment: send-prod
     runs-on: ubuntu-latest
     env:
       IS_CI_AUTOMATION: "yes"
@@ -126,6 +127,7 @@ jobs:
             --target-dependents
 
   deploy-frontend:
+    environment: send-prod
     runs-on: ubuntu-latest
     env:
       IS_CI_AUTOMATION: "yes"

--- a/packages/send/pulumi/config.stage.yaml
+++ b/packages/send/pulumi/config.stage.yaml
@@ -97,7 +97,7 @@ resources:
           - FARGATE
         container_definitions:
           backend:
-            image: 768512802988.dkr.ecr.us-east-1.amazonaws.com/send:b0f8aa115ce9ad68ed6c98dce8ec4b0bd137f5d2
+            image: 768512802988.dkr.ecr.us-east-1.amazonaws.com/send:37239f49bb9eefd6e833a756e0513c62124744ea
             portMappings:
               - name: send-suite
                 containerPort: 8080


### PR DESCRIPTION
I built out new CI users for each environment, stage and prod. This means new access keys, and it means changing from a single credential shared across environments to multiple credentials for each env. Therefore, this is the first time this repo has been configured to store environment-specific secrets. I set up `send-stage` and `send-prod` and stashed their credentials in Github as environment secrets.

This PR updates a few CI jobs to specify those environments so they will get the right authentication data. It also brings the stage image up to date.