### PR TITLE
Fix upload reliability: XHR timeout, HTTP retry, S3Client config

### DIFF
--- a/packages/send/backend/src/storage/s3b2.ts
+++ b/packages/send/backend/src/storage/s3b2.ts
@@ -16,6 +16,8 @@ export async function getClientFromAWSSDK() {
       accessKeyId: process.env.B2_APPLICATION_KEY_ID,
       secretAccessKey: process.env.B2_APPLICATION_KEY,
     },
+    requestHandler: { requestTimeout: 30000 },
+    maxAttempts: 3,
   });
 
   return s3Client;

--- a/packages/send/frontend/src/lib/helpers.ts
+++ b/packages/send/frontend/src/lib/helpers.ts
@@ -272,6 +272,12 @@ export const uploadWithTracker = ({
     blob: Blob,
     attempt: number
   ): Promise<string> => {
+    // Reset progress on retry so the UI gets a clean signal
+    // rather than silently jumping backwards
+    if (attempt > 0) {
+      setProgress(0);
+    }
+
     return new Promise<string>((resolve, reject) => {
       const xhr = new XMLHttpRequest();
       xhr.open('PUT', url, true);

--- a/packages/send/frontend/src/lib/helpers.ts
+++ b/packages/send/frontend/src/lib/helpers.ts
@@ -264,36 +264,59 @@ export const uploadWithTracker = ({
   progressTracker,
 }: UploadOptions) => {
   const { setProgress } = progressTracker;
+  const HTTP_RETRY_LIMIT = 2;
+  const HTTP_RETRY_DELAY_MS = 1000;
+  const XHR_TIMEOUT_MS = 30000;
 
-  // Track upload progress using XMLHttpRequest
-  return new Promise<string>((resolve, reject) => {
-    const xhr = new XMLHttpRequest();
-    xhr.open('PUT', url, true);
-    xhr.setRequestHeader('Content-Type', 'application/octet-stream');
+  const attemptPut = (
+    blob: Blob,
+    attempt: number
+  ): Promise<string> => {
+    return new Promise<string>((resolve, reject) => {
+      const xhr = new XMLHttpRequest();
+      xhr.open('PUT', url, true);
+      xhr.setRequestHeader('Content-Type', 'application/octet-stream');
+      xhr.timeout = XHR_TIMEOUT_MS;
 
-    xhr.upload.onprogress = (event) => {
-      if (event.lengthComputable) {
-        // For multipart uploads, the progress tracker will handle the proper calculation
-        const uploadProgress = event.loaded;
-        setProgress(uploadProgress);
+      xhr.upload.onprogress = (event) => {
+        if (event.lengthComputable) {
+          // For multipart uploads, the progress tracker will handle the proper calculation
+          const uploadProgress = event.loaded;
+          setProgress(uploadProgress);
+        }
+      };
+
+      xhr.onload = () => {
+        if (xhr.status >= 200 && xhr.status < 300) {
+          resolve(xhr.response);
+        } else {
+          console.error('Upload failed:');
+          reject(new Error('UPLOAD_FAILED'));
+        }
+      };
+
+      xhr.onerror = () => reject(new Error('XHR: UPLOAD_FAILED'));
+      xhr.ontimeout = () =>
+        reject(new Error('Upload timed out after 30s'));
+
+      xhr.send(blob);
+    }).catch((error) => {
+      if (attempt < HTTP_RETRY_LIMIT) {
+        console.warn(
+          `HTTP PUT attempt ${attempt + 1} failed, retrying...`,
+          error.message
+        );
+        return new Promise<string>((resolve) =>
+          setTimeout(resolve, HTTP_RETRY_DELAY_MS)
+        ).then(() => attemptPut(blob, attempt + 1));
       }
-    };
-
-    xhr.onload = () => {
-      if (xhr.status >= 200 && xhr.status < 300) {
-        resolve(xhr.response);
-      } else {
-        console.error('Upload failed:');
-        reject(new Error('UPLOAD_FAILED'));
-      }
-    };
-
-    xhr.onerror = () => reject(new Error('XHR: UPLOAD_FAILED'));
-
-    // Convert ReadableStream to Blob and send
-    new Response(readableStream).blob().then((uploadBlob) => {
-      xhr.send(uploadBlob);
+      throw error;
     });
+  };
+
+  // Convert ReadableStream to Blob and send with HTTP-level retries
+  return new Response(readableStream).blob().then((uploadBlob) => {
+    return attemptPut(uploadBlob, 0);
   });
 };
 


### PR DESCRIPTION
## Summary
- Add 30s timeout (`xhr.timeout`) to the XHR PUT in `uploadWithTracker()` so stalled uploads reject instead of hanging indefinitely
- Add HTTP-level retry (up to 2 retries with 1s delay) on the raw PUT request, separate from and in addition to the existing application-level retry in `upload.ts`
- Add `requestTimeout: 30000` and `maxAttempts: 3` to the `S3Client` constructor in `s3b2.ts` for presigned URL generation reliability

No changes to business logic, retry counts, or backoff values in `upload.ts`. The existing application-level retry loop (3 attempts, exponential backoff wrapping sendBlob + metadata + item creation) is preserved as-is.

## Files changed
- `packages/send/frontend/src/lib/helpers.ts` — XHR timeout + HTTP-level retry
- `packages/send/backend/src/storage/s3b2.ts` — S3Client timeout + retry config

Could improve #666

## Root cause hypothesis: no XHR timeout + no HTTP-level retry = silent stalls

The 7%+ failure rate on tiny files (~5KB) is the key signal. Large files failing intermittently would point to network/timeout issues. But 5KB files failing 7% of the time means the upload is completing near-instantly from a data transfer perspective.

The most likely culprit is B2 returning a non-2xx response (or no response) that the XHR treats as a failure, but the retry loop wraps the entire sequence including metadata creation, so a transient B2 hiccup causes the metadata record to be created in a conflicted state, resulting in an empty upload on retrieval — which is exactly what's showing up as `UPLOAD_SIZE_ERROR`.

The three specific gaps that interact badly:
1. **No HTTP-level retry on the XHR PUT** - a single 5xx or connection reset from B2 fails the whole part immediately
1. **Retry wraps the entire sequence** - retrying `sendBlob` + `POST /uploads` + `POST /containers/{id}/item` means the metadata endpoints get called again on retry, potentially creating duplicate or inconsistent records
1. **No XHR timeout** - if B2 accepts the connection but doesn't respond (stalled), the XHR hangs until the browser kills it, which isn't logged anywhere useful



## Test plan
- [ ] Upload a file under 100 MB and verify it completes successfully
- [ ] Upload a file over 100 MB to exercise multipart path
- [ ] Simulate network interruption mid-upload and verify HTTP-level retry fires before application-level retry
- [ ] Verify progress tracking still works correctly on retried uploads
- [ ] Confirm presigned URL generation still works with new S3Client config