### PR TITLE
[CI]:Refine production release deployment workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,13 +15,15 @@ permissions:
   contents: read
 
 jobs:
-  deploy-backend:
+  backend-deploy-prod-aws:
     environment: send-prod
     runs-on: ubuntu-latest
     container:
         image: ghcr.io/${{ github.repository }}/cached-devcontainer:latest
     env:
       IS_CI_AUTOMATION: "yes"
+    outputs:
+      ecs_deployed: ${{ steps.wait-deployment.outputs.ecs_deployed }}
     steps:
       - name: Check out the code
         if: contains(github.event.release.assets.*.name, 'ecr_tag.zip')
@@ -112,13 +114,22 @@ jobs:
             'urn:pulumi:prod::send-suite::tb:fargate:FargateClusterWithLogging$aws:ecs/taskDefinition:TaskDefinition::send-suite-prod-fargate-taskdef' \
             --target-dependents
 
-  deploy-frontend:
+      - name: Wait for ECS to update the service
+        id: wait-deployment
+        if: contains(github.event.release.assets.*.name, 'ecr_tag.zip')
+        run: |
+          aws ecs wait services-stable --region eu-central-1 --cluster send-suite-prod-fargate --services send-suite-prod-fargate
+          echo "ecs_deployed=true" >> $GITHUB_OUTPUT
+          
+  frontend-deploy-prod-aws:
     environment: send-prod
     runs-on: ubuntu-latest
     container:
         image: ghcr.io/${{ github.repository }}/cached-devcontainer:latest
     env:
       IS_CI_AUTOMATION: "yes"
+    outputs:
+      s3_deployed: ${{ steps.frontend-deploy.outputs.s3_deployed }}
     steps:
       - name: Download frontend source
         if: contains(github.event.release.assets.*.name, 'dist-web-prod.zip')
@@ -142,27 +153,29 @@ jobs:
           unzip -d frontend-source dist-web-prod.zip
           cd frontend-source
           aws s3 cp . s3://tb-send-suite-prod-frontend/ --recursive
+          echo "s3_deployed=true" >> $GITHUB_OUTPUT
 
+  frontend-invalidate-prod-cdn:
+    needs: ["frontend-deploy-prod-aws", "backend-deploy-prod-aws"]
+    if: ${{ needs.frontend-deploy-prod-aws.outputs.s3_deployed == 'true' && needs.backend-deploy-prod-aws.outputs.ecs_deployed == 'true' }}
+    runs-on: ubuntu-latest
+    environment: send-prod
+    steps:
+      - name: Test echo
+        run: |
+          echo "Invalidating CDN for prod environment"
+          echo $(date)
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: eu-central-1 
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: Invalidate CDN, prod only
+        run: |
           # Invalidate the CDN
           aws cloudfront create-invalidation --distribution-id ${{ vars.PROD_CF_DISTRO_ID }} --paths "/*"
-
-  deploy-xpi-prod:
-    runs-on: ubuntu-latest
-    container:
-        image: ghcr.io/${{ github.repository }}/cached-devcontainer:latest
-    env:
-      IS_CI_AUTOMATION: "yes"
-    steps:
-      - name: Check out the code
-        if: contains(github.event.release.assets.*.name, 'xpi-prod.zip')
-        uses: actions/checkout@v4
-
-      - name: Download XPI artifact
-        id: xpi-download
-        if: contains(github.event.release.assets.*.name, 'xpi-prod.zip')
-        uses: dsaltares/fetch-gh-release-asset@master
-        with:
-          version: ${{ github.event.release.id }}
-          file: xpi-prod.zip
 
 


### PR DESCRIPTION
Resolves: #640 
## Summary
- remove the legacy ATN/XPI deployment path from the production release workflow
- split production frontend and backend deployment results into explicit job outputs
- wait for ECS to report the backend service as stable before invalidating the production CDN

## Testing
- not run (GitHub Actions workflow change only)
