### PR TITLE
add file hash on uploads

### DIFF
--- a/packages/send/backend/prisma/migrations/20250908164120_add_suspicious_file_table_and_file_hash_for_files/migration.sql
+++ b/packages/send/backend/prisma/migrations/20250908164120_add_suspicious_file_table_and_file_hash_for_files/migration.sql
@@ -1,0 +1,16 @@
+-- AlterTable
+ALTER TABLE "Upload" ADD COLUMN     "fileHash" TEXT;
+
+-- CreateTable
+CREATE TABLE "SuspiciousFile" (
+    "id" UUID NOT NULL,
+    "fileHash" TEXT NOT NULL,
+
+    CONSTRAINT "SuspiciousFile_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SuspiciousFile_id_key" ON "SuspiciousFile"("id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SuspiciousFile_fileHash_key" ON "SuspiciousFile"("fileHash");

--- a/packages/send/backend/prisma/schema.prisma
+++ b/packages/send/backend/prisma/schema.prisma
@@ -228,6 +228,14 @@ model Upload {
   reportedAt DateTime?
   // This helps us it helps us put together multi-part uploads
   part          Int?
+  fileHash      String?     
+}
+
+// Store hashes of files that have been reported as suspicious
+// This helps us prevent re-uploads of known bad files  
+model SuspiciousFile {
+  id        String   @id @default(uuid()) @unique @db.Uuid
+  fileHash      String   @unique
 }
 
 // A tag can be associated with items and containers
@@ -261,3 +269,4 @@ model EncryptedPassphrase {
   salt     String
   codeSalt String
 }
+

--- a/packages/send/backend/src/models/uploads.ts
+++ b/packages/send/backend/src/models/uploads.ts
@@ -15,7 +15,8 @@ export async function createUpload(
   size: number,
   ownerId: string,
   type: string,
-  part?: number
+  part?: number,
+  fileHash?: string
 ) {
   // Confirm that file `id` exists and what's on disk
   // is at least as large as the stated size.
@@ -42,6 +43,7 @@ export async function createUpload(
         createdAt: new Date(),
         type,
         part,
+        fileHash,
       },
     });
     // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/send/backend/src/routes/uploads.ts
+++ b/packages/send/backend/src/routes/uploads.ts
@@ -68,7 +68,7 @@ router.post(
   requireWritePermission,
   addErrorHandling(UPLOAD_ERRORS.NOT_CREATED),
   wrapAsyncHandler(async (req, res) => {
-    const { id, size, ownerId, type, part } = req.body;
+    const { id, size, ownerId, type, part, fileHash } = req.body;
     const Metrics = useMetrics();
 
     const { uniqueHash } = getDataFromAuthenticatedRequest(req);
@@ -76,7 +76,14 @@ router.post(
     const distinctId = uniqueHash;
 
     try {
-      const upload = await createUpload(id, size, ownerId, type, part);
+      const upload = await createUpload(
+        id,
+        size,
+        ownerId,
+        type,
+        part,
+        fileHash
+      );
       // Capture metrics
       Metrics.capture({
         event: 'upload.size',

--- a/packages/send/backend/src/test/utils/index.test.ts
+++ b/packages/send/backend/src/test/utils/index.test.ts
@@ -109,6 +109,7 @@ describe('addExpiryToContainer', () => {
       size: 100n,
       type: 'image/jpeg',
       part: null,
+      fileHash: '222',
     };
 
     const result = addExpiryToContainer(mockUpload);
@@ -126,6 +127,7 @@ describe('addExpiryToContainer', () => {
       size: 100n,
       type: 'image/jpeg',
       part: null,
+      fileHash: '222',
     };
 
     const result = addExpiryToContainer(mockUpload);
@@ -143,6 +145,7 @@ describe('addExpiryToContainer', () => {
       size: 100n,
       type: 'image/jpeg',
       part: null,
+      fileHash: '222',
     };
 
     const result = addExpiryToContainer(mockUpload);
@@ -182,6 +185,7 @@ describe('addExpiryToContainer', () => {
       size: 100n,
       type: 'image/jpeg',
       part: null,
+      fileHash: '222',
     };
 
     const result = addExpiryToContainer(mockUpload);

--- a/packages/send/frontend/src/lib/upload.ts
+++ b/packages/send/frontend/src/lib/upload.ts
@@ -10,7 +10,11 @@ import { NamedBlob, sendBlob } from '@send-frontend/lib/filesync';
 import { Keychain } from '@send-frontend/lib/keychain';
 import { UserType } from '@send-frontend/types';
 import { SPLIT_SIZE } from './const';
-import { retryUntilSuccessOrTimeout, splitIntoMultipleZips } from './utils';
+import {
+  generateFileHash,
+  retryUntilSuccessOrTimeout,
+  splitIntoMultipleZips,
+} from './utils';
 
 export default class Uploader {
   user: UserType;
@@ -111,6 +115,10 @@ export default class Uploader {
     if (!fileBlob) {
       return null;
     }
+
+    // generate a hash from the file
+    const fileHash = await generateFileHash(fileBlob);
+    console.log('File hash (SHA-256):', fileHash);
 
     // get folder key
     const wrappingKey = await this.keychain.get(containerId);
@@ -214,6 +222,7 @@ export default class Uploader {
               type: blob.type,
               containerId,
               part, // if the file was split into multiple zips, we add the part
+              fileHash,
             },
             'POST'
           );

--- a/packages/send/frontend/src/lib/utils.ts
+++ b/packages/send/frontend/src/lib/utils.ts
@@ -2,6 +2,23 @@ import { JsonResponse } from '@send-frontend/lib/api';
 import { NamedBlob } from '@send-frontend/types';
 import JSZip from 'jszip';
 import { MAX_FILE_SIZE } from './const';
+
+/**
+ * Generates a SHA-256 hash from a file blob.
+ *
+ * @param {Blob} fileBlob - The file blob to hash
+ * @returns {Promise<string>} - Returns a Promise that resolves to the hexadecimal hash string
+ */
+export async function generateFileHash(fileBlob: Blob): Promise<string> {
+  const fileArrayBuffer = await fileBlob.arrayBuffer();
+  const hashBuffer = await crypto.subtle.digest('SHA-256', fileArrayBuffer);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  const fileHash = hashArray
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+  return fileHash;
+}
+
 /**
  * Returns a promise that resolves after an amount of time has passed.
  *

--- a/packages/send/frontend/src/test/lib/upload.test.ts
+++ b/packages/send/frontend/src/test/lib/upload.test.ts
@@ -20,6 +20,7 @@ vi.mock('@send-frontend/lib/utils', () => ({
       Object.assign(new Blob(['part2']), { name: 'large-file.txt' }),
     ]),
   retryUntilSuccessOrTimeout: vi.fn().mockResolvedValue(undefined),
+  generateFileHash: vi.fn().mockResolvedValue('abc123def456'),
 }));
 
 describe('Uploader', () => {

--- a/packages/send/frontend/src/test/lib/utils.test.ts
+++ b/packages/send/frontend/src/test/lib/utils.test.ts
@@ -1,5 +1,133 @@
-import { getDaysUntilDate } from '@send-frontend/lib/utils';
+import { generateFileHash, getDaysUntilDate } from '@send-frontend/lib/utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('generateFileHash', () => {
+  it('should generate the same hash for identical file content', async () => {
+    const content = 'Hello, World!';
+    const blob1 = new Blob([content], { type: 'text/plain' });
+    const blob2 = new Blob([content], { type: 'text/plain' });
+
+    const hash1 = await generateFileHash(blob1);
+    const hash2 = await generateFileHash(blob2);
+
+    expect(hash1).toBe(hash2);
+    expect(hash1).toMatch(/^[a-f0-9]{64}$/); // Should be a 64-character hex string
+  });
+
+  it('should generate different hashes for different file content', async () => {
+    const blob1 = new Blob(['Hello, World!'], { type: 'text/plain' });
+    const blob2 = new Blob(['Hello, Universe!'], { type: 'text/plain' });
+
+    const hash1 = await generateFileHash(blob1);
+    const hash2 = await generateFileHash(blob2);
+
+    expect(hash1).not.toBe(hash2);
+    expect(hash1).toMatch(/^[a-f0-9]{64}$/);
+    expect(hash2).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('should generate the same hash for the same file content regardless of Blob type', async () => {
+    const content = 'Test content for hashing';
+    const blob1 = new Blob([content], { type: 'text/plain' });
+    const blob2 = new Blob([content], { type: 'application/octet-stream' });
+
+    const hash1 = await generateFileHash(blob1);
+    const hash2 = await generateFileHash(blob2);
+
+    expect(hash1).toBe(hash2);
+  });
+
+  it('should generate consistent hash for binary data', async () => {
+    const binaryData = new Uint8Array([0, 1, 2, 3, 255, 128, 64]);
+    const blob1 = new Blob([binaryData]);
+    const blob2 = new Blob([binaryData]);
+
+    const hash1 = await generateFileHash(blob1);
+    const hash2 = await generateFileHash(blob2);
+
+    expect(hash1).toBe(hash2);
+    expect(hash1).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('should generate the same hash when called multiple times on the same blob', async () => {
+    const blob = new Blob(['Consistent content'], { type: 'text/plain' });
+
+    const hash1 = await generateFileHash(blob);
+    const hash2 = await generateFileHash(blob);
+    const hash3 = await generateFileHash(blob);
+
+    expect(hash1).toBe(hash2);
+    expect(hash2).toBe(hash3);
+  });
+
+  it('should handle empty files consistently', async () => {
+    const emptyBlob1 = new Blob([]);
+    const emptyBlob2 = new Blob([]);
+
+    const hash1 = await generateFileHash(emptyBlob1);
+    const hash2 = await generateFileHash(emptyBlob2);
+
+    expect(hash1).toBe(hash2);
+    expect(hash1).toMatch(/^[a-f0-9]{64}$/);
+    // SHA-256 of empty string should be: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    expect(hash1).toBe(
+      'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+    );
+  });
+
+  it('should handle large files consistently', async () => {
+    // Create a larger file content
+    const largeContent = 'A'.repeat(10000);
+    const blob1 = new Blob([largeContent]);
+    const blob2 = new Blob([largeContent]);
+
+    const hash1 = await generateFileHash(blob1);
+    const hash2 = await generateFileHash(blob2);
+
+    expect(hash1).toBe(hash2);
+    expect(hash1).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('should produce known hash for known content', async () => {
+    // Known test vector: SHA-256 of "abc" should be ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
+    const blob = new Blob(['abc']);
+    const hash = await generateFileHash(blob);
+
+    expect(hash).toBe(
+      'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad'
+    );
+  });
+
+  it('should handle unicode content correctly', async () => {
+    const unicodeContent = '🚀 Unicode test 你好 🌟';
+    const blob1 = new Blob([unicodeContent], { type: 'text/plain' });
+    const blob2 = new Blob([unicodeContent], { type: 'text/plain' });
+
+    const hash1 = await generateFileHash(blob1);
+    const hash2 = await generateFileHash(blob2);
+
+    expect(hash1).toBe(hash2);
+    expect(hash1).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('should be deterministic across different execution contexts', async () => {
+    const content = 'Deterministic test content';
+    const results = [];
+
+    // Generate hash multiple times in sequence
+    for (let i = 0; i < 5; i++) {
+      const blob = new Blob([content]);
+      const hash = await generateFileHash(blob);
+      results.push(hash);
+    }
+
+    // All results should be identical
+    const firstHash = results[0];
+    results.forEach((hash) => {
+      expect(hash).toBe(firstHash);
+    });
+  });
+});
 
 describe('getDaysUntilDate', () => {
   beforeEach(() => {


### PR DESCRIPTION
This PR features:
- added a file hash field to the uploads table
- uploads from client send file hash
- added a `SuspiciousFile` table to handle reporting 
- updated test files