### PR TITLE
set max version to 149

### DIFF
--- a/packages/addon/public/manifest.json
+++ b/packages/addon/public/manifest.json
@@ -8,7 +8,7 @@
     "gecko": {
       "id": "tbpro-addon-stage@thunderbird.net",
       "strict_min_version": "128.0",
-      "strict_max_version": "148.*"
+      "strict_max_version": "149.*"
     }
   },
   "background": {


### PR DESCRIPTION
Closes https://github.com/thunderbird/tbpro-add-on/issues/428

This pull request contains a small change to the `manifest.json` file, updating the maximum supported version for Gecko-based browsers from 148.* to 149.*. This ensures compatibility with the latest TB release.