### PR TITLE
[CI]: Configure e2e-bucket-test to use devcontainer ci

### DIFF
--- a/.github/workflows/e2e-bucket-test.yml
+++ b/.github/workflows/e2e-bucket-test.yml
@@ -46,7 +46,7 @@ jobs:
               - 'packages/shared/**'
   end-to-end-tests:
     needs: detect-changes
-    # if: needs.detect-changes.outputs.backend-changed == 'true' || needs.detect-changes.outputs.frontend-changed == 'true'
+    if: needs.detect-changes.outputs.backend-changed == 'true' || needs.detect-changes.outputs.frontend-changed == 'true'
     runs-on: ubuntu-latest
     container:
         image: ghcr.io/${{ github.repository }}/cached-devcontainer:latest


### PR DESCRIPTION
Bucket tests confirmed working:
<img width="805" height="794" alt="Screenshot 2026-02-11 at 4 00 13 PM" src="https://github.com/user-attachments/assets/2f500350-e93f-47f3-9528-d4da14156aa4" />
