### PR TITLE
[CI]:Explicitly set Github deployments false for non deployment jobs (aka testing)

### DIFF
--- a/.github/workflows/audit-fix.yml
+++ b/.github/workflows/audit-fix.yml
@@ -25,9 +25,6 @@ jobs:
       IS_CI_AUTOMATION: "yes"
     outputs:
       has-changes: ${{ steps.check-changes.outputs.has-changes }}
-    environment:
-      name: default
-      deployment: false
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-and-push-devcontainer.yml
+++ b/.github/workflows/build-and-push-devcontainer.yml
@@ -21,9 +21,6 @@ jobs:
   # Build and cache devcontainer for faster CI stages
   devcontainer-build:
     runs-on: ubuntu-latest
-    environment:
-      name: default
-      deployment: false
     steps:
       - name: Checkout (GitHub)
         uses: actions/checkout@v4

--- a/.github/workflows/e2e-bucket-test.yml
+++ b/.github/workflows/e2e-bucket-test.yml
@@ -28,9 +28,6 @@ jobs:
       iac-changed: ${{ steps.check.outputs.iac-changed }}
       frontend-changed: ${{ steps.check.outputs.frontend-changed }}
       shared-changed: ${{ steps.check.outputs.shared-changed }}
-    environment:
-      name: default
-      deployment: false
     steps:
       - uses: actions/checkout@v4
 
@@ -57,9 +54,6 @@ jobs:
       options: --shm-size=2gb --security-opt seccomp=unconfined
     env:
       IS_CI_AUTOMATION: "yes"
-    environment:
-      name: send-prod
-      deployment: false
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -28,9 +28,6 @@ jobs:
       iac-changed: ${{ steps.check.outputs.iac-changed }}
       frontend-changed: ${{ steps.check.outputs.frontend-changed }}
       shared-changed: ${{ steps.check.outputs.shared-changed }}
-    environment:
-      name: default
-      deployment: false
     steps:
       - uses: actions/checkout@v4
 
@@ -55,9 +52,6 @@ jobs:
       image: ghcr.io/${{ github.repository }}/cached-devcontainer:latest
     env:
       IS_CI_AUTOMATION: "yes"
-    environment:
-      name: send-stage
-      deployment: false
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -25,9 +25,6 @@ jobs:
       iac-changed: ${{ steps.check.outputs.iac-changed }}
       frontend-changed: ${{ steps.check.outputs.frontend-changed }}
       shared-changed: ${{ steps.check.outputs.shared-changed }}
-    environment:
-      name: detect-changes
-      deployment: false
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -51,9 +48,6 @@ jobs:
         image: ghcr.io/${{ github.repository }}/cached-devcontainer:latest
     env:
       IS_CI_AUTOMATION: "yes"
-    environment:
-      name: send-stage
-      deployment: false
     steps:
       - uses: actions/checkout@v4
       - name: Set up environments and install dependencies

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -41,9 +41,6 @@ jobs:
       iac-changed: ${{ steps.check.outputs.iac-changed }}
       frontend-changed: ${{ steps.check.outputs.frontend-changed == 'true' || github.event.inputs.force_frontend == 'true' }}
       addon-changed: ${{ steps.check.outputs.addon-changed }}
-    environment:
-      name: default
-      deployment: false
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3

--- a/.github/workflows/nightly-e2e-tests-desktop.yml
+++ b/.github/workflows/nightly-e2e-tests-desktop.yml
@@ -23,7 +23,7 @@ jobs:
     container:
       image: ghcr.io/${{ github.repository }}/cached-devcontainer:latest
     environment:
-      name: send-prod
+      name: production
       deployment: false
     env:
       TBPRO_USERNAME: ${{ secrets.E2E_NIGHTLY_PROD_TBPRO_USERNAME }}

--- a/.github/workflows/nightly-e2e-tests-mobile.yml
+++ b/.github/workflows/nightly-e2e-tests-mobile.yml
@@ -23,7 +23,7 @@ jobs:
     container:
       image: ghcr.io/${{ github.repository }}/cached-devcontainer:latest
     environment:
-      name: send-prod
+      name: production
       deployment: false
     env:
       TBPRO_USERNAME: ${{ secrets.E2E_NIGHTLY_PROD_TBPRO_USERNAME }}

