### PR TITLE
add authenticated request data for uploads

### DIFF
--- a/packages/send/backend/src/routes/uploads.ts
+++ b/packages/send/backend/src/routes/uploads.ts
@@ -75,7 +75,8 @@ router.post(
     const { id, size, ownerId, type, part, fileHash } = req.body;
     const Metrics = useMetrics();
 
-    const { uniqueHash } = getDataFromAuthenticatedRequest(req);
+    const { uniqueHash, id: useridfromtoken } =
+      getDataFromAuthenticatedRequest(req);
 
     const distinctId = uniqueHash;
 
@@ -83,7 +84,7 @@ router.post(
       const upload = await createUpload(
         id,
         size,
-        ownerId,
+        ownerId || useridfromtoken,
         type,
         part,
         fileHash


### PR DESCRIPTION
This PR adds an alternative value to get the userid on a couple of api endpoints. This fixes an issue where the addon can't upload files because of this missing value. Although it's a temporary fix I'll still investigate why the id isn't being passed automatically 