### PR TITLE
oven-sh/setup-bun@v2

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -256,7 +256,7 @@ jobs:
           EOF
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
@@ -371,7 +371,7 @@ jobs:
           EOF
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,8 +98,6 @@ jobs:
           curl -fsSL https://get.pulumi.com | sh
           pip install -Ur requirements.txt
 
-
-
       - name: Deploy version-tagged image to prod
         if: contains(github.event.release.assets.*.name, 'ecr_tag.zip')
         env:
@@ -194,7 +192,7 @@ jobs:
           file: xpi-prod.zip
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to use the latest version of the Bun setup action and performs minor cleanup in the release workflow. The most significant changes are upgrading the Bun action to v2 for improved reliability and removing unnecessary blank lines.

**Workflow Updates:**

* Upgraded the Bun setup action from `oven-sh/setup-bun@v1` to `oven-sh/setup-bun@v2` in both `.github/workflows/merge.yml` and `.github/workflows/release.yml` to ensure compatibility with the latest Bun features and bug fixes. [[1]](diffhunk://#diff-bdb37b2ad65e049a0fc043e88813fdcf7ca0118abc11d99bbda676adfcbbb5a1L259-R259) [[2]](diffhunk://#diff-bdb37b2ad65e049a0fc043e88813fdcf7ca0118abc11d99bbda676adfcbbb5a1L374-R374) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L197-R195)

**Minor Cleanup:**

* Removed extra blank lines in `.github/workflows/release.yml` for improved readability.