### PR TITLE
Allow deployment to continue on error for ATN (in PROD)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,6 +199,7 @@ jobs:
           bun-version: latest
 
       - name: Deploy to ATN
+        continue-on-error: true
         if: contains(github.event.release.assets.*.name, 'xpi-prod.zip')
         id: xpi-deploy
         shell: bash


### PR DESCRIPTION
https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-preventing-a-specific-failing-matrix-job-from-failing-a-workflow-run

Same as for stage:
https://github.com/thunderbird/tbpro-add-on/pull/307