### PR TITLE
Update E2E sign-in test for latest dashboard changes

### DIFF
--- a/packages/send/e2e/browserstack-desktop-nightly.yml
+++ b/packages/send/e2e/browserstack-desktop-nightly.yml
@@ -90,7 +90,7 @@ framework: playwright
 # and mobile browsers; and therefore must be the same in all of our browserstack-*.yml config files
 # for playwright ver we need one compatible with our desktop and mobile browsers, see:
 # https://www.browserstack.com/docs/automate/playwright/browsers-and-os?fw-lang=nodejs
-browserstack.playwrightVersion: 1.53.0 # must match our client playwright version in package.json
+browserstack.playwrightVersion: 1.56.1 # must match our client playwright version in package.json
 browserstack.playwrightLogs: false # disable playwright logs appearing on browserstack builds as may contain sensitive info like credentials
 # CUSTOM_TAG_<INT>: # <string> (Default: parent folder name of the test file) Custom tag for your test suite
 browserstack.maskBasicAuth: true # mask username and passwords from browserstack session logs

--- a/packages/send/e2e/browserstack-mobile-nightly.yml
+++ b/packages/send/e2e/browserstack-mobile-nightly.yml
@@ -79,7 +79,7 @@ idleTimeout: 500 # seeing if this helps rid BROWSERSTACK_IDLE_TIMEOUTs on ios
 # and mobile browsers; and therefore must be the same in all of our browserstack-*.yml config files
 # for playwright ver we need one compatible with our desktop and mobile browsers, see:
 # https://www.browserstack.com/docs/automate/playwright/browsers-and-os?fw-lang=nodejs
-browserstack.playwrightVersion: 1.53.0 # must match ver in package.json
+browserstack.playwrightVersion: 1.56.1 # must match ver in package.json
 browserstack.playwrightLogs: false # disable playwright logs appearing on browserstack builds as may contain sensitive info like credentials
 # CUSTOM_TAG_<INT>: # <string> (Default: parent folder name of the test file) Custom tag for your test suite
 browserstack.maskBasicAuth: true # mask username and passwords from browserstack session logs

--- a/packages/send/e2e/pages/dashboard-page.ts
+++ b/packages/send/e2e/pages/dashboard-page.ts
@@ -1,19 +1,37 @@
 import { type Page, type Locator } from '@playwright/test';
 
 import { 
-  TB_ACCTS_EMAIL,
+  TIMEOUT_1_SECOND,
+  TIMEOUT_5_SECONDS
 } from "../const/const";
 
 export class DashboardPage {
   readonly page: Page;
-  readonly tbProHdrLogo: Locator;
-  readonly sendStorageHdr: Locator;
-  readonly logoutBtn: Locator;
+  readonly sendHdrLogoLink: Locator;
+  readonly sendHdrDashboardLink: Locator;
+  readonly sendHdrEncryptedLink: Locator;
+  readonly sendHdrSecurityLink: Locator;
+  readonly userAvatarMenuBtn: Locator;
+  readonly logoutMenuBtn: Locator;
 
   constructor(page: Page) {
     this.page = page;
-    this.tbProHdrLogo = this.page.locator('.header-logo');
-    this.sendStorageHdr = this.page.getByRole('heading', { name: 'Send Storage' })
-    this.logoutBtn = this.page.getByTestId('log-out-button');
+    this.sendHdrLogoLink = this.page.getByRole('link', { name: 'Send' }).first();
+    this.sendHdrDashboardLink = this.page.getByTestId('navlink-dashboard');
+    this.sendHdrEncryptedLink = this.page.getByTestId('navlink-encrypted-files');
+    this.sendHdrSecurityLink = this.page.getByTestId('navlink-security-&-privacy');
+    this.userAvatarMenuBtn = this.page.locator('aside.avatar.regular');
+    this.logoutMenuBtn = this.page.getByRole('button', { name: 'Logout', exact: true });
+  }
+
+  /**
+   * Log out via the user avatar menu
+   */
+  async signOut(testProjectName: string = 'desktop') {
+    console.log('signing out of tb send');
+    await this.userAvatarMenuBtn.click();
+    await this.page.waitForTimeout(TIMEOUT_1_SECOND);
+    await this.logoutMenuBtn.click();
+    await this.page.waitForTimeout(TIMEOUT_5_SECONDS);
   }
 }

