### PR TITLE
Remove access to the old Pulumi bucket

### DIFF
--- a/packages/send/pulumi/config.prod.yaml
+++ b/packages/send/pulumi/config.prod.yaml
@@ -229,9 +229,7 @@ resources:
         - send-suite-prod-fargate
       fargate_task_role_arns:
         - arn:aws:iam::768512802988:role/send-suite-prod-fargate
-      enable_full_s3_access: true
-      s3_full_access_buckets:
-        - tb-send-suite-pulumi
+      enable_full_s3_access: false
       enable_s3_bucket_upload: true
       s3_upload_buckets:
         - tb-send-suite-prod-frontend

--- a/packages/send/pulumi/config.stage.yaml
+++ b/packages/send/pulumi/config.stage.yaml
@@ -228,9 +228,7 @@ resources:
         - send-suite-stage-fargate
       fargate_task_role_arns:
         - arn:aws:iam::768512802988:role/send-suite-stage-fargate
-      enable_full_s3_access: true
-      s3_full_access_buckets:
-        - tb-send-suite-pulumi
+      enable_full_s3_access: false
       enable_s3_bucket_upload: true
       s3_upload_buckets:
         - tb-send-suite-stage-frontend


### PR DESCRIPTION
This removes all access to the `tb-send-suite-pulumi` S3 bucket, which used to be the Pulumi state backend, but which has since been deleted.

This should further the efforts of #246 to revoke unnecessary global permissions.