### PR TITLE
[SEND] Update nightly sign-in E2E test for latest sign-in changes

### DIFF
--- a/packages/send/e2e/utils/utils.ts
+++ b/packages/send/e2e/utils/utils.ts
@@ -1,6 +1,5 @@
 import { expect, type Page } from '@playwright/test';
 import { TBAcctsPage } from "../pages/tb-accts-page";
-import { DashboardPage } from '../pages/dashboard-page';
 
 import { 
   TB_SEND_TARGET_ENV,
@@ -20,7 +19,6 @@ import {
 export const navigateToSendAndSignIn = async (page: Page, testProjectName: string = 'desktop') => {
   console.log(`navigating to send ${TB_SEND_TARGET_ENV} (${TB_SEND_BASE_URL})`);
   const tbAcctsSignInPage = new TBAcctsPage(page);
-  const dashboardPage = new DashboardPage(page);
 
   await page.goto(`${TB_SEND_BASE_URL}`);
   await page.waitForTimeout(TIMEOUT_5_SECONDS);
@@ -32,10 +30,7 @@ export const navigateToSendAndSignIn = async (page: Page, testProjectName: strin
       await tbAcctsSignInPage.localSendSignIn();
     }
   } else {
-    // sign-in using tb accts; first we click the 'login with your tb pro account' button
-    await expect(tbAcctsSignInPage.signInUsingTBAcctsBtn).toBeVisible({ timeout: TIMEOUT_60_SECONDS });
-    await tbAcctsSignInPage.signInUsingTBAcctsBtn.click();
-    // then we sign-in to tb accounts itself
+    // when navigate to TB Send it now automatically goes directly to TB Pro sign-in dialog
     await tbAcctsSignInPage.signIn(testProjectName);
   }
 }


### PR DESCRIPTION
Update the nightly sign-in E2E test for the new sign-in flow that landed in #676. Fixes #681.

BrowserStack links running the updated nightly E2E sign-in test on (all tests passed):

- [desktop Firefox](https://automate.browserstack.com/dashboard/v2/builds/7ddf08bc9e164d791158695b999ef841416ac108)
- [desktop Chromium](https://automate.browserstack.com/dashboard/v2/builds/ca2c89d9924c94efebe06bc31d9cd198f63581d2)
- [desktop Safari](https://automate.browserstack.com/dashboard/v2/builds/e8610286e1941ea61a58ea382db456c3281c7b5c)
- [android Chrome](https://automate.browserstack.com/dashboard/v2/builds/2278ada4bc03b41fffa9f1c785bae3f0d17f44a3)
- and [iOS Safari](https://automate.browserstack.com/dashboard/v2/builds/84941ee4b1d2ef25b5b1387800d6ddaad46698f7)