### PR TITLE
use migrate deploy instead of db push

### DIFF
--- a/packages/send/backend/package.json
+++ b/packages/send/backend/package.json
@@ -14,7 +14,7 @@
     "db:generate": "prisma generate",
     "db:migrate": "prisma migrate dev",
     "db:reset": "prisma migrate reset --force",
-    "db:update": "prisma db push",
+    "db:update": "prisma migrate deploy",
     "debug": "pnpm db:browse & pnpm debug:attach",
     "debug:attach": "nodemon -e js,ts --exec 'node --inspect=0.0.0.0:9229 --require ts-node/register -r tsconfig-paths/register src/index.ts'",
     "dev": "nodemon -e js,ts src/index.ts",


### PR DESCRIPTION
This PR changes migration script to use migrate deploy instead of db push. This avoids migration errors