### PR TITLE
[CI]: Setting Devcontainer Python version to 3.13 to satisfy TB pulumi requirements

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,9 @@
     "PNPM_HOME": "~/.local/share/pnpm/store"
   },
   "features": {
-    "ghcr.io/devcontainers/features/python:1": {},
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "3.13"
+    },
     "ghcr.io/devcontainers-extra/features/pulumi:1": {},
     "ghcr.io/jsburckhardt/devcontainer-features/ruff:1": {},
     "ghcr.io/devcontainers/features/aws-cli:1": {},


### PR DESCRIPTION
When running projects utilizing TB_Pulumi, the package requires the python version to be >=3.13.
<img width="1079" height="72" alt="Screenshot 2026-02-20 at 9 22 20 AM" src="https://github.com/user-attachments/assets/5a3f1ad7-735a-483e-8d15-ad644b968952" />
