### PR TITLE
Call hamburger menu's login function after login via add-on

### DIFF
--- a/packages/addon/src/background.ts
+++ b/packages/addon/src/background.ts
@@ -217,6 +217,9 @@ browser.runtime.onMessage.addListener(async (message) => {
       });
 
       console.log(`🎯 user auth stored in add-on context.`);
+      console.log(`updating the 🍔 menu.`);
+      menuLoggedIn({ username: email });
+
       break;
 
     case OIDC_TOKEN:


### PR DESCRIPTION
Closes #403 

Tiny change that updates the hamburger menu's state when logging in from add-on.
Tested by clicking Sign-in button from TB Send panel in Composition settings and completing the sign-in flow.