### PR TITLE
[CI] : Use devcontainer configuration for e2e nightly tests 

### DIFF
--- a/.github/workflows/nightly-e2e-tests-desktop.yml
+++ b/.github/workflows/nightly-e2e-tests-desktop.yml
@@ -11,9 +11,6 @@ on:
     - cron:  '0 2 * * *'
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
-  push:
-    branches:
-      - "**"
 
 permissions:
   packages: read


### PR DESCRIPTION
Updating Github action for e2e nightly browserstack tests to use devcontainer for CI.

Confirmed with @rwood-moz that the tests are working!