### PR TITLE
quick and dirty removal of debugging UI for content script

### DIFF
--- a/packages/addon/public/token-bridge.js
+++ b/packages/addon/public/token-bridge.js
@@ -17,7 +17,7 @@ Object.assign(tag.style, {
   padding: "6px 10px", background: "lime", color: "black",
   fontFamily: "monospace", boxShadow: "0 2px 8px rgba(0,0,0,.25)"
 });
-document.documentElement.appendChild(tag);
+// document.documentElement.appendChild(tag);
 
 // Initial message to the background
 browser.runtime.sendMessage({


### PR DESCRIPTION
Just comments out the `appendChild` call that adds the DOM element.