### PR TITLE
[CI]: Use devcontainer for validation action

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -53,7 +53,7 @@ jobs:
       image: ghcr.io/${{ github.repository }}/cached-devcontainer:latest
     env:
       IS_CI_AUTOMATION: "yes"
-    # if: needs.detect-changes.outputs.backend-changed == 'true'
+    if: needs.detect-changes.outputs.backend-changed == 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -97,7 +97,7 @@ jobs:
       image: ghcr.io/${{ github.repository }}/cached-devcontainer:latest
     env:
       IS_CI_AUTOMATION: "yes"
-    # if: needs.detect-changes.outputs.iac-changed == 'true'
+    if: needs.detect-changes.outputs.iac-changed == 'true'
     steps:
       - uses: actions/checkout@v4
       - name: Ruff checks for Send Pulumi code
@@ -113,7 +113,7 @@ jobs:
       image: ghcr.io/${{ github.repository }}/cached-devcontainer:latest
     env:
       IS_CI_AUTOMATION: "yes"
-    # if: needs.detect-changes.outputs.frontend-changed == 'true'
+    if: needs.detect-changes.outputs.frontend-changed == 'true'
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
@@ -151,7 +151,7 @@ jobs:
       image: ghcr.io/${{ github.repository }}/cached-devcontainer:latest
     env:
       IS_CI_AUTOMATION: "yes"
-    # if: needs.detect-changes.outputs.shared-changed == 'true'
+    if: needs.detect-changes.outputs.shared-changed == 'true'
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
@@ -174,7 +174,7 @@ jobs:
       image: ghcr.io/${{ github.repository }}/cached-devcontainer:latest
     env:
       IS_CI_AUTOMATION: "yes"
-    # if: needs.detect-changes.outputs.addon-changed == 'true'
+    if: needs.detect-changes.outputs.addon-changed == 'true'
     steps:
       - uses: actions/checkout@v4
       - name: Create .env file so tests will work


### PR DESCRIPTION
Building on the dev container setup for CI, I've modified the validation Action workflow to use the cached container.

Evidence of his workflow continuing to work:
<img width="1033" height="390" alt="Screenshot 2026-02-11 at 12 08 19 PM" src="https://github.com/user-attachments/assets/a3e3238b-f5ad-4db3-ac15-dce5d13aac1b" />
<img width="1001" height="1298" alt="Screenshot 2026-02-11 at 12 11 04 PM" src="https://github.com/user-attachments/assets/4240bd7e-bbc6-4c47-ad66-53e0411b8aef" />
<img width="1002" height="1290" alt="Screenshot 2026-02-11 at 12 09 59 PM" src="https://github.com/user-attachments/assets/254fb9cb-ea62-46c5-a2a4-8cb55b9ba8b9" />
<img width="1030" height="1110" alt="Screenshot 2026-02-11 at 12 10 18 PM" src="https://github.com/user-attachments/assets/31b7090f-4eed-4e95-bd80-f192a0abeedb" />
<img width="1002" height="1297" alt="Screenshot 2026-02-11 at 12 10 28 PM" src="https://github.com/user-attachments/assets/c0bcedd2-baa0-4fd5-b415-5e61697641e5" />
<img width="1008" height="1094" alt="Screenshot 2026-02-11 at 12 10 37 PM" src="https://github.com/user-attachments/assets/ed6b31b5-ff35-4a81-b223-0b42221ae9b5" />
