### PR TITLE
[CI][Addon] Fix atn upload archive steps

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -388,7 +388,7 @@ jobs:
       - name: (Addon) Create .env file from secrets
         env:
           SENTRY_AUTH_TOKEN: ${{ matrix.env == 'stage' && secrets.VITE_SENTRY_AUTH_TOKEN_STAGE || secrets.VITE_SENTRY_AUTH_TOKEN_PROD }}
-          SENTRY_DSN:  $$ {{ matrix.env == 'stage' && vars.VITE_SENTRY_DSN_STAGE || vars.VITE_SENTRY_DSN_PROD}}
+          SENTRY_DSN:  ${{ matrix.env == 'stage' && vars.VITE_SENTRY_DSN_STAGE || vars.VITE_SENTRY_DSN_PROD}}
           POSTHOG_KEY: ${{ matrix.env == 'stage' && secrets.VITE_POSTHOG_PROJECT_KEY_STAGE || secrets.VITE_POSTHOG_PROJECT_KEY_PROD }}
           POSTHOG_HOST: ${{ matrix.env == 'stage' && vars.VITE_POSTHOG_HOST_STAGE ||  vars.VITE_POSTHOG_HOST_PROD}} 
           OIDC_CLIENT_ID: ${{ matrix.env == 'stage' && secrets.VITE_OIDC_CLIENT_ID_STAGE || secrets.VITE_OIDC_CLIENT_ID_PROD }}
@@ -413,6 +413,16 @@ jobs:
           EOF
 
       - name: (Addon) Create .env file from secrets
+        env:
+          SENTRY_AUTH_TOKEN: ${{ matrix.env == 'stage' && secrets.VITE_SENTRY_AUTH_TOKEN_STAGE || secrets.VITE_SENTRY_AUTH_TOKEN_PROD }}
+          SENTRY_DSN:  ${{ matrix.env == 'stage' && vars.VITE_SENTRY_DSN_STAGE || vars.VITE_SENTRY_DSN_PROD}}
+          POSTHOG_KEY: ${{ matrix.env == 'stage' && secrets.VITE_POSTHOG_PROJECT_KEY_STAGE || secrets.VITE_POSTHOG_PROJECT_KEY_PROD }}
+          POSTHOG_HOST: ${{ matrix.env == 'stage' && vars.VITE_POSTHOG_HOST_STAGE ||  vars.VITE_POSTHOG_HOST_PROD}}
+          OIDC_CLIENT_ID: ${{ matrix.env == 'stage' && secrets.VITE_OIDC_CLIENT_ID_STAGE || secrets.VITE_OIDC_CLIENT_ID_PROD }}
+          OIDC_ROOT_URL: ${{ matrix.env == 'stage' && secrets.VITE_OIDC_ROOT_URL_STAGE || secrets.VITE_OIDC_ROOT_URL_PROD}}
+          BASE_URL: ${{ matrix.base_url }}
+          SEND_SERVER_URL: ${{ matrix.send_server_url }}
+          SEND_CLIENT_URL: ${{ matrix.send_client_url }}
         run: |
           echo "Environment: ${{ matrix.env }}"
           cd packages/addon


### PR DESCRIPTION
## Summary

Fixes several bugs in the `addon-changes` CI job that were preventing the addon XPI from being built, archived, and uploaded to ATN correctly.

## Changes

### `merge.yml`

- **Added `force_addon` workflow dispatch input** — allows manually triggering a full addon build/deploy without requiring file changes.
- **Updated `addon-changes` job condition** to honour the new `force_addon` input.
- **Fixed `$$` typo in `SENTRY_DSN`** — the double-dollar sign caused the expression to be treated as a literal string instead of being evaluated, resulting in an empty/broken DSN in the built XPI.
- **Added missing `env:` block to the second `(Addon) Create .env file from secrets` step** — without it, all secret/var references resolved to empty strings, producing a misconfigured `packages/addon/.env`.
- **Fixed XPI rename logic** — replaced the ambiguous `${ENV}_XPI` variable (which bash expands as an empty variable) with `RENAMED_XPI`, so the file is correctly renamed and both `xpi_filename` and `xpi_file_path` outputs are set.
- **Fixed archive step** — updated `name` and `path` to use the step outputs instead of a glob pattern, and set `compression-level: 0` so the XPI is not double-zipped.
- **Fixed ATN sign step** — updated `source` to reference the correct `xpi_file_path` output instead of the old `stage_xpi_file` output that no longer existed.