### PR TITLE
Bump minor send frontend version to 6.5.0

### DIFF
--- a/packages/send/frontend/package.json
+++ b/packages/send/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "send-frontend",
-  "version": "6.4.2",
+  "version": "6.5.0",
   "private": false,
   "type": "module",
   "scripts": {

--- a/packages/send/frontend/public/manifest.json
+++ b/packages/send/frontend/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "version": "6.4.2",
+  "version": "6.5.0",
   "author": "Thunderbird Team",
   "name": "Thunderbird Send",
   "description": "Thunderbird and friends",


### PR DESCRIPTION
Following other PR examples like:

https://github.com/thunderbird/tbpro-add-on/pull/495

And the instructions here:

https://github.com/thunderbird/tbpro-add-on/tree/main/packages/send#releasing

I've only ran `pnpm version minor` in `/packages/send/frontend` to attempt to deploy the header / footer changes.