### PR TITLE
Fix incorrect args and request method

### DIFF
--- a/packages/send/backend/src/routes/oidc-auth.ts
+++ b/packages/send/backend/src/routes/oidc-auth.ts
@@ -23,7 +23,7 @@ const router: Router = Router();
  * Endpoint for handling OIDC authentication after the frontend completes the OAuth flow
  * The frontend should call this endpoint with the access token received from OIDC
  */
-router.get(
+router.post(
   '/oidc/authenticate',
   requireOIDCAuth,
   addErrorHandling(AUTH_ERRORS.AUTH_FAILED),
@@ -34,7 +34,6 @@ router.get(
         error: 'missing_oidc_user',
       });
     }
-
     const { sub, email, username } = req.oidcUser;
 
     try {

--- a/packages/send/frontend/src/stores/auth-store.ts
+++ b/packages/send/frontend/src/stores/auth-store.ts
@@ -119,13 +119,7 @@ export const useAuthStore = defineStore('auth', () => {
       );
 
       // Send the access token to our backend to create/update user
-      const response = await api.call('auth/oidc/authenticate', {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${user.access_token}`,
-          'Content-Type': 'application/json',
-        },
-      });
+      const response = await api.call('auth/oidc/authenticate', {}, 'POST');
 
       if (response?.user) {
         isLoggedIn.value = true;

--- a/packages/send/frontend/src/stores/auth-store.ts
+++ b/packages/send/frontend/src/stores/auth-store.ts
@@ -119,7 +119,16 @@ export const useAuthStore = defineStore('auth', () => {
       );
 
       // Send the access token to our backend to create/update user
-      const response = await api.call('auth/oidc/authenticate', {}, 'POST');
+      const response = await api.call(
+        'auth/oidc/authenticate',
+        {
+          headers: {
+            Authorization: `Bearer ${user.access_token}`,
+            'Content-Type': 'application/json',
+          },
+        },
+        'POST'
+      );
 
       if (response?.user) {
         isLoggedIn.value = true;


### PR DESCRIPTION
While investigating #407, I noticed that the API call to `auth/oidc/authenticate` was incorrect.

* Updated both the caller and the route to `POST`.
* ~Removed unused headers.~

Side note:
I haven't looked into it, but I suspect that the headers are added by `oidc-client-ts` and our `api.call()` function automatically includes the headers.

The backend automatically extracts and uses the auth token from the headers via the `requireOIDCAuth` middleware.