### PR TITLE
Addon build: enable minify bundle and also set sourcemap to true

### DIFF
--- a/packages/addon/vite.config.management.js
+++ b/packages/addon/vite.config.management.js
@@ -38,8 +38,8 @@ export default defineConfig(({ mode }) => {
     },
     build: {
       outDir: 'dist/pages',
-      sourcemap: 'inline',
-      minify: false,
+      sourcemap: true,
+      minify: true,
       rollupOptions: {
         input: {
           management: path.resolve(__dirname, 'index.management.html'),


### PR DESCRIPTION
Resolves: #648 

**Problem**
The Mozilla add-on verification (AMO/ATN) was rejecting the addon XPI because management.js exceeded the 4MB file size limit (was 5.7MB):

> File is too large to parse.
> This file is not binary and is too large to parse. Files larger than 4MB will not be parsed.

**Root Cause**
The Vite build configuration for the management page had:

- sourcemap: 'inline' — base64-encoded the entire sourcemap directly into management.js, adding 4.32MB to the file
- minify: false — shipped unminified code (1.30MB of JS)
- Together these produced a 5.62MB single file.

**Changes**
In vite.config.management.js:

- sourcemap: true — generates an external .map file instead of inlining. The sourcemap is still produced for Sentry error tracking but no longer bloats the JS bundle shipped in the XPI.
- minify: true — enables production minification, further reducing the JS code size.
- Result
- The management.js shipped in the XPI is now well under the 4MB AMO limit.

**Result**

```
ls -alh ./packages/addon/tbpro-addon-1-6-0.xpi
-rw-r--r-- 1 vscode vscode 3.7M Mar 23 17:38 ./packages/addon/tbpro-addon-1-6-0.xpi
```

**Validation passes:**

<img width="1336" height="662" alt="Screenshot From 2026-03-23 10-36-12" src="https://github.com/user-attachments/assets/54570f6c-4f6e-46fc-ba63-495d4c3df1bf" />
