### PR TITLE
Feat/Block reported files from generating links

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -96,6 +96,7 @@ jobs:
         id: install-pnpm-build
         run: |
           npm install -g pnpm
+          pnpm install lerna -g
           pnpm install --filter @thunderbird/tbpro-add-on && lerna run bootstrap
           pnpm install --filter send-backend
           lerna run build-image:backend --scope=send-suite
@@ -201,6 +202,7 @@ jobs:
           # Initial setup of dependencies
           cd packages/send/frontend
           npm install -g pnpm
+          pnpm install lerna -g
           pnpm install --filter @thunderbird/tbpro-add-on && lerna run bootstrap
           pnpm install --filter tbpro-shared
           pnpm install --filter send-frontend
@@ -259,6 +261,7 @@ jobs:
           # Initial setup of dependencies
           cd packages/send/frontend
           npm install -g pnpm
+          pnpm install lerna -g          
           pnpm install --filter @thunderbird/tbpro-add-on && lerna run bootstrap
           pnpm install --filter tbpro-shared
           pnpm install --filter send-frontend

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Install the package managers `bun` and `pnpm` globally. You can do this using np
 ```sh
 npm install -g bun
 npm install -g pnpm
+# This step is optional if you don't have lerna installed globally but it's easier to run commands that use it
+pnpm install -g lerna
 ```
 
 Or alternatively