--- a/.github/workflows/validate-devcontainer.yml
+++ b/.github/workflows/validate-devcontainer.yml
@@ -26,9 +26,6 @@ jobs:
       IS_CI_AUTOMATION: "yes"
     outputs:
       devcontainer-changed: ${{ steps.check.outputs.devcontainer-changed }}
-    environment:
-      name: default
-      deployment: false
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -43,9 +40,6 @@ jobs:
     needs: detect-changes
     runs-on: ubuntu-latest
     if: needs.detect-changes.outputs.devcontainer-changed == 'true'
-    environment:
-      name: default
-      deployment: false
     steps:
       - name: Checkout (GitHub)
         uses: actions/checkout@v4
@@ -70,9 +64,6 @@ jobs:
     needs: devcontainer-test-build
     container:
       image: ghcr.io/${{ github.repository }}/cached-devcontainer-test:latest
-    environment:
-      name: default
-      deployment: false
     steps:
       - name: Checkout (GitHub)
         uses: actions/checkout@v4

--- a/.github/workflows/validate-workflows.yml
+++ b/.github/workflows/validate-workflows.yml
@@ -19,9 +19,6 @@ permissions:
 jobs:
   actionlint:
     runs-on: ubuntu-latest
-    environment:
-      name: default
-      deployment: false
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -27,9 +27,6 @@ jobs:
       frontend-changed: ${{ steps.check.outputs.frontend-changed }}
       shared-changed: ${{ steps.check.outputs.shared-changed }}
       addon-changed: ${{ steps.check.outputs.addon-changed }}
-    environment:
-      name: default
-      deployment: false
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -57,9 +54,6 @@ jobs:
     env:
       IS_CI_AUTOMATION: "yes"
     if: needs.detect-changes.outputs.backend-changed == 'true'
-    environment:
-      name: default
-      deployment: false
     steps:
       - uses: actions/checkout@v4
 
@@ -104,9 +98,6 @@ jobs:
     env:
       IS_CI_AUTOMATION: "yes"
     if: needs.detect-changes.outputs.iac-changed == 'true'
-    environment:
-      name: send-stage
-      deployment: false
     steps:
       - uses: actions/checkout@v4
       - name: Ruff checks for Send Pulumi code
@@ -161,9 +152,6 @@ jobs:
     env:
       IS_CI_AUTOMATION: "yes"
     if: needs.detect-changes.outputs.shared-changed == 'true'
-    environment:
-      name: send-stage
-      deployment: false
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
@@ -187,9 +175,6 @@ jobs:
     env:
       IS_CI_AUTOMATION: "yes"
     if: needs.detect-changes.outputs.addon-changed == 'true'
-    environment:
-      name: send-stage
-      deployment: false
     steps:
       - uses: actions/checkout@v4
       - name: Create .env file so tests will work


### PR DESCRIPTION
Resolves: #651

## Summary

GitHub recently added support for disabling deployments on a per-job basis via the `deployment: false` flag under `environment`. This PR uses that feature to stop non-deployment jobs (tests, linting, etc.) from polluting the deployments page.

## Changes

**Jobs with `deployment: false` added** (previously had `environment: xxx`, but aren't actual deployments):
- `nightly-e2e-tests-desktop.yml` — `environment: production` expanded to `name: production` + `deployment: false`
- `nightly-e2e-tests-mobile.yml` — same

**Jobs left unchanged** (actual deployments in `merge.yml` and `release.yml`):
- All `send-stage` and `send-prod` jobs — expanded from single-line to multi-line `name: xxx` syntax, `deployment: true` is the default so no explicit flag needed

**Jobs where environment was removed entirely** (never had one before, don't need one):
- `audit-fix.yml`, `build-and-push-devcontainer.yml`, `validate.yml`, `validate-workflows.yml`, `validate-devcontainer.yml`, `e2e-test.yml`, `e2e-bucket-test.yml`, `integration-test.yml`, `merge.yml` (detect-changes job)

## References
- https://github.blog/changelog/2026-03-19-github-actions-late-march-2026-updates/
- https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/control-deployments#using-environments-without-deployments