--- a/packages/send/e2e/pages/tb-accts-page.ts
+++ b/packages/send/e2e/pages/tb-accts-page.ts
@@ -32,7 +32,7 @@ export class TBAcctsPage {
    * test project name (i.e. 'android-chrome') as some actions differ on different mobile platforms.
    */
   async signIn(testProjectName: string = 'desktop') {
-    console.log('signing in to TB Accounts');
+    console.log('signing in to tb accounts');
     expect(TB_ACCTS_EMAIL, 'getting TB_ACCTS_EMAIL env var').toBeTruthy();
     expect(TB_ACCTS_PWORD, 'getting TB_ACCTS_PWORD env var').toBeTruthy();
     await expect(this.emailInput).toBeVisible({ timeout: TIMEOUT_30_SECONDS });

--- a/packages/send/e2e/tests/desktop/sign-in.spec.ts
+++ b/packages/send/e2e/tests/desktop/sign-in.spec.ts
@@ -6,7 +6,7 @@ import { DashboardPage } from '../../pages/dashboard-page';
 import {
   PLAYWRIGHT_TAG_DESKTOP_NIGHTLY,
   TIMEOUT_1_SECOND,
-  TIMEOUT_5_SECONDS,
+  TIMEOUT_30_SECONDS,
  } from "../../const/const"
 
 var tbAcctsPage: TBAcctsPage;
@@ -33,12 +33,12 @@ test.describe('sign-in (desktop)', () => {
     await navigateToSendAndSignIn(page);
 
     // verify we're now on the tb send dashboard, give lots of time as BrowserStack can be slow
-    await expect(dashboardPage.sendStorageHdr).toBeVisible();
-    await expect(dashboardPage.logoutBtn).toBeVisible();
+    await expect(dashboardPage.sendHdrLogoLink).toBeVisible({ timeout: TIMEOUT_30_SECONDS });
+    await expect(dashboardPage.sendHdrEncryptedLink).toBeVisible();
+    await expect(dashboardPage.sendHdrSecurityLink).toBeVisible();
 
-    // now that we're done, wait a second and sign out
+    // now that we're done, wait a second and sign out via user avatar menu
     await page.waitForTimeout(TIMEOUT_1_SECOND);
-    await dashboardPage.logoutBtn.click();
-    await page.waitForTimeout(TIMEOUT_5_SECONDS);
+    await dashboardPage.signOut();
   });
 });

--- a/packages/send/e2e/tests/mobile/sign-in.spec.ts
+++ b/packages/send/e2e/tests/mobile/sign-in.spec.ts
@@ -6,7 +6,7 @@ import { DashboardPage } from '../../pages/dashboard-page';
 import {
   PLAYWRIGHT_TAG_MOBILE_NIGHTLY,
   TIMEOUT_1_SECOND,
-  TIMEOUT_5_SECONDS,
+  TIMEOUT_30_SECONDS,
  } from "../../const/const"
 
 var tbAcctsPage: TBAcctsPage;
@@ -33,12 +33,10 @@ test.describe('sign-in (mobile)', () => {
     await navigateToSendAndSignIn(page, testInfo.project.name); //ie. ios-safari
 
     // verify we're now on the tb send dashboard, give lots of time as BrowserStack can be slow
-    await expect(dashboardPage.sendStorageHdr).toBeVisible();
-    await expect(dashboardPage.logoutBtn).toBeVisible();
+    await expect(dashboardPage.sendHdrLogoLink).toBeVisible({ timeout: TIMEOUT_30_SECONDS });
 
-    // now that we're done, wait a second and sign out
+    // now that we're done, wait a second and sign out via user avatar menu
     await page.waitForTimeout(TIMEOUT_1_SECOND);
-    await dashboardPage.logoutBtn.click();
-    await page.waitForTimeout(TIMEOUT_5_SECONDS);
+    await dashboardPage.signOut(testInfo.project.name);
   });
 });

