### PR TITLE
add storage auth validation

### DIFF
--- a/packages/send/frontend/src/lib/validations.ts
+++ b/packages/send/frontend/src/lib/validations.ts
@@ -13,7 +13,16 @@ export const validateToken = async (api: ApiConnection): Promise<boolean> => {
       const authStore = await import('@send-frontend/stores/auth-store').then(
         (m) => m.useAuthStore()
       );
+      const isExtension = await import('@send-frontend/stores').then(
+        (m) => m.useConfigStore().isExtension
+      );
       const accessToken = await authStore.getAccessToken();
+
+      // Load user from stored auth data, if available.
+      // No-op if we are not in the add-on.
+      if (isExtension) {
+        await authStore.loadUser();
+      }
 
       if (accessToken) {
         // Try OIDC validation

--- a/packages/send/frontend/src/stores/auth-store.ts
+++ b/packages/send/frontend/src/stores/auth-store.ts
@@ -1,19 +1,19 @@
 // stores/auth-store.js
 
 import logger from '@send-frontend/logger';
-import { useApiStore } from '@send-frontend/stores';
+import { useApiStore, useConfigStore } from '@send-frontend/stores';
 import { User, UserManager, UserManagerSettings } from 'oidc-client-ts';
 import { defineStore } from 'pinia';
 
-import { ref, watch } from 'vue';
 import {
   BRIDGE_PING,
   BRIDGE_READY,
-  OIDC_USER,
   OIDC_TOKEN,
-  STORAGE_KEY_AUTH,
+  OIDC_USER,
   SIGN_OUT,
+  STORAGE_KEY_AUTH,
 } from '@send-frontend/lib/const';
+import { ref, watch } from 'vue';
 
 const settings: UserManagerSettings = {
   authority: import.meta.env?.VITE_OIDC_ROOT_URL,
@@ -32,6 +32,7 @@ const userManager = new UserManager(settings);
 
 export const useAuthStore = defineStore('auth', () => {
   const { api } = useApiStore();
+  const { isExtension } = useConfigStore();
 
   const isLoggedIn = ref(false);
   const currentUser = ref<User | null>(null);
@@ -146,7 +147,9 @@ export const useAuthStore = defineStore('auth', () => {
     try {
       // Load user from stored auth data, if available.
       // No-op if we are not in the add-on.
-      await loadUser();
+      if (isExtension) {
+        await loadUser();
+      }
 
       const user = await userManager.getUser();
 
@@ -269,5 +272,8 @@ export const useAuthStore = defineStore('auth', () => {
     logoutFromOIDC,
     refreshToken,
     loginToKeyCloak, // Alias for loginToOIDC
+
+    // add-on specific
+    loadUser,
   };
 });

--- a/packages/send/frontend/src/test/stores/user-store.test.ts
+++ b/packages/send/frontend/src/test/stores/user-store.test.ts
@@ -219,12 +219,19 @@ describe('User Store', () => {
       const newId = 2;
       const newTier = UserTier.PRO;
       const newEmail = 'new@example.com';
+      const thundermailEmail = 'thundermail@thundermail.com';
       const storageMock = vi.spyOn(Storage.prototype, 'storeUser');
-      await userStore.store(newId.toString(), newTier, newEmail);
+      await userStore.store(
+        newId.toString(),
+        newTier,
+        newEmail,
+        thundermailEmail
+      );
       expect(storageMock).toHaveBeenCalledWith({
         id: newId.toString(),
         tier: newTier,
         email: newEmail,
+        thundermailEmail: thundermailEmail,
       });
     });
 


### PR DESCRIPTION
This pull request updates authentication logic to better support extension-specific behavior and ensures user information is properly loaded when running as an extension. It also fixes imports and improves test coverage for user storage.

Authentication and extension support:

* In `validateToken` and `useAuthStore`, added logic to detect if the app is running as an extension (`isExtension`) and to load user information from stored auth data only when in extension mode. [[1]](diffhunk://#diff-9a8772cfd7891bc2e7926f3e6f7b31a2a9ee882b15b16577242757037bcc9785R16-R26) [[2]](diffhunk://#diff-1c91e095262964968224c290200b11345756016de3340456e9137d24f478ae43R35) [[3]](diffhunk://#diff-1c91e095262964968224c290200b11345756016de3340456e9137d24f478ae43R150-R152)
* Exposed the `loadUser` method from `useAuthStore` for add-on specific use.

Code organization and imports:

* Cleaned up and reordered imports in `auth-store.ts` for clarity and consistency.

Testing improvements:

* Updated the user store test to include the `thundermailEmail` property when storing user data, ensuring all relevant fields are tested.