### PR TITLE
[CI]: Make deployments of frontend and backend more simultaneous (stage)

### DIFF
--- a/packages/send/pulumi/requirements.txt
+++ b/packages/send/pulumi/requirements.txt
@@ -1,2 +1,2 @@
-tb_pulumi @ git+https://github.com/thunderbird/pulumi.git@allow-awsautomationuser-ecs-describeservices 
+tb_pulumi @ git+https://github.com/thunderbird/pulumi.git@v0.0.16
 pulumi_cloudflare==5.48.0


### PR DESCRIPTION
Addresses  #612 for Stage environment only
- Breaks frontend-merge and backend-merge into *-build and *-deploy-stage jobs for each (prod is deployed by the release workflow)
- Adds a matrix strategy for frontend-build, one job for stage and prod with var and secret substitution
- Add dependent job for invalidating the cache last, depend on both backend and frontend pipelines
- Only invalidate frontend cache if deployed to s3
- All jobs will now fun regardless if changes are detected or not, but individual steps will test for changes instead. This is to preserve job hierarchy and dependency graph.
frontend, backend, or both sources may change but the invalidation should always occur at the end and only if frontend was deployed.
- aws ecs wait services-stable was used to wait for ecs deployments to succeed before moving to the invalidation stage
Modify merge.yml workflow to synchronize availability of the send frontend and backend during deployment.
<img width="1470" height="528" alt="Screenshot From 2026-03-09 17-58-25" src="https://github.com/user-attachments/assets/d3967350-e0a9-4f95-832b-036009332e3a" />

