### PR TITLE
when multi-part files are uploaded, hash files before zipping

### DIFF
--- a/packages/send/frontend/src/apps/send/components/ProgressBarV2.vue
+++ b/packages/send/frontend/src/apps/send/components/ProgressBarV2.vue
@@ -19,7 +19,11 @@ const stageInfo = computed(() => {
     ProcessStage,
     { text: string; color: string; bgColor: string }
   > = {
-    idle: { text: 'Ready', color: 'text-gray-600', bgColor: 'bg-gray-100' },
+    idle: {
+      text: 'Hashing...',
+      color: 'text-gray-600',
+      bgColor: 'bg-gray-100',
+    },
     preparing: {
       text: 'Preparing...',
       color: 'text-blue-600',

--- a/packages/send/frontend/src/lib/filesync.ts
+++ b/packages/send/frontend/src/lib/filesync.ts
@@ -65,6 +65,16 @@ export async function getBlob(
   api: ApiConnection,
   progressTracker: ProgressTracker
 ): Promise<string | void> {
+  // Check if this file has not been reported as suspicious
+  // check fileHash against suspicious files
+  const { isSuspicious } = await api.call<{ isSuspicious: boolean }>(
+    `download/check-upload-id/${id}`
+  );
+
+  if (isSuspicious) {
+    throw new Error('File has been reported as suspicious');
+  }
+
   if (!isBucketStorage) {
     const downloadedBlob = await _download({ id, progressTracker });
 

--- a/packages/send/frontend/src/test/lib/filesync-fs.test.ts
+++ b/packages/send/frontend/src/test/lib/filesync-fs.test.ts
@@ -58,6 +58,9 @@ vi.mock('@send-frontend/lib/helpers', async (importOriginal) => {
 describe(`Filesync`, () => {
   describe(`getBlob`, async () => {
     const restHandlers = [
+      http.get(`${API_URL}/download/check-upload-id/${UPLOAD_ID}`, async () =>
+        HttpResponse.json({ isSuspicious: false })
+      ),
       http.get(`${API_URL}/uploads/${UPLOAD_ID}/metadata`, async () =>
         HttpResponse.json(metadata)
       ),
@@ -76,6 +79,9 @@ describe(`Filesync`, () => {
 
     it(`should download and decrypt the upload`, async () => {
       const progress = mockProgressTracker;
+      const mockApi = {
+        call: vi.fn().mockResolvedValue({ isSuspicious: false }),
+      } as any;
       const result = await getBlob(
         UPLOAD_ID,
         metadata.size,
@@ -83,7 +89,7 @@ describe(`Filesync`, () => {
         false,
         fileName,
         metadata.type,
-        vi.fn() as any,
+        mockApi,
         progress
       );
       expect(result).toBe(undefined);
@@ -91,6 +97,9 @@ describe(`Filesync`, () => {
 
     it(`should download and decrypt the upload with no key`, async () => {
       const progress = mockProgressTracker;
+      const mockApi = {
+        call: vi.fn().mockResolvedValue({ isSuspicious: false }),
+      } as any;
       const result = await getBlob(
         UPLOAD_ID,
         metadata.size,
@@ -98,7 +107,7 @@ describe(`Filesync`, () => {
         false,
         fileName,
         metadata.type,
-        vi.fn() as any,
+        mockApi,
         progress
       );
       expect(result).toBe(undefined);

--- a/packages/send/frontend/src/test/lib/filesync.test.ts
+++ b/packages/send/frontend/src/test/lib/filesync.test.ts
@@ -58,6 +58,9 @@ vi.mock('@send-frontend/lib/helpers', async (importOriginal) => {
 
 describe(`Filesync`, () => {
   const restHandlers = [
+    http.get(`${API_URL}/download/check-upload-id/${UPLOAD_ID}`, async () =>
+      HttpResponse.json({ isSuspicious: false })
+    ),
     http.get(`${API_URL}/uploads/${UPLOAD_ID}/metadata`, async () =>
       HttpResponse.json(metadata)
     ),


### PR DESCRIPTION
This PR makes sure the file hash is generated on each piece of a multi part upload and not on the entire file. This avoids running out of memory. Additionally, we run the hash before zipping because if we don't, then the hashes are always different 

Fixes #347 