### PR TITLE
Use Send icon in created accounts as well

### DIFF
--- a/packages/addon/public/icons/send-glyph.svg
+++ b/packages/addon/public/icons/send-glyph.svg
@@ -2,7 +2,15 @@
      License, v. 2.0. If a copy of the MPL was not distributed with this
      file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
-  <g fill="context-fill" fill-opacity="context-fill-opacity">
+  <style>
+    path {
+      fill: black;
+    }
+    @media (prefers-color-scheme: dark) {
+      path { fill: white; }
+    }
+  </style>
+  <g>
     <path d="M16 8.25v1.5H0v-1.5h16Z"/>
     <path d="M8 .25c3.471 0 6.25 2.887 6.25 6.404v5.58c0 1.922-1.522 3.516-3.441 3.516-1.878 0-3.559-1.553-3.559-3.517V7.182H5.54a.299.299 0 0 1-.212-.51l2.355-2.355a.45.45 0 0 1 .634 0l2.355 2.355a.299.299 0 0 1-.211.51H8.75v5.051c0 1.092.965 2.017 2.059 2.017 1.052 0 1.941-.883 1.941-2.017V6.654c0-2.728-2.146-4.904-4.75-4.904S3.25 3.926 3.25 6.654V8.25h-1.5V6.654C1.75 3.137 4.529.25 8 .25Z"/>
   </g>


### PR DESCRIPTION
Dark mode looks kinda bad, though I don't know if we can solve this without worse hacks. Anyway, the icon is now in both places and I removed the polling.

<img width="242" height="465" alt="image" src="https://github.com/user-attachments/assets/2f4a432f-e689-4869-8f34-dbf9a5e66814" />
<img width="226" height="460" alt="image" src="https://github.com/user-attachments/assets/48dfc1da-f5d8-462a-bde8-1978b8b727ab" />

