### PR TITLE
open login on install

### DIFF
--- a/packages/addon/src/background.ts
+++ b/packages/addon/src/background.ts
@@ -327,6 +327,8 @@ browser.runtime.onMessage.addListener(async (message) => {
       );
       await closeLoginTab();
       await initCloudFile();
+      // Open the add-on options page after successful login
+      await browser.runtime.openOptionsPage();
       break;
 
     // Popup is ready and is requesting the file list.

--- a/packages/addon/src/menu.ts
+++ b/packages/addon/src/menu.ts
@@ -139,6 +139,13 @@ export async function closeLoginTab() {
  * Creates the root menu item and registers listeners for all menu actions.
  */
 export function init() {
+  // Register onInstalled handler to open BASE_URL on extension install/update
+  browser.runtime.onInstalled.addListener(async (details) => {
+    if (details.reason === 'install') {
+      await menuLogin();
+    }
+  });
+
   // Register click handler for all menu items
   browser.TBProMenu.onClicked.addListener(async (action) => {
     switch (action) {

--- a/packages/send/frontend/src/apps/send/LoginPage.vue
+++ b/packages/send/frontend/src/apps/send/LoginPage.vue
@@ -25,7 +25,7 @@ const userStore = useUserStore();
 const { keychain } = useKeychainStore();
 const folderStore = useFolderStore();
 const { isPublicLogin } = useConfigStore();
-const { isExtension } = useConfigStore();
+const { isExtension, openManagementPage, isThunderbirdHost } = useConfigStore();
 const { loginToOIDC } = useAuthStore();
 const { isRouteExtension } = useIsRouteExtension();
 
@@ -55,6 +55,9 @@ async function pingSession() {
 async function onSuccess() {
   await dbUserSetup(userStore, keychain, folderStore);
   await pingSession();
+  if (isThunderbirdHost) {
+    await openManagementPage();
+  }
 }
 
 trpc.onLoginFinished.subscribe(

--- a/packages/send/frontend/src/apps/send/stores/config-store.ts
+++ b/packages/send/frontend/src/apps/send/stores/config-store.ts
@@ -45,6 +45,10 @@ export const useConfigStore = defineStore('config', () => {
     }
   }
 
+  async function openManagementPage() {
+    await browser.runtime.openOptionsPage();
+  }
+
   return {
     isProd,
     isStaging,
@@ -60,6 +64,7 @@ export const useConfigStore = defineStore('config', () => {
     isTbproExtension,
     isThunderbirdHost,
     getAddonId,
+    openManagementPage,
   };
 });
 


### PR DESCRIPTION
Closes https://github.com/thunderbird/tbpro-add-on/issues/430
This PR opens the login flow when the add-on is installed. Additionally, the management page opens after successfully logging in