--- a/packages/send/e2e/utils/utils.ts
+++ b/packages/send/e2e/utils/utils.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { expect, type Page } from '@playwright/test';
 import { TBAcctsPage } from "../pages/tb-accts-page";
 import { DashboardPage } from '../pages/dashboard-page';
 
@@ -33,11 +33,9 @@ export const navigateToSendAndSignIn = async (page: Page, testProjectName: strin
     }
   } else {
     // sign-in using tb accts; first we click the 'login with your tb pro account' button
+    await expect(tbAcctsSignInPage.signInUsingTBAcctsBtn).toBeVisible({ timeout: TIMEOUT_60_SECONDS });
     await tbAcctsSignInPage.signInUsingTBAcctsBtn.click();
     // then we sign-in to tb accounts itself
     await tbAcctsSignInPage.signIn(testProjectName);
   }
-  
-  // check for tbpro logo on dashboard, give lots of time for page to load as BrowserStack can be slow
-  await expect(dashboardPage.tbProHdrLogo).toBeVisible({ timeout: TIMEOUT_60_SECONDS });
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2098,21 +2098,25 @@ packages:
     resolution: {integrity: sha512-D+tPXB0tkSuDPsuXvyQIsF3f3PBWfAwIe9FkBWtVoDVYqE+jbz+tVGsjQMNWGafLE4sC8ZQdjhsxyT8I53Anbw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-arm64-musl@22.5.2':
     resolution: {integrity: sha512-UbO527qqa8KLBi13uXto5SmxcZv1Smer7sPexJonshDlmrJsyvx5m8nm6tcSv04W5yQEL90vPlTux8dNvEDWrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-linux-x64-gnu@22.5.2':
     resolution: {integrity: sha512-wR6596Vr/Z+blUAmjLHG2TCQMs4O1oi9JXK1J/PoPeO9UqdHwStCJBAd61zDFSUYJe0x+dkeRQu96fE5BW8Kcg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-x64-musl@22.5.2':
     resolution: {integrity: sha512-MBXOw4AH4FWl4orwVykj/e75awTNDePogrl3pXNX9NcQLdj6JzS4e2jaALQeRBQLxQzeFvFQV/W4PBzoPV6/NA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-win32-arm64-msvc@22.5.2':
     resolution: {integrity: sha512-SaWSZkRH5uV8vP2lj6RRv+kw2IzaIDXkutReOXpooshIWZl9KjrQELNTCZTYyhLDsMlcyhSvLFlTiA4NkZ8udw==}
@@ -2548,56 +2552,67 @@ packages:
     resolution: {integrity: sha512-PsNAbcyv9CcecAUagQefwX8fQn9LQ4nZkpDboBOttmyffnInRy8R8dSg6hxxl2Re5QhHBf6FYIDhIj5v982ATQ==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.52.5':
     resolution: {integrity: sha512-Fw4tysRutyQc/wwkmcyoqFtJhh0u31K+Q6jYjeicsGJJ7bbEq8LwPWV/w0cnzOqR2m694/Af6hpFayLJZkG2VQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.52.5':
     resolution: {integrity: sha512-a+3wVnAYdQClOTlyapKmyI6BLPAFYs0JM8HRpgYZQO02rMR09ZcV9LbQB+NL6sljzG38869YqThrRnfPMCDtZg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.52.5':
     resolution: {integrity: sha512-AvttBOMwO9Pcuuf7m9PkC1PUIKsfaAJ4AYhy944qeTJgQOqJYJ9oVl2nYgY7Rk0mkbsuOpCAYSs6wLYB2Xiw0Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.52.5':
     resolution: {integrity: sha512-DkDk8pmXQV2wVrF6oq5tONK6UHLz/XcEVow4JTTerdeV1uqPeHxwcg7aFsfnSm9L+OO8WJsWotKM2JJPMWrQtA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.52.5':
     resolution: {integrity: sha512-W/b9ZN/U9+hPQVvlGwjzi+Wy4xdoH2I8EjaCkMvzpI7wJUs8sWJ03Rq96jRnHkSrcHTpQe8h5Tg3ZzUPGauvAw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.52.5':
     resolution: {integrity: sha512-sjQLr9BW7R/ZiXnQiWPkErNfLMkkWIoCz7YMn27HldKsADEKa5WYdobaa1hmN6slu9oWQbB6/jFpJ+P2IkVrmw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.52.5':
     resolution: {integrity: sha512-hq3jU/kGyjXWTvAh2awn8oHroCbrPm8JqM7RUpKjalIRWWXE01CQOf/tUNWNHjmbMHg/hmNCwc/Pz3k1T/j/Lg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.52.5':
     resolution: {integrity: sha512-gn8kHOrku8D4NGHMK1Y7NA7INQTRdVOntt1OCYypZPRt6skGbddska44K8iocdpxHTMMNui5oH4elPH4QOLrFQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.52.5':
     resolution: {integrity: sha512-hXGLYpdhiNElzN770+H2nlx+jRog8TyynpTVzdlc6bndktjKWyZyiCsuDAlpd+j+W+WNqfcyAWz9HxxIGfZm1Q==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.52.5':
     resolution: {integrity: sha512-arCGIcuNKjBoKAXD+y7XomR9gY6Mw7HnFBv5Rw7wQRvwYLR7gBAgV7Mb2QTyjXfTveBNFAtPt46/36vV9STLNg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.52.5':
     resolution: {integrity: sha512-QoFqB6+/9Rly/RiPjaomPLmR/13cgkIGfA40LHly9zcH1S0bN2HVFYk3a1eAyHQyjs3ZJYlXvIGtcCs5tko9Cw==}
@@ -3988,6 +4003,7 @@ packages:
   aws-sdk@2.1693.0:
     resolution: {integrity: sha512-cJmb8xEnVLT+R6fBS5sn/EFJiX7tUnDaPtOPZ1vFbOJtd0fnZn/Ky2XGgsvvoeliWeH7mL3TWSX5zXXGSQV6gQ==}
     engines: {node: '>= 10.0.0'}
+    deprecated: The AWS SDK for JavaScript (v2) has reached end-of-support, and no longer receives updates. Please migrate your code to use AWS SDK for JavaScript (v3). More info https://a.co/cUPnyil
 
   axios-retry@3.9.1:
     resolution: {integrity: sha512-8PJDLJv7qTTMMwdnbMvrLYuvB47M81wRtxQmEdV5w4rgbTXTt+vtPkXwajOfOdSyv/wZICJOC+/UhXH4aQ/R+w==}
@@ -4054,6 +4070,7 @@ packages:
   basic-ftp@5.1.0:
     resolution: {integrity: sha512-RkaJzeJKDbaDWTIPiJwubyljaEPwpVWkm9Rt5h9Nd6h7tEXTJ3VB4qxdZBioV7JO5yLUaOKwz7vDOzlncUsegw==}
     engines: {node: '>=10.0.0'}
+    deprecated: Security vulnerability fixed in 5.2.0, please upgrade
 
   bcryptjs@3.0.3:
     resolution: {integrity: sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==}
@@ -5225,15 +5242,6 @@ packages:
 
   follow-redirects@1.15.11:
     resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-
-  follow-redirects@1.15.9:
-    resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -10359,7 +10367,7 @@ snapshots:
       '@types/node': 24.10.9
       '@types/node-fetch': 2.6.13
       '@types/stream-buffers': 3.0.8
-      form-data: 4.0.4
+      form-data: 4.0.5
       hpagent: 1.2.0
       isomorphic-ws: 5.0.0(ws@8.19.0)
       js-yaml: 4.1.1
@@ -11935,7 +11943,7 @@ snapshots:
     dependencies:
       '@types/http-cache-semantics': 4.2.0
       '@types/keyv': 3.1.4
-      '@types/node': 22.14.0
+      '@types/node': 25.3.0
       '@types/responselike': 1.0.3
 
   '@types/caseless@0.12.5': {}
@@ -12020,7 +12028,7 @@ snapshots:
 
   '@types/keyv@3.1.4':
     dependencies:
-      '@types/node': 22.14.0
+      '@types/node': 25.3.0
 
   '@types/long@4.0.2': {}
 
@@ -12044,8 +12052,8 @@ snapshots:
 
   '@types/node-fetch@2.6.13':
     dependencies:
-      '@types/node': 22.14.0
-      form-data: 4.0.4
+      '@types/node': 25.3.0
+      form-data: 4.0.5
 
   '@types/node@20.17.50':
     dependencies:
@@ -12102,13 +12110,13 @@ snapshots:
   '@types/request@2.48.13':
     dependencies:
       '@types/caseless': 0.12.5
-      '@types/node': 22.14.0
+      '@types/node': 25.3.0
       '@types/tough-cookie': 4.0.5
       form-data: 2.5.5
 
   '@types/responselike@1.0.3':
     dependencies:
-      '@types/node': 22.14.0
+      '@types/node': 25.3.0
 
   '@types/send@0.17.4':
     dependencies:
@@ -12132,7 +12140,7 @@ snapshots:
 
   '@types/stream-buffers@3.0.8':
     dependencies:
-      '@types/node': 22.14.0
+      '@types/node': 25.3.0
 
   '@types/superagent@8.1.9':
     dependencies:
@@ -13266,10 +13274,10 @@ snapshots:
       browserstack-local: 1.5.8
       chalk: 4.1.2
       cheerio: 1.0.0-rc.11
-      dotenv: 16.4.7
+      dotenv: 16.6.1
       emittery: 0.11.0
-      follow-redirects: 1.15.9
-      form-data: 4.0.4
+      follow-redirects: 1.15.11
+      form-data: 4.0.5
       getos: 3.2.1
       git-last-commit: 1.0.1
       git-repo-info: 2.1.1
@@ -14520,8 +14528,6 @@ snapshots:
 
   follow-redirects@1.15.11: {}
 
-  follow-redirects@1.15.9: {}
-
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
@@ -15309,7 +15315,7 @@ snapshots:
 
   jest-worker@28.1.3:
     dependencies:
-      '@types/node': 22.14.0
+      '@types/node': 25.3.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -16903,7 +16909,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 22.14.0
+      '@types/node': 25.3.0
       long: 5.3.2
 
   protoc-gen-ts@0.8.7: {}


### PR DESCRIPTION
Fix the nightly sign-in E2E test failure by updating it according to the latest UI changes (logout button on dashboard was removed). FIxes #605.

Ran the nightly test jobs against this branch, all tests pass now, BrowserStack links:

- MacOS [Firefox](https://automate.browserstack.com/dashboard/v2/builds/5b57374915164a2768c923f1f6c63265a2239d36)
- MacOS [Safari](https://automate.browserstack.com/dashboard/v2/builds/71b2b9c78ef3dee83a489f122b6d914a0ab4c038)
- Win11 [Chrome](https://automate.browserstack.com/dashboard/v2/builds/80e204737a1e60be4049068905841ac556def50f)
- iOS [Safari](https://automate.browserstack.com/dashboard/v2/builds/bbdf6497cdf268479b56da295b979fe8693727e3)
- Android [Chrome](https://automate.browserstack.com/dashboard/v2/builds/d4c5fad47863a4e1dddd1f8b7d77563e6365c089)