--- a/packages/send/backend/prisma/migrations/20250910130100_add_default_folder_field/migration.sql
+++ b/packages/send/backend/prisma/migrations/20250910130100_add_default_folder_field/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Container" ADD COLUMN     "isDefault" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/send/backend/prisma/schema.prisma
+++ b/packages/send/backend/prisma/schema.prisma
@@ -190,6 +190,7 @@ model Container {
   children  Container[]     @relation("Nesting")
 
   tags      Tag[]
+  isDefault Boolean     @default(false) // Whether this is the user's default folder
 }
 
 enum ItemType {

--- a/packages/send/backend/src/models/containers.ts
+++ b/packages/send/backend/src/models/containers.ts
@@ -105,13 +105,38 @@ export async function getContainerWithAncestors(id: string) {
 }
 
 export async function getContainerWithoutAncestors(userId: string) {
-  const topLevelContainers = prisma.container.findFirst({
+  const topLevelContainers = prisma.container.findMany({
     where: {
       parent: { is: null },
       owner: { id: userId },
     },
   });
   return topLevelContainers;
+}
+
+export async function setContainerAsDefault(
+  container: string,
+  ownerId: string
+) {
+  return await prisma.container.update({
+    where: {
+      id: container,
+      ownerId,
+    },
+    data: {
+      isDefault: true,
+      updatedAt: new Date(),
+    },
+  });
+}
+
+export async function getDefaultContainerForOwner(ownerId: string) {
+  return await prisma.container.findFirst({
+    where: {
+      ownerId,
+      isDefault: true,
+    },
+  });
 }
 
 export async function getAccessLinksForContainer(containerId: string) {

--- a/packages/send/backend/src/models/sharing.ts
+++ b/packages/send/backend/src/models/sharing.ts
@@ -833,3 +833,21 @@ export async function deleteAccessLink(linkId: string) {
 export async function burnEphemeralConversation(containerId: string) {
   return await burnFolder(containerId);
 }
+
+export async function checkIfAccessLinkCanBeCreated(containerId: string) {
+  const reportedUploads = await prisma.container.findUnique({
+    where: { id: containerId },
+    select: {
+      items: {
+        where: {
+          upload: {
+            is: {
+              reported: true,
+            },
+          },
+        },
+      },
+    },
+  });
+  return reportedUploads?.items.length === 0;
+}

--- a/packages/send/backend/src/trpc/users.ts
+++ b/packages/send/backend/src/trpc/users.ts
@@ -181,7 +181,6 @@ export const usersRouter = router({
     )
     .subscription(async function* (opts) {
       if (!opts.ctx?.user?.id) {
-        console.error('Verification can only be done by logged for users');
         return;
       }
       // listen for new events
@@ -203,7 +202,6 @@ export const usersRouter = router({
     )
     .subscription(async function* (opts) {
       if (!opts.ctx?.user?.id) {
-        console.error('Verification can only be done by logged for users');
         return;
       }
       // listen for new events
@@ -230,7 +228,6 @@ export const usersRouter = router({
     )
     .subscription(async function* (opts) {
       if (!opts.ctx?.user?.id) {
-        console.error('Verification can only be done by logged for users');
         return;
       }
       // listen for new events

--- a/packages/send/backend/src/utils.ts
+++ b/packages/send/backend/src/utils.ts
@@ -93,3 +93,17 @@ export const addExpiryToContainer = ({ createdAt, ...upload }: Upload) => {
     expired: daysToExpiry <= 0,
   };
 };
+type Shares = {
+  id: string;
+  passwordHash: string;
+  expiryDate: Date;
+  locked: boolean;
+};
+export const formatAccessLinkWithPasswordHash = (shares: Partial<Shares>[]) => {
+  return shares.map((link) => {
+    // If there password hash is present, we add it to the id so that the full shareable link can be shown to the user
+    return link.passwordHash
+      ? { ...link, id: link.id + `#${link.passwordHash}` }
+      : link;
+  });
+};

--- a/packages/send/frontend/src/apps/send/components/FileInfo.vue
+++ b/packages/send/frontend/src/apps/send/components/FileInfo.vue
@@ -3,7 +3,7 @@ import useFolderStore from '@send-frontend/apps/send/stores/folder-store';
 import useSharingStore from '@send-frontend/apps/send/stores/sharing-store';
 import { trpc } from '@send-frontend/lib/trpc';
 import { useMutation } from '@tanstack/vue-query';
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
 
 import FileAccessLinksList from '@send-frontend/apps/send/components/FileAccessLinksList.vue';
 import Btn from '@send-frontend/apps/send/elements/BtnComponent.vue';
@@ -26,6 +26,10 @@ const tooltipText = ref('Copied to clipboard');
 const clipboard = useClipboard();
 const accessUrlInput = ref<HTMLInputElement | null>(null);
 const isLoading = ref(false);
+
+const canDisplay = computed(() => {
+  return folderStore?.selectedFile?.upload?.reported !== true;
+});
 
 const { mutate } = useMutation({
   mutationKey: ['getAccessLink'],
@@ -86,7 +90,15 @@ Note about shareOnly containers.
 </script>
 
 <template>
-  <div v-if="folderStore.selectedFile" class="flex flex-col gap-6 h-full">
+  <section v-if="!canDisplay">
+    This file has been reported for abuse. Please contact support if you believe
+    this is a mistake.
+  </section>
+
+  <div
+    v-if="folderStore.selectedFile && canDisplay"
+    class="flex flex-col gap-6 h-full"
+  >
     <!-- info -->
     <header class="flex flex-col items-center">
       <img src="@send-frontend/apps/send/assets/file.svg" class="w-20 h-20" />

--- a/packages/send/frontend/src/lib/share.ts
+++ b/packages/send/frontend/src/lib/share.ts
@@ -212,6 +212,17 @@ export default class Sharer {
     password?: string,
     expiration?: string
   ): Promise<string | null> {
+    // check if the container doesn't have reported items first
+    const canCreateLink = await this.api.call<{ canCreateLink: boolean }>(
+      `sharing/${containerId}/canCreateAccessLink`
+    );
+
+    if (!canCreateLink?.canCreateLink) {
+      throw new Error(
+        'Cannot create access link for this container because it contains files that have been reported for abuse.'
+      );
+    }
+
     // get the key (which unwraps it),
     const unwrappedKey = await this.keychain.get(containerId);
 
@@ -264,7 +275,7 @@ export default class Sharer {
       'POST'
     );
 
-    if (!resp.id) {
+    if (!resp?.id) {
       return null;
     }
 

--- a/packages/send/frontend/src/test/lib/share.test.ts
+++ b/packages/send/frontend/src/test/lib/share.test.ts
@@ -159,10 +159,13 @@ describe(`Sharer`, () => {
   });
   describe(`requestAccessLink`, () => {
     it(`Returns null if unable to create a new share`, async () => {
-      const handler = http.post(`${API_URL}/sharing`, async () =>
-        HttpResponse.json({})
-      );
-      const server = setupServer(handler);
+      const handlers = [
+        http.get(`${API_URL}/sharing/1/canCreateAccessLink`, async () =>
+          HttpResponse.json({ canCreateLink: true })
+        ),
+        http.post(`${API_URL}/sharing`, async () => HttpResponse.json({})),
+      ];
+      const server = setupServer(...handlers);
       server.listen();
 
       const keychain = new Keychain();
@@ -178,12 +181,17 @@ describe(`Sharer`, () => {
       const LINK_ID = 'abcdef123456';
       const url = `${import.meta.env.VITE_SEND_CLIENT_URL}/share/${LINK_ID}`;
 
-      const handler = http.post(`${API_URL}/sharing`, async () =>
-        HttpResponse.json({
-          id: LINK_ID,
-        })
-      );
-      const server = setupServer(handler);
+      const handlers = [
+        http.get(`${API_URL}/sharing/1/canCreateAccessLink`, async () =>
+          HttpResponse.json({ canCreateLink: true })
+        ),
+        http.post(`${API_URL}/sharing`, async () =>
+          HttpResponse.json({
+            id: LINK_ID,
+          })
+        ),
+      ];
+      const server = setupServer(...handlers);
       server.listen();
 
       const keychain = new Keychain();

--- a/packages/send/frontend/src/types.ts
+++ b/packages/send/frontend/src/types.ts
@@ -134,6 +134,7 @@ export interface Upload {
   expired?: boolean;
   daysToExpiry?: number;
   part?: number; // true if the file was split into multiple zips
+  reported?: boolean; // true if the upload was reported for abuse
 }
 
 export interface Backup {


### PR DESCRIPTION
- block file link generation when it contains reported files
- set default folder from api
- fix builds

## Testing
Create a new access link for a file and open it on a new incognito window. Report the link and close that window.
Go back to the access link tab and try generating a new link, it should fail. If you refresh the page, you should see a warning message saying that generating link is disabled for that file. 

If you generated a link to a folder where a file has been reported inside it, you should see a warning and won't be able to generate links either