### PR TITLE
Upload font files to S3 separately for explicit MIME types

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -310,7 +310,16 @@ jobs:
         shell: bash
         run: |
           cd packages/send/dist-web-stage
-          aws s3 cp . s3://tb-send-suite-stage-frontend/ --recursive
+
+          # Upload everything except font files first
+          aws s3 cp . s3://tb-send-suite-stage-frontend/ --recursive \
+            --exclude "*.woff" --exclude "*.woff2"
+
+          # Upload font files with explicit MIME types
+          aws s3 cp . s3://tb-send-suite-stage-frontend/ --recursive \
+            --exclude "*" --include "*.woff" --content-type "font/woff"
+          aws s3 cp . s3://tb-send-suite-stage-frontend/ --recursive \
+            --exclude "*" --include "*.woff2" --content-type "font/woff2"
 
           # Invalidate the CDN
           aws cloudfront create-invalidation --distribution-id ${{ vars.STAGE_CF_DISTRO_ID }} --paths "/*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,7 +164,16 @@ jobs:
         run: |
           unzip -d frontend-source dist-web-prod.zip
           cd frontend-source
-          aws s3 cp . s3://tb-send-suite-prod-frontend/ --recursive
+
+          # Upload everything except font files first
+          aws s3 cp . s3://tb-send-suite-prod-frontend/ --recursive \
+            --exclude "*.woff" --exclude "*.woff2"
+
+          # Upload font files with explicit MIME types
+          aws s3 cp . s3://tb-send-suite-prod-frontend/ --recursive \
+            --exclude "*" --include "*.woff" --content-type "font/woff"
+          aws s3 cp . s3://tb-send-suite-prod-frontend/ --recursive \
+            --exclude "*" --include "*.woff2" --content-type "font/woff2"
 
           # Invalidate the CDN
           aws cloudfront create-invalidation --distribution-id ${{ vars.PROD_CF_DISTRO_ID }} --paths "/*"


### PR DESCRIPTION
## Description of changes

Honestly, this is an attempt to fix the fonts not being loaded by the browser. It seems that the font files themselves are there as the network tabs do request it successfully and doing a `curl` also returns 200.

However, seems like the MIME type is `text/html` which apparently may cause the fonts not to load. Unclear if that's going to solve the issue but seems harmless-ish to try.

## Related issues
https://github.com/thunderbird/tbpro-add-on/issues/518