### PR TITLE
Reduce z-index of NavBar component

### DIFF
--- a/packages/send/frontend/src/apps/send/components/NavBar.vue
+++ b/packages/send/frontend/src/apps/send/components/NavBar.vue
@@ -83,7 +83,7 @@ header {
 
   /* Without this we can't be on top of main content when we need */
   position: relative;
-  z-index: 9999;
+  z-index: 999;
 
   &:first-child {
     margin-right: auto;


### PR DESCRIPTION
## Description of changes

TIL that we are using `vue-final-modal` lib for handling modals and its default z-index is `1000` [[ref](https://vue-final-modal.org/api/components/vue-final-modal#zindexfn)].

The `NavBar` component had a `z-index` of `9999` so this PR reduces it to `999` instead.

## Screenshots

<img width="1279" height="968" alt="image" src="https://github.com/user-attachments/assets/864f05a0-0e59-4b8d-86f0-5d338927eba0" />



## Related issues

Fixes https://github.com/thunderbird/tbpro-add-on/issues/516