### PR TITLE
[SEND] Migration CI pipeline: drain, Neon snapshot, ECS init container, rollback

### DIFF
--- a/docs/specs/2026-04-14-migration-ci-pipeline.md
+++ b/docs/specs/2026-04-14-migration-ci-pipeline.md
@@ -1,6 +1,6 @@
 # Database Migration CI Pipeline Design
 
-**Date:** 2026-04-14  
+**Date:** 2026-04-14 (revised after 10-agent review)
 **Issue:** thunderbird/tbpro-add-on#273  
 **Assignee:** Arron Atchison
 
@@ -23,14 +23,15 @@ This design adds a safe, observable, rollback-capable migration pipeline to both
 ## Solution Overview
 
 1. **Detect** — `paths-filter` on `prisma/migrations/**` in the `detect-changes` job  
-2. **Drain** — scale ECS service to 0, suspend autoscaler to prevent it fighting us  
-3. **Snapshot** — create a Neon branch from the live database before any DDL runs  
-4. **Migrate** — Pulumi deploys a new task definition that includes a `migrate` init container; ECS starts tasks, init container runs `prisma migrate deploy` and exits, then `backend` starts (enforced via ECS `dependsOn`)  
-5. **Verify** — `aws ecs wait services-stable` confirms healthy tasks  
-6. **Re-enable** — autoscaler re-enabled; service traffic resumes naturally  
-7. **Rollback (on any failure)** — restore Neon branch to snapshot LSN, revert ECS service to previous task definition revision  
+2. **Pre-flight** — check for a stranded service left by a previously-cancelled run  
+3. **Drain** — suspend autoscaler scaling actions (without changing `min_capacity`), scale ECS to 0, wait for ALB deregistration  
+4. **Snapshot** — create a Neon branch from the live database; poll until the branch is materialized  
+5. **Migrate** — Pulumi deploys a new task definition that includes a `migrate` init container (`essential: true`); ECS starts tasks, the init container runs `prisma migrate deploy` and exits, then `backend` starts (enforced via ECS `dependsOn: condition: SUCCESS`)  
+6. **Verify** — early failure detection via task polling + `aws ecs wait services-stable`  
+7. **Re-enable** — dedicated cleanup job restores autoscaler and `desired_count`; fires even on cancellation  
+8. **Rollback (on any failure)** — poll Neon restore to completion, then revert ECS task definition; run `pulumi refresh` to reconcile state  
 
-For **frontend**: CloudFront invalidation already depends on backend deploy success. The `frontend-invalidate-*-cdn` jobs will be updated to also accept the new `backend-migrate-*` job as a valid backend success path.
+For **frontend**: `frontend-invalidate-*-cdn` jobs are updated to accept either the migrate job or the normal deploy job as the valid backend success signal. Stage and prod use different condition patterns because they have different job-graph architectures.
 
 ---
 
@@ -40,151 +41,298 @@ For **frontend**: CloudFront invalidation already depends on backend deploy succ
 
 ```
 detect-changes
-  ├─ backend-build-stage          (if backend-changed)
-  │    ├─ backend-migrate-stage   (if backend-changed && migration-changed) ← NEW
-  │    └─ backend-deploy-stage-aws (if backend-changed && !migration-changed)
-  ├─ frontend-build               (if frontend-changed)
+  ├─ backend-build-stage             (if backend-changed)
+  │    ├─ backend-migrate-stage      (if backend-changed && migration-changed) ← NEW
+  │    └─ backend-deploy-stage-aws   (if backend-changed && !migration-changed)
+  │
+  ├─ autoscaler-cleanup-stage        (needs: backend-migrate-stage, if: always()) ← NEW
+  │
+  ├─ frontend-build                  (if frontend-changed)
   │    └─ frontend-deploy-stage-aws
-  │         └─ frontend-invalidate-stage-cdn (depends on either backend job + frontend)
-  └─ addon-changes                (if addon/frontend-changed)
+  │         └─ frontend-invalidate-stage-cdn
+  │              (needs both backend jobs + frontend; fires if either backend succeeded or backend didn't change)
+  └─ addon-changes                   (if addon/frontend-changed)
 ```
 
-`backend-migrate-stage` and `backend-deploy-stage-aws` are **mutually exclusive** — exactly one runs per push.
+`backend-migrate-stage` and `backend-deploy-stage-aws` are **mutually exclusive** — exactly one runs per push. `autoscaler-cleanup-stage` is a separate job so it fires even when `backend-migrate-stage` is cancelled.
 
 ### Job graph (release.yml, prod)
 
 ```
 [Release published]
-  ├─ backend-migrate-prod         (if ecr_tag.zip asset present) ← replaces backend-deploy-prod-aws
-  ├─ frontend-deploy-prod-aws     (if dist-web-prod.zip asset present)
-  └─ frontend-invalidate-prod-cdn (depends on backend-migrate-prod + frontend-deploy-prod-aws)
+  ├─ backend-migrate-prod            (if ecr_tag.zip asset present) ← replaces backend-deploy-prod-aws
+  ├─ autoscaler-cleanup-prod         (needs: backend-migrate-prod, if: always()) ← NEW
+  ├─ frontend-deploy-prod-aws        (if dist-web-prod.zip asset present)
+  └─ frontend-invalidate-prod-cdn    (see prod-specific condition below)
 ```
 
-For prod, the migration pipeline always runs when a backend is being deployed (safe default — `prisma migrate deploy` is a no-op if no pending migrations, and the snapshot/drain overhead is acceptable for production).
+For prod, the migration pipeline always runs when a backend is being deployed (`prisma migrate deploy` is a no-op if no pending migrations, and the snapshot/drain overhead is acceptable for production).
 
 ---
 
 ## Component Design
 
-### 1. Migration Detection (stage only)
+### 1. Migration Detection (stage)
 
-Add to `detect-changes` job in `merge.yml`:
+**Add filter to `detect-changes` in `merge.yml`:**
 
 ```yaml
+# Under steps.check.with.filters:
 migration-changed:
   - 'packages/send/backend/prisma/migrations/**'
 ```
 
-Output: `needs.detect-changes.outputs.migration-changed`
+**Add to `detect-changes` job `outputs:` block** (this is required — without it, downstream jobs see an empty string):
 
-Stage conditions:
-- `backend-migrate-stage`: `backend-changed == 'true' && migration-changed == 'true'`
-- `backend-deploy-stage-aws`: `backend-changed == 'true' && migration-changed != 'true'`
+```yaml
+outputs:
+  backend-changed: ...   # existing
+  iac-changed: ...       # existing
+  frontend-changed: ...  # existing
+  addon-changed: ...     # existing
+  migration-changed: ${{ steps.check.outputs.migration-changed == 'true' && github.event.inputs.skip_migration != 'true' }}  # NEW
+```
 
-### 2. Traffic Drain
+**Add `skip_migration` workflow dispatch input** (operational escape hatch for force-redeploy without migration):
 
-Before any DDL runs, stop all traffic to the backend:
+```yaml
+on:
+  workflow_dispatch:
+    inputs:
+      skip_migration:
+        description: Force the non-migration deploy path even if migration files changed
+        required: false
+        type: boolean
+        default: false
+      # ... existing inputs ...
+```
+
+**Job conditions (mutually exclusive):**
+- `backend-migrate-stage`: `needs.detect-changes.outputs.backend-changed == 'true' && needs.detect-changes.outputs.migration-changed == 'true'`
+- `backend-deploy-stage-aws`: `needs.detect-changes.outputs.backend-changed == 'true' && needs.detect-changes.outputs.migration-changed != 'true'`
+
+### 2. Pre-flight Check
+
+Run at the start of `backend-migrate-stage` before doing anything else. Detects a service left stranded at `desired_count=0` with the autoscaler suspended by a previously-cancelled run:
 
 ```bash
-# 1. Suspend autoscaler (prevents min_capacity=2 fighting the scale-down)
+CURRENT_DESIRED=$(aws ecs describe-services \
+  --cluster $CLUSTER --services $SERVICE \
+  --query 'services[0].desiredCount' --output text)
+
+if [ "$CURRENT_DESIRED" = "0" ]; then
+  echo "ERROR: Service is already at desired_count=0. A previous migration run may have been cancelled."
+  echo "Manually verify the service state and re-enable autoscaling before retrying."
+  exit 1
+fi
+```
+
+This surfaces the stranded state as a loud failure rather than silently proceeding.
+
+### 3. Traffic Drain
+
+**Critical:** Do NOT pass `--min-capacity 0` to `register-scalable-target`. That would cause Pulumi state drift. Only use the suspend flags.
+
+```bash
+# 1. Suspend autoscaler scaling actions (min_capacity stays at 2 in AWS state, matching Pulumi config)
 aws application-autoscaling register-scalable-target \
   --service-namespace ecs \
   --resource-id "service/${CLUSTER}/${SERVICE}" \
   --scalable-dimension ecs:service:DesiredCount \
-  --min-capacity 0 --max-capacity 4 \
   --suspended-state "DynamicScalingInSuspended=true,DynamicScalingOutSuspended=true,ScheduledScalingSuspended=true"
 
-# 2. Record previous task definition ARN (for rollback)
+# Brief pause to let the suspended state propagate before scaling down
+sleep 5
+
+# 2. Record previous task definition ARN for rollback — must be persisted to GITHUB_OUTPUT
 PREV_TASK_DEF=$(aws ecs describe-services \
   --cluster $CLUSTER --services $SERVICE \
   --query 'services[0].taskDefinition' --output text)
+echo "prev_task_def=${PREV_TASK_DEF}" >> "$GITHUB_OUTPUT"
 
-# 3. Scale to 0 and wait for full drain
+# Fail loudly if we couldn't capture it
+if [ -z "$PREV_TASK_DEF" ] || [ "$PREV_TASK_DEF" = "None" ]; then
+  echo "ERROR: Could not determine current task definition ARN. Aborting."
+  exit 1
+fi
+
+# 3. Scale to 0
 aws ecs update-service --cluster $CLUSTER --service $SERVICE --desired-count 0
-aws ecs wait services-stable --cluster $CLUSTER --services $SERVICE
+
+# 4. Wait for ECS runningCount to reach 0
+aws ecs wait services-stable --region eu-central-1 --cluster $CLUSTER --services $SERVICE
+
+# 5. Additional wait for ALB target deregistration delay (AWS default is 300s;
+#    this should be reduced to 30s in the Pulumi config for both stage and prod).
+#    If deregistration_delay is set to 30s in Pulumi config, a 35s sleep is sufficient here.
+sleep 35
 ```
 
-### 3. Neon Snapshot
+**Required Pulumi config change** — add to both `config.stage.yaml` and `config.prod.yaml` under the service definition:
 
-Two separate Neon projects: one for stage, one for prod.
+```yaml
+services:
+  send-suite:
+    deregistration_delay: 30   # default is 300; reduce so drain completes quickly
+    # ... existing fields ...
+```
 
-**New GitHub secrets/variables (scoped to `send-stage` and `send-prod` environments):**
+**Required IAM change** — the CI user (`AwsAutomationUser`) currently has no `application-autoscaling` permissions. Add to the Pulumi config (the `additional_policies` hook exists and is commented out):
+
+```yaml
+tb:ci:AwsAutomationUser:
+  ci:
+    additional_policies:
+      - arn:aws:iam::768512802988:policy/send-suite-STACK-autoscaling-ci
+```
+
+And define this policy to grant `application-autoscaling:RegisterScalableTarget` and `application-autoscaling:DescribeScalableTargets` scoped to the ECS service resource.
+
+### 4. Neon Snapshot
+
+**Secret/variable scope:** `NEON_API_KEY` must be a **per-environment** secret (not repo-wide) to limit blast radius. Store it in the `send-stage` and `send-prod` GitHub environments with separate Neon API keys scoped to each project.
 
 | Name | Type | Scope | Value |
 |------|------|-------|-------|
-| `NEON_API_KEY` | secret | repo-wide | Neon personal access token |
+| `NEON_API_KEY` | secret | **per-environment** (`send-stage`, `send-prod`) | Project-scoped Neon API key |
 | `NEON_PROJECT_ID` | variable | per-environment | Neon project ID for that env |
 | `NEON_BRANCH_ID` | variable | per-environment | ID of the main database branch |
 
-**Create snapshot:**
+**Create snapshot and poll until materialized:**
 
 ```bash
-SNAPSHOT_RESPONSE=$(curl -sfS -X POST \
+# Create the snapshot branch
+SNAPSHOT_RESPONSE=$(curl --silent --fail-with-body --show-error -X POST \
   "https://console.neon.tech/api/v2/projects/${NEON_PROJECT_ID}/branches" \
   -H "Authorization: Bearer ${NEON_API_KEY}" \
   -H "Content-Type: application/json" \
   -d "{\"branch\": {\"parent_id\": \"${NEON_BRANCH_ID}\", \"name\": \"migration-snapshot-${GITHUB_RUN_ID}\"}}")
-SNAPSHOT_BRANCH_ID=$(echo "$SNAPSHOT_RESPONSE" | jq -r '.branch.id')
-echo "snapshot_branch_id=$SNAPSHOT_BRANCH_ID" >> "$GITHUB_OUTPUT"
+
+# Validate the branch ID before proceeding — abort if Neon didn't return a valid ID
+SNAPSHOT_BRANCH_ID=$(echo "$SNAPSHOT_RESPONSE" | jq -r '.branch.id // empty')
+if [ -z "$SNAPSHOT_BRANCH_ID" ] || ! echo "$SNAPSHOT_BRANCH_ID" | grep -qE '^br-[a-z0-9-]+$'; then
+  echo "ERROR: Failed to create Neon snapshot branch. Response: $SNAPSHOT_RESPONSE"
+  exit 1
+fi
+echo "snapshot_branch_id=${SNAPSHOT_BRANCH_ID}" >> "$GITHUB_OUTPUT"
+
+# Poll the create-branch operation until it reaches 'finished'
+BRANCH_OP_ID=$(echo "$SNAPSHOT_RESPONSE" | jq -r '.operations[0].id // empty')
+for i in $(seq 1 24); do
+  OP_STATUS=$(curl --silent --fail-with-body --show-error \
+    "https://console.neon.tech/api/v2/projects/${NEON_PROJECT_ID}/operations/${BRANCH_OP_ID}" \
+    -H "Authorization: Bearer ${NEON_API_KEY}" | jq -r '.operation.status')
+  echo "Neon branch creation status: $OP_STATUS (attempt $i/24)"
+  case "$OP_STATUS" in
+    finished) break ;;
+    cancelled|skipped) echo "ERROR: Neon branch creation did not complete: $OP_STATUS"; exit 1 ;;
+    failed)
+      FAIL_COUNT=$((FAIL_COUNT+1))
+      [ $FAIL_COUNT -gt 3 ] && { echo "ERROR: Neon branch creation failed repeatedly"; exit 1; }
+      ;;
+  esac
+  sleep 5
+done
 ```
 
-**Rollback (restore main branch to snapshot state):**
+**Restore main branch to snapshot state (called from rollback):**
 
 ```bash
-RESTORE_RESPONSE=$(curl -sfS -X POST \
+# NOTE: preserve_under_name saves the current (post-migration, broken) state of the main branch
+# before it is overwritten — useful for forensics. The snapshot branch itself is preserved separately.
+RESTORE_RESPONSE=$(curl --silent --fail-with-body --show-error -X POST \
   "https://console.neon.tech/api/v2/projects/${NEON_PROJECT_ID}/branches/${NEON_BRANCH_ID}/restore" \
   -H "Authorization: Bearer ${NEON_API_KEY}" \
   -H "Content-Type: application/json" \
   -d "{\"source_branch_id\": \"${SNAPSHOT_BRANCH_ID}\", \"preserve_under_name\": \"failed-migration-${GITHUB_RUN_ID}\"}")
-# Poll the operation to confirm completion
-OPERATION_ID=$(echo "$RESTORE_RESPONSE" | jq -r '.operations[0].id')
-# poll GET /projects/{id}/operations/{op_id} until status == "finished"
+
+RESTORE_OP_ID=$(echo "$RESTORE_RESPONSE" | jq -r '.operations[0].id // empty')
+if [ -z "$RESTORE_OP_ID" ]; then
+  echo "ERROR: Neon restore did not return an operation ID. Response: $RESTORE_RESPONSE"
+  echo "WARNING: Database may be in a partially-migrated state. Manual intervention required."
+  exit 1
+fi
+
+# Poll until restore completes — ECS must NOT start until this finishes
+FAIL_COUNT=0
+for i in $(seq 1 60); do
+  OP_STATUS=$(curl --silent --fail-with-body --show-error \
+    "https://console.neon.tech/api/v2/projects/${NEON_PROJECT_ID}/operations/${RESTORE_OP_ID}" \
+    -H "Authorization: Bearer ${NEON_API_KEY}" | jq -r '.operation.status')
+  echo "Neon restore status: $OP_STATUS (attempt $i/60)"
+  case "$OP_STATUS" in
+    finished) echo "Neon restore complete."; break ;;
+    cancelled|skipped) echo "ERROR: Neon restore did not complete: $OP_STATUS"; exit 1 ;;
+    failed)
+      FAIL_COUNT=$((FAIL_COUNT+1))
+      [ $FAIL_COUNT -gt 5 ] && { echo "ERROR: Neon restore failed repeatedly"; exit 1; }
+      ;;
+  esac
+  sleep 5
+done
 ```
 
-**Cleanup (success):** Delete snapshot branch via `DELETE /projects/{id}/branches/{snapshot_branch_id}`.
+**Cleanup (success path):** On success, delete the snapshot branch via `DELETE /projects/{id}/branches/{snapshot_branch_id}`. This succeeds on the happy path.
 
-### 4. ECS Init Container (Migration Sidecar)
+**Important:** After a rollback that uses `preserve_under_name`, the snapshot branch may become undeletable (Neon does not allow deleting a branch that was used as a restore source when a backup was preserved). Do not attempt to delete the snapshot branch after a rollback — leave it for forensics. These branches will accumulate in the Neon project and should be periodically cleaned up manually.
 
-The same Docker image runs both the migration and the backend. Add a `migrate` container alongside `backend` in both `config.stage.yaml` and `config.prod.yaml`:
+### 5. ECS Init Container (Migration Sidecar)
+
+The same Docker image runs both migration and the backend. Add a `migrate` container to both `config.stage.yaml` and `config.prod.yaml`:
 
 ```yaml
 container_definitions:
   migrate:
-    image: <ECR_TAG>           # same image as backend
-    essential: false
+    image: <ECR_TAG>           # same image as backend; updated by yq stump on each deploy
+    essential: true            # MUST be true: a migration failure kills the task immediately
+                               # (essential: false would delay failure detection by 210+ seconds)
     command: ["pnpm", "db:update"]
+    linuxParameters:
+      initProcessEnabled: True  # consistent with backend container; ensures clean subprocess reaping
     secrets:
       - name: DATABASE_URL
         valueFrom: <same ARN as backend's DATABASE_URL secret>
+        # The ECS task execution role already has secretsmanager:GetSecretValue for send-suite/STACK/*
+        # No new IAM policy needed for this.
   backend:
     image: <ECR_TAG>
     dependsOn:
       - containerName: migrate
-        condition: SUCCESS      # backend won't start if migration fails
+        condition: SUCCESS      # backend will not start if migration exits non-zero
     portMappings: [...]
+    linuxParameters:
+      initProcessEnabled: True
     secrets: [...]
     environment: [...]
 ```
 
-**Remove** `pnpm db:update` from `packages/send/backend/scripts/entry.sh`.
+**Remove** `pnpm db:update` (line 18) from `packages/send/backend/scripts/entry.sh`. Leave `pnpm db:generate` (line 21) — it regenerates the Prisma client for the backend process on startup and should remain.
 
-The `yq` merge step in both workflows also needs to update the `migrate` container's image in addition to `backend`:
+**Local development impact:** Removing `pnpm db:update` from `entry.sh` means developers running `docker compose up` locally will no longer have migrations applied automatically. Add a `migrate` service to `compose.ci.yml` (and document the same for local dev compose):
 
 ```yaml
-resources:
-  tb:fargate:FargateClusterWithLogging:
-    backend:
-      task_definition:
-        container_definitions:
-          backend:
-            image: "$ECR_TAG"
-          migrate:
-            image: "$ECR_TAG"
+services:
+  migrate:
+    image: send-backend
+    command: ["pnpm", "db:update"]
+    environment:
+      DATABASE_URL: ${DATABASE_URL}
+    depends_on:
+      db:
+        condition: service_healthy
+  backend:
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
 ```
 
-### 5. Pulumi Deploy (inside migration job)
+**Atomicity requirement:** The `config.stage.yaml` / `config.prod.yaml` changes (adding the `migrate` container) and the `yq` stump changes in `merge.yml` / `release.yml` (adding `migrate.image` to the merge) **must land in the same PR**. If the config adds `migrate` before the stump is updated, the migrate container will run the old image while the backend runs new code on every deploy between those two commits.
 
-The migration job calls Pulumi the same way as the existing deploy job — it registers the new task definition (now containing the migrate container) and updates the ECS service, which restores `desired_count` to 2 as declared in the config:
+**Recovery from a dirty `_prisma_migrations` state:** If a migration was partially applied (e.g., an OOM-killed init container left a `failed` row in `_prisma_migrations`), all init containers will refuse to run with Prisma error `P3009`. Recovery requires manual intervention: connect to the database and run `prisma migrate resolve --rolled-back <migration_name>` (or restore from the Neon snapshot). This is documented here so engineers know the recovery path.
+
+### 6. Pulumi Deploy (inside migration job)
+
+Same Pulumi invocation as the existing deploy job. Because `desired_count=0` was set manually in the drain step, Pulumi will restore it to 2 as part of the `--target-dependents` service update:
 
 ```bash
 pulumi up -y --diff --target \
@@ -192,70 +340,193 @@ pulumi up -y --diff --target \
   --target-dependents
 ```
 
-Then wait for stability:
+### 7. Observability: Early Failure Detection
+
+Do not rely solely on `aws ecs wait services-stable` — on migrate failure it hangs silently for up to 10 minutes before timing out. Add an early-detection polling loop immediately after Pulumi deploys:
 
 ```bash
-aws ecs wait services-stable --region eu-central-1 \
-  --cluster send-suite-STACK-fargate --services send-suite-STACK-fargate
+# Poll for stopped tasks (indication of migrate container failure) before running the full waiter
+for i in $(seq 1 20); do
+  STOPPED=$(aws ecs list-tasks \
+    --cluster $CLUSTER --desired-status STOPPED \
+    --family send-suite-STACK-fargate-taskdef \
+    --query 'length(taskArns)' --output text)
+  RUNNING=$(aws ecs list-tasks \
+    --cluster $CLUSTER --desired-status RUNNING \
+    --family send-suite-STACK-fargate-taskdef \
+    --query 'length(taskArns)' --output text)
+  echo "Running: $RUNNING  Stopped: $STOPPED  (poll $i/20)"
+  if [ "$STOPPED" -gt 0 ] && [ "$RUNNING" -eq 0 ]; then
+    echo "ERROR: Tasks are stopping — migrate container likely failed."
+    break
+  fi
+  [ "$RUNNING" -ge 2 ] && echo "Tasks healthy." && break
+  sleep 15
+done
+
+# Full ECS stability waiter (10-minute ceiling; set job timeout-minutes >= 45 to cover this + rollback)
+aws ecs wait services-stable --region eu-central-1 --cluster $CLUSTER --services $SERVICE
 ```
 
-### 6. Rollback (on failure)
-
-Triggered by `if: failure()` step at the end of the migration job:
+**Surface CloudWatch logs on failure** (add as `if: failure()` step):
 
 ```bash
-# a) Restore Neon snapshot (undo DDL)
-# ... curl POST to restore API (see section 3) ...
+# Get the most recently stopped task ARN
+TASK_ARN=$(aws ecs list-tasks \
+  --cluster $CLUSTER --desired-status STOPPED \
+  --family send-suite-STACK-fargate-taskdef \
+  --query 'taskArns[0]' --output text)
 
-# b) Roll back ECS to previous task definition revision
+if [ -n "$TASK_ARN" ] && [ "$TASK_ARN" != "None" ]; then
+  TASK_ID=$(basename $TASK_ARN)
+  LOG_STREAM="ecs/migrate/${TASK_ID}"
+  echo "=== migrate container logs ==="
+  aws logs get-log-events \
+    --region eu-central-1 \
+    --log-group-name "/ecs/send-suite-STACK-fargate" \
+    --log-stream-name "$LOG_STREAM" \
+    --limit 200 \
+    --query 'events[*].message' --output text || echo "(log stream not found)"
+fi
+```
+
+**Set `timeout-minutes` on the migration job.** The job can use up to three sequential `services-stable` waits (drain + forward deploy + rollback) plus Neon polling. Set:
+
+```yaml
+jobs:
+  backend-migrate-stage:
+    timeout-minutes: 45
+```
+
+### 8. Rollback (on failure)
+
+Use `if: failure()` to trigger. Reference `PREV_TASK_DEF` via the step output set in section 3:
+
+```bash
+PREV_TASK_DEF="${{ steps.drain.outputs.prev_task_def }}"
+
+if [ -z "$PREV_TASK_DEF" ]; then
+  echo "ERROR: No previous task definition ARN captured. Cannot roll back ECS."
+  echo "Manual recovery required: restore ECS service and re-enable autoscaling."
+  exit 1
+fi
+
+# a) Restore Neon snapshot (must complete before ECS starts)
+SNAPSHOT_BRANCH_ID="${{ steps.snapshot.outputs.snapshot_branch_id }}"
+if [ -n "$SNAPSHOT_BRANCH_ID" ]; then
+  # ... run restore + polling loop from section 4 ...
+else
+  echo "WARNING: No Neon snapshot branch ID available. Database schema may not be restored."
+fi
+
+# b) Roll back ECS to previous task definition
 aws ecs update-service \
   --cluster $CLUSTER --service $SERVICE \
   --task-definition "$PREV_TASK_DEF" \
   --desired-count 2
 
-aws ecs wait services-stable --cluster $CLUSTER --services $SERVICE
+aws ecs wait services-stable --region eu-central-1 --cluster $CLUSTER --services $SERVICE
 ```
 
-Note: Pulumi state will diverge temporarily after a rollback. The next successful deploy will reconcile it.
+**Pulumi state drift after rollback:** After `aws ecs update-service` reverts to the old task definition, Pulumi's state file still records the new (failed) task definition. The next `pulumi up` will detect this as drift and attempt to revert the ECS service back to the failed image. This is not self-healing.
 
-### 7. Re-enable Autoscaler
-
-Always runs (even on failure, after rollback):
+**Required post-rollback recovery step** (run manually after rollback, before the next deploy):
 
 ```bash
-aws application-autoscaling register-scalable-target \
-  --service-namespace ecs \
-  --resource-id "service/${CLUSTER}/${SERVICE}" \
-  --scalable-dimension ecs:service:DesiredCount \
-  --min-capacity 2 --max-capacity 4 \
-  --suspended-state "DynamicScalingInSuspended=false,DynamicScalingOutSuspended=false,ScheduledScalingSuspended=false"
+cd packages/send/pulumi
+export PULUMI_CONFIG_PASSPHRASE='...'
+pulumi login
+pulumi stack select STACK
+pulumi refresh --yes  # imports current live AWS state into Pulumi's state file
+# Then revert config.STACK.yaml image tags to the previous working version
+# and commit before triggering a new deploy
 ```
 
-### 8. Frontend CDN Invalidation Update
+**GitHub Release re-publish loop (prod only):** After a prod migration failure and rollback, the GitHub Release object remains published. Re-publishing the same release will re-trigger `release.yml` with the same broken image/migration — a loop. After a prod rollback, convert the release to a pre-release via the GitHub API to prevent accidental re-triggering:
 
-`frontend-invalidate-stage-cdn` in `merge.yml` currently has:
+```bash
+gh release edit ${{ github.event.release.tag_name }} --prerelease
+```
+
+Add this as a `if: failure()` step in the prod migration job.
+
+### 9. Autoscaler Cleanup (separate job — handles cancellation)
+
+`if: failure()` steps do not fire when a job is cancelled. Because `concurrency: cancel-in-progress: true` is active in `merge.yml`, a second push can cancel the migration job mid-drain, leaving the service at `desired_count=0` with the autoscaler suspended indefinitely.
+
+The fix is a **separate job** (`autoscaler-cleanup-stage` / `autoscaler-cleanup-prod`) that is always evaluated, even when its dependency is cancelled:
 
 ```yaml
-needs: [detect-changes, frontend-deploy-stage-aws, backend-deploy-stage-aws]
-if: always() && ... && (backend-changed != true || backend-deploy-stage-aws.result == success)
+autoscaler-cleanup-stage:
+  needs: [backend-migrate-stage]
+  if: always()
+  runs-on: ubuntu-latest
+  environment:
+    name: send-stage
+  steps:
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-region: eu-central-1
+        # ...
+
+    - name: Re-enable autoscaler and ensure desired_count >= 2
+      run: |
+        # Re-enable autoscaler suspend flags (min_capacity unchanged — avoids Pulumi drift)
+        aws application-autoscaling register-scalable-target \
+          --service-namespace ecs \
+          --resource-id "service/${CLUSTER}/${SERVICE}" \
+          --scalable-dimension ecs:service:DesiredCount \
+          --suspended-state "DynamicScalingInSuspended=false,DynamicScalingOutSuspended=false,ScheduledScalingSuspended=false"
+
+        # Ensure service is not stranded at 0 (handles cancelled-mid-drain case)
+        CURRENT_DESIRED=$(aws ecs describe-services \
+          --cluster $CLUSTER --services $SERVICE \
+          --query 'services[0].desiredCount' --output text)
+        if [ "$CURRENT_DESIRED" = "0" ]; then
+          echo "Service is at 0 replicas — restoring desired_count to 2"
+          aws ecs update-service --cluster $CLUSTER --service $SERVICE --desired-count 2
+        fi
 ```
 
-Update `needs` to include `backend-migrate-stage` and update the `if` condition to accept either backend job succeeding:
+### 10. Frontend CDN Invalidation
+
+#### Stage (`merge.yml`)
+
+The `if:` condition must be written as a multi-line expression **without** the `${{ }}` wrapper (GitHub Actions supports bare expressions in `if:` fields). The existing line 342 uses `${{ }}` inline — the new multi-line form is equivalent and correct:
 
 ```yaml
-needs: [detect-changes, frontend-deploy-stage-aws, backend-deploy-stage-aws, backend-migrate-stage]
-if: |
-  always()
-  && needs.detect-changes.outputs.frontend-changed == 'true'
-  && needs.frontend-deploy-stage-aws.result == 'success'
-  && (
-    needs.detect-changes.outputs.backend-changed != 'true'
-    || needs.backend-deploy-stage-aws.result == 'success'
-    || needs.backend-migrate-stage.result == 'success'
-  )
+frontend-invalidate-stage-cdn:
+  needs: [detect-changes, frontend-deploy-stage-aws, backend-deploy-stage-aws, backend-migrate-stage]
+  if: >-
+    always()
+    && needs.detect-changes.outputs.frontend-changed == 'true'
+    && needs.frontend-deploy-stage-aws.result == 'success'
+    && (
+      needs.detect-changes.outputs.backend-changed != 'true'
+      || needs.backend-deploy-stage-aws.result == 'success'
+      || needs.backend-migrate-stage.result == 'success'
+    )
 ```
 
-Same pattern for `frontend-invalidate-prod-cdn` in `release.yml` (replace `backend-deploy-prod-aws` dependency with `backend-migrate-prod`).
+**Atomicity requirement:** `backend-migrate-stage` must be defined in the workflow before this `needs` reference is added. Both changes must land in the same PR — adding a `needs` reference to a non-existent job causes the entire workflow to fail to parse.
+
+#### Prod (`release.yml`)
+
+The prod workflow uses step-level conditionals (`contains(github.event.release.assets.*)`) rather than job-level `if` conditions, so `backend-migrate-prod` always exits `success` (same as the current `backend-deploy-prod-aws` behavior). The prod CDN condition does **not** use `always()` — without it, a failing backend job automatically blocks the CDN via GitHub's default cascade behavior:
+
+```yaml
+frontend-invalidate-prod-cdn:
+  needs: ["frontend-deploy-prod-aws", "backend-migrate-prod"]
+  if: >-
+    needs.frontend-deploy-prod-aws.outputs.s3_deployed == 'true'
+    && (
+      needs.backend-migrate-prod.outputs.ecs_deployed == 'true'
+      || needs.backend-migrate-prod.outputs.ecs_deployed == ''
+    )
+```
+
+The second clause (`ecs_deployed == ''`) handles frontend-only releases where no `ecr_tag.zip` was present and the backend step was skipped — the CDN should still fire.
 
 ---
 
@@ -263,32 +534,48 @@ Same pattern for `frontend-invalidate-prod-cdn` in `release.yml` (replace `backe
 
 | File | Change |
 |------|--------|
-| `.github/workflows/merge.yml` | Add `migration-changed` to `detect-changes`; add `backend-migrate-stage` job; update `backend-deploy-stage-aws` condition; update `frontend-invalidate-stage-cdn` needs/condition |
-| `.github/workflows/release.yml` | Replace `backend-deploy-prod-aws` with `backend-migrate-prod` job; update `frontend-invalidate-prod-cdn` |
-| `packages/send/backend/scripts/entry.sh` | Remove `pnpm db:update` (migration moves to init container) |
-| `packages/send/pulumi/config.stage.yaml` | Add `migrate` init container to `container_definitions` |
-| `packages/send/pulumi/config.prod.yaml` | Add `migrate` init container to `container_definitions` |
+| `.github/workflows/merge.yml` | Add `skip_migration` input; add `migration-changed` to both `paths-filter` and `outputs:` block; add `backend-migrate-stage` job; update `backend-deploy-stage-aws` condition; add `autoscaler-cleanup-stage` job; update `frontend-invalidate-stage-cdn` needs/condition |
+| `.github/workflows/release.yml` | Replace `backend-deploy-prod-aws` with `backend-migrate-prod` job; add `autoscaler-cleanup-prod` job; update `frontend-invalidate-prod-cdn` condition (see explicit form above — do not use "same pattern as stage") |
+| `packages/send/backend/scripts/entry.sh` | Remove `pnpm db:update` (line 18); leave `pnpm db:generate` (line 21) |
+| `packages/send/pulumi/config.stage.yaml` | Add `migrate` init container; reduce `deregistration_delay` to 30s; add autoscaling IAM policy |
+| `packages/send/pulumi/config.prod.yaml` | Same as stage |
+| `compose.ci.yml` | Add `migrate` service; add `depends_on: migrate` to `backend` service |
 
 ---
 
 ## New Secrets / Variables Required
 
-To be added in GitHub Settings → Environments (`send-stage`, `send-prod`):
+To be added in GitHub Settings → Environments (`send-stage`, `send-prod`). All Neon credentials are **per-environment** — do not use a repo-wide `NEON_API_KEY`.
 
-| Name | Type | Notes |
-|------|------|-------|
-| `NEON_API_KEY` | secret | Neon personal access token (or project-scoped key) |
-| `NEON_PROJECT_ID` | variable | Different value per environment |
-| `NEON_BRANCH_ID` | variable | ID of the main database branch per environment |
+| Name | Type | Environment | Notes |
+|------|------|-------------|-------|
+| `NEON_API_KEY` | secret | `send-stage` | Project-scoped Neon API key for the stage project only |
+| `NEON_API_KEY` | secret | `send-prod` | Project-scoped Neon API key for the prod project only |
+| `NEON_PROJECT_ID` | variable | `send-stage` | Neon project ID for stage |
+| `NEON_PROJECT_ID` | variable | `send-prod` | Neon project ID for prod |
+| `NEON_BRANCH_ID` | variable | `send-stage` | ID of the main database branch in the stage project |
+| `NEON_BRANCH_ID` | variable | `send-prod` | ID of the main database branch in the prod project |
+
+---
+
+## Required Infrastructure Changes (before first deploy)
+
+1. **CI IAM policy for Application Auto Scaling** — add a new IAM policy granting the CI user `application-autoscaling:RegisterScalableTarget` and `application-autoscaling:DescribeScalableTargets`. Wire it up via the `additional_policies` key in `config.stage.yaml` and `config.prod.yaml`. Without this, the suspend/re-enable steps fail with `AccessDenied`.
+
+2. **ALB deregistration delay** — reduce from the AWS default (300s) to 30s in the Pulumi service config. This makes the drain step's 35s sleep sufficient and prevents unnecessarily long maintenance windows.
+
+3. **ALB health check path** — the current `health_check` block in `config.stage.yaml` / `config.prod.yaml` has no explicit `path`, defaulting to `/`. The backend's actual health endpoint is `/api/health`. Set `path: /api/health` to ensure health checks accurately reflect backend readiness.
 
 ---
 
 ## Verification
 
-1. Push a commit that adds a new migration file to `prisma/migrations/` along with a backend code change
-2. Observe `merge.yml` run: `detect-changes` outputs `migration-changed=true`; `backend-migrate-stage` runs; `backend-deploy-stage-aws` is skipped
-3. In AWS Console, confirm ECS service scaled to 0, then back to 2 with new task definition
-4. In ECS task logs, confirm `migrate` container ran `prisma migrate deploy` successfully before `backend` container started
-5. In Neon console, confirm a `migration-snapshot-{run_id}` branch was created (and deleted on success)
-6. Confirm frontend CDN was invalidated after both backend and frontend deploys succeeded
-7. Force a failure (e.g., break the migration SQL) and confirm: ECS rolls back to previous task def, Neon branch is restored, service recovers
+1. Push a commit that adds a new migration file — confirm `migration-changed=true` in detect-changes; `backend-migrate-stage` runs; `backend-deploy-stage-aws` is skipped
+2. Confirm ECS scales to 0, autoscaler is suspended (check AWS console), then Pulumi restores desired_count to 2
+3. Confirm `migrate` container logs appear in CloudWatch under the task's log stream before `backend` starts
+4. Confirm Neon console shows a `migration-snapshot-{run_id}` branch created and deleted on success
+5. Confirm CDN invalidation fires after both backend and frontend deploys succeed
+6. **Failure test:** Break the migration SQL — confirm CI surfaces CloudWatch logs within ~2 minutes (not 10), Neon branch is restored, ECS reverts to old task definition, `autoscaler-cleanup-stage` re-enables the autoscaler
+7. **Cancellation test:** Trigger a migration run, cancel it mid-drain — confirm `autoscaler-cleanup-stage` fires independently and restores desired_count to 2
+8. **Push a backend-only change (no migration)** — confirm normal `backend-deploy-stage-aws` path runs; no drain; no Neon snapshot
+9. **Frontend-only prod release** — confirm CDN invalidation fires even with no `ecr_tag.zip` asset

--- a/docs/specs/2026-04-14-migration-ci-pipeline.md
+++ b/docs/specs/2026-04-14-migration-ci-pipeline.md
@@ -1,0 +1,294 @@
+# Database Migration CI Pipeline Design
+
+**Date:** 2026-04-14  
+**Issue:** thunderbird/tbpro-add-on#273  
+**Assignee:** Arron Atchison
+
+---
+
+## Context
+
+Prisma migrations are currently applied inside `entry.sh` via `pnpm db:update` (`prisma migrate deploy`) on every container start. In a 2-replica Fargate setup this means:
+
+- Both replicas race to apply the same migration on startup
+- Auto-scaling events re-run migrations unnecessarily
+- There is no drain before schema changes (old code can see a partially-migrated schema)
+- There is no snapshot to roll back to if a migration breaks things
+- There is no CI-level gate to confirm a migration succeeded before enabling traffic
+
+This design adds a safe, observable, rollback-capable migration pipeline to both `merge.yml` (stage) and `release.yml` (prod).
+
+---
+
+## Solution Overview
+
+1. **Detect** — `paths-filter` on `prisma/migrations/**` in the `detect-changes` job  
+2. **Drain** — scale ECS service to 0, suspend autoscaler to prevent it fighting us  
+3. **Snapshot** — create a Neon branch from the live database before any DDL runs  
+4. **Migrate** — Pulumi deploys a new task definition that includes a `migrate` init container; ECS starts tasks, init container runs `prisma migrate deploy` and exits, then `backend` starts (enforced via ECS `dependsOn`)  
+5. **Verify** — `aws ecs wait services-stable` confirms healthy tasks  
+6. **Re-enable** — autoscaler re-enabled; service traffic resumes naturally  
+7. **Rollback (on any failure)** — restore Neon branch to snapshot LSN, revert ECS service to previous task definition revision  
+
+For **frontend**: CloudFront invalidation already depends on backend deploy success. The `frontend-invalidate-*-cdn` jobs will be updated to also accept the new `backend-migrate-*` job as a valid backend success path.
+
+---
+
+## Architecture
+
+### Job graph (merge.yml, stage)
+
+```
+detect-changes
+  ├─ backend-build-stage          (if backend-changed)
+  │    ├─ backend-migrate-stage   (if backend-changed && migration-changed) ← NEW
+  │    └─ backend-deploy-stage-aws (if backend-changed && !migration-changed)
+  ├─ frontend-build               (if frontend-changed)
+  │    └─ frontend-deploy-stage-aws
+  │         └─ frontend-invalidate-stage-cdn (depends on either backend job + frontend)
+  └─ addon-changes                (if addon/frontend-changed)
+```
+
+`backend-migrate-stage` and `backend-deploy-stage-aws` are **mutually exclusive** — exactly one runs per push.
+
+### Job graph (release.yml, prod)
+
+```
+[Release published]
+  ├─ backend-migrate-prod         (if ecr_tag.zip asset present) ← replaces backend-deploy-prod-aws
+  ├─ frontend-deploy-prod-aws     (if dist-web-prod.zip asset present)
+  └─ frontend-invalidate-prod-cdn (depends on backend-migrate-prod + frontend-deploy-prod-aws)
+```
+
+For prod, the migration pipeline always runs when a backend is being deployed (safe default — `prisma migrate deploy` is a no-op if no pending migrations, and the snapshot/drain overhead is acceptable for production).
+
+---
+
+## Component Design
+
+### 1. Migration Detection (stage only)
+
+Add to `detect-changes` job in `merge.yml`:
+
+```yaml
+migration-changed:
+  - 'packages/send/backend/prisma/migrations/**'
+```
+
+Output: `needs.detect-changes.outputs.migration-changed`
+
+Stage conditions:
+- `backend-migrate-stage`: `backend-changed == 'true' && migration-changed == 'true'`
+- `backend-deploy-stage-aws`: `backend-changed == 'true' && migration-changed != 'true'`
+
+### 2. Traffic Drain
+
+Before any DDL runs, stop all traffic to the backend:
+
+```bash
+# 1. Suspend autoscaler (prevents min_capacity=2 fighting the scale-down)
+aws application-autoscaling register-scalable-target \
+  --service-namespace ecs \
+  --resource-id "service/${CLUSTER}/${SERVICE}" \
+  --scalable-dimension ecs:service:DesiredCount \
+  --min-capacity 0 --max-capacity 4 \
+  --suspended-state "DynamicScalingInSuspended=true,DynamicScalingOutSuspended=true,ScheduledScalingSuspended=true"
+
+# 2. Record previous task definition ARN (for rollback)
+PREV_TASK_DEF=$(aws ecs describe-services \
+  --cluster $CLUSTER --services $SERVICE \
+  --query 'services[0].taskDefinition' --output text)
+
+# 3. Scale to 0 and wait for full drain
+aws ecs update-service --cluster $CLUSTER --service $SERVICE --desired-count 0
+aws ecs wait services-stable --cluster $CLUSTER --services $SERVICE
+```
+
+### 3. Neon Snapshot
+
+Two separate Neon projects: one for stage, one for prod.
+
+**New GitHub secrets/variables (scoped to `send-stage` and `send-prod` environments):**
+
+| Name | Type | Scope | Value |
+|------|------|-------|-------|
+| `NEON_API_KEY` | secret | repo-wide | Neon personal access token |
+| `NEON_PROJECT_ID` | variable | per-environment | Neon project ID for that env |
+| `NEON_BRANCH_ID` | variable | per-environment | ID of the main database branch |
+
+**Create snapshot:**
+
+```bash
+SNAPSHOT_RESPONSE=$(curl -sfS -X POST \
+  "https://console.neon.tech/api/v2/projects/${NEON_PROJECT_ID}/branches" \
+  -H "Authorization: Bearer ${NEON_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d "{\"branch\": {\"parent_id\": \"${NEON_BRANCH_ID}\", \"name\": \"migration-snapshot-${GITHUB_RUN_ID}\"}}")
+SNAPSHOT_BRANCH_ID=$(echo "$SNAPSHOT_RESPONSE" | jq -r '.branch.id')
+echo "snapshot_branch_id=$SNAPSHOT_BRANCH_ID" >> "$GITHUB_OUTPUT"
+```
+
+**Rollback (restore main branch to snapshot state):**
+
+```bash
+RESTORE_RESPONSE=$(curl -sfS -X POST \
+  "https://console.neon.tech/api/v2/projects/${NEON_PROJECT_ID}/branches/${NEON_BRANCH_ID}/restore" \
+  -H "Authorization: Bearer ${NEON_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d "{\"source_branch_id\": \"${SNAPSHOT_BRANCH_ID}\", \"preserve_under_name\": \"failed-migration-${GITHUB_RUN_ID}\"}")
+# Poll the operation to confirm completion
+OPERATION_ID=$(echo "$RESTORE_RESPONSE" | jq -r '.operations[0].id')
+# poll GET /projects/{id}/operations/{op_id} until status == "finished"
+```
+
+**Cleanup (success):** Delete snapshot branch via `DELETE /projects/{id}/branches/{snapshot_branch_id}`.
+
+### 4. ECS Init Container (Migration Sidecar)
+
+The same Docker image runs both the migration and the backend. Add a `migrate` container alongside `backend` in both `config.stage.yaml` and `config.prod.yaml`:
+
+```yaml
+container_definitions:
+  migrate:
+    image: <ECR_TAG>           # same image as backend
+    essential: false
+    command: ["pnpm", "db:update"]
+    secrets:
+      - name: DATABASE_URL
+        valueFrom: <same ARN as backend's DATABASE_URL secret>
+  backend:
+    image: <ECR_TAG>
+    dependsOn:
+      - containerName: migrate
+        condition: SUCCESS      # backend won't start if migration fails
+    portMappings: [...]
+    secrets: [...]
+    environment: [...]
+```
+
+**Remove** `pnpm db:update` from `packages/send/backend/scripts/entry.sh`.
+
+The `yq` merge step in both workflows also needs to update the `migrate` container's image in addition to `backend`:
+
+```yaml
+resources:
+  tb:fargate:FargateClusterWithLogging:
+    backend:
+      task_definition:
+        container_definitions:
+          backend:
+            image: "$ECR_TAG"
+          migrate:
+            image: "$ECR_TAG"
+```
+
+### 5. Pulumi Deploy (inside migration job)
+
+The migration job calls Pulumi the same way as the existing deploy job — it registers the new task definition (now containing the migrate container) and updates the ECS service, which restores `desired_count` to 2 as declared in the config:
+
+```bash
+pulumi up -y --diff --target \
+  "urn:pulumi:STACK::send-suite::tb:fargate:FargateClusterWithLogging$aws:ecs/taskDefinition:TaskDefinition::send-suite-STACK-fargate-taskdef" \
+  --target-dependents
+```
+
+Then wait for stability:
+
+```bash
+aws ecs wait services-stable --region eu-central-1 \
+  --cluster send-suite-STACK-fargate --services send-suite-STACK-fargate
+```
+
+### 6. Rollback (on failure)
+
+Triggered by `if: failure()` step at the end of the migration job:
+
+```bash
+# a) Restore Neon snapshot (undo DDL)
+# ... curl POST to restore API (see section 3) ...
+
+# b) Roll back ECS to previous task definition revision
+aws ecs update-service \
+  --cluster $CLUSTER --service $SERVICE \
+  --task-definition "$PREV_TASK_DEF" \
+  --desired-count 2
+
+aws ecs wait services-stable --cluster $CLUSTER --services $SERVICE
+```
+
+Note: Pulumi state will diverge temporarily after a rollback. The next successful deploy will reconcile it.
+
+### 7. Re-enable Autoscaler
+
+Always runs (even on failure, after rollback):
+
+```bash
+aws application-autoscaling register-scalable-target \
+  --service-namespace ecs \
+  --resource-id "service/${CLUSTER}/${SERVICE}" \
+  --scalable-dimension ecs:service:DesiredCount \
+  --min-capacity 2 --max-capacity 4 \
+  --suspended-state "DynamicScalingInSuspended=false,DynamicScalingOutSuspended=false,ScheduledScalingSuspended=false"
+```
+
+### 8. Frontend CDN Invalidation Update
+
+`frontend-invalidate-stage-cdn` in `merge.yml` currently has:
+
+```yaml
+needs: [detect-changes, frontend-deploy-stage-aws, backend-deploy-stage-aws]
+if: always() && ... && (backend-changed != true || backend-deploy-stage-aws.result == success)
+```
+
+Update `needs` to include `backend-migrate-stage` and update the `if` condition to accept either backend job succeeding:
+
+```yaml
+needs: [detect-changes, frontend-deploy-stage-aws, backend-deploy-stage-aws, backend-migrate-stage]
+if: |
+  always()
+  && needs.detect-changes.outputs.frontend-changed == 'true'
+  && needs.frontend-deploy-stage-aws.result == 'success'
+  && (
+    needs.detect-changes.outputs.backend-changed != 'true'
+    || needs.backend-deploy-stage-aws.result == 'success'
+    || needs.backend-migrate-stage.result == 'success'
+  )
+```
+
+Same pattern for `frontend-invalidate-prod-cdn` in `release.yml` (replace `backend-deploy-prod-aws` dependency with `backend-migrate-prod`).
+
+---
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `.github/workflows/merge.yml` | Add `migration-changed` to `detect-changes`; add `backend-migrate-stage` job; update `backend-deploy-stage-aws` condition; update `frontend-invalidate-stage-cdn` needs/condition |
+| `.github/workflows/release.yml` | Replace `backend-deploy-prod-aws` with `backend-migrate-prod` job; update `frontend-invalidate-prod-cdn` |
+| `packages/send/backend/scripts/entry.sh` | Remove `pnpm db:update` (migration moves to init container) |
+| `packages/send/pulumi/config.stage.yaml` | Add `migrate` init container to `container_definitions` |
+| `packages/send/pulumi/config.prod.yaml` | Add `migrate` init container to `container_definitions` |
+
+---
+
+## New Secrets / Variables Required
+
+To be added in GitHub Settings → Environments (`send-stage`, `send-prod`):
+
+| Name | Type | Notes |
+|------|------|-------|
+| `NEON_API_KEY` | secret | Neon personal access token (or project-scoped key) |
+| `NEON_PROJECT_ID` | variable | Different value per environment |
+| `NEON_BRANCH_ID` | variable | ID of the main database branch per environment |
+
+---
+
+## Verification
+
+1. Push a commit that adds a new migration file to `prisma/migrations/` along with a backend code change
+2. Observe `merge.yml` run: `detect-changes` outputs `migration-changed=true`; `backend-migrate-stage` runs; `backend-deploy-stage-aws` is skipped
+3. In AWS Console, confirm ECS service scaled to 0, then back to 2 with new task definition
+4. In ECS task logs, confirm `migrate` container ran `prisma migrate deploy` successfully before `backend` container started
+5. In Neon console, confirm a `migration-snapshot-{run_id}` branch was created (and deleted on success)
+6. Confirm frontend CDN was invalidated after both backend and frontend deploys succeeded
+7. Force a failure (e.g., break the migration SQL) and confirm: ECS rolls back to previous task def, Neon branch is restored, service recovers


### PR DESCRIPTION
## Summary

Design and research for safe Prisma schema migration deployment in CI. Closes #273.

Full spec: [`docs/specs/2026-04-14-migration-ci-pipeline.md`](docs/specs/2026-04-14-migration-ci-pipeline.md)

---

## Key findings from 10-agent review

The spec was reviewed by 10 parallel agents covering workflow logic, ECS design, Neon API correctness, IAM, rollback, observability, and Prisma migration safety. The following issues were found and reconciled into the revised spec.

### Blockers (won't work without these)

- **Missing IAM permissions** — The CI user has no `application-autoscaling:RegisterScalableTarget` permission. The drain/suspend and autoscaler re-enable steps both fail with `AccessDenied`. A new policy must be added to the CI user via Pulumi before the pipeline can be deployed.
- **`migration-changed` output not wired** — Adding the `paths-filter` entry is not enough. The output must also be added to the `detect-changes` job's `outputs:` block. Without this, every downstream reference returns `''` and `backend-migrate-stage` never runs.
- **`PREV_TASK_DEF` lost between steps** — GitHub Actions steps don't share shell state. The variable must be written to `$GITHUB_OUTPUT` and read back via `steps.<id>.outputs.prev_task_def`. Without this, rollback calls `update-service --task-definition ""`.
- **Prod CDN condition broken for frontend-only releases** — `backend-deploy-prod-aws` currently has no job-level `if` condition, so it always exits `success` and the CDN fires. Replacing it with a job-gated `backend-migrate-prod` changes the result to `skipped` for frontend-only releases, silently blocking CDN invalidation. The prod condition needs an explicit `ecs_deployed == ''` clause. "Same pattern as stage" does not work here.

### Critical design flaws

- **`essential: false` causes 10-minute silent hang on migration failure** — With `essential: false`, a non-zero migrate exit doesn't kill the task. ECS keeps cycling failed tasks while `aws ecs wait services-stable` sits silently for up to 10 minutes. Changed to `essential: true` so a failed migration kills the task immediately.
- **`--min-capacity 0` in drain causes Pulumi state drift** — Pulumi declares `min_capacity: 2`. Passing `--min-capacity 0` to `register-scalable-target` writes conflicting state to AWS. Changed to use only the `DynamicScalingInSuspended/OutSuspended` flags, which pause scaling actions without touching `min_capacity`.
- **`if: failure()` doesn't fire on job cancellation** — `concurrency: cancel-in-progress: true` is already active. A second push cancels the migration job mid-drain, leaving the service at `desired_count=0` with the autoscaler suspended permanently. Fixed by moving autoscaler re-enable and desired_count restoration into a **separate job** (`autoscaler-cleanup-stage`) that runs `if: always()` — separate jobs execute even when their dependency is cancelled.
- **Pulumi state diverges after rollback and is not self-healing** — After rollback, Pulumi's state records the new (failed) task definition. The next `pulumi up` detects drift and pushes the failed image again. The post-rollback recovery path requires `pulumi refresh` before the next deploy — not just "the next deploy will reconcile it."
- **Neon restore polling was a comment, not code** — `# poll until status == "finished"` was a placeholder. ECS rollback must not run until the restore completes. Added a concrete bounded polling loop (60 × 5s) handling all terminal states (`finished`, `cancelled`, `skipped`, `failed`).
- **Snapshot branch creation also needs a poll** — Branch creation is async on Neon. Added the same poll for the create-branch operation before proceeding to migration.

### High-confidence gaps

- **Local dev and `e2e-test`/`integration-test` CI lose migrations** — Removing `pnpm db:update` from `entry.sh` also removes it from `docker compose up`. Added a `migrate` service to `compose.ci.yml` and documented the local dev impact. `compose.ci.yml` added to Files to Modify.
- **No CI step surfaces CloudWatch logs on failure** — When migration fails, the job waits 10 minutes then exits with a generic timeout. Added an `if: failure()` step that fetches the migrate container's log stream from CloudWatch. Also added an early-detection polling loop that detects stopped tasks within ~2 minutes.
- **GitHub Release stays published after prod migration failure** — Re-publishing the same release retriggers the same broken migration in a loop. Added an `if: failure()` step that converts the release to a pre-release via `gh release edit --prerelease`.
- **`NEON_API_KEY` must be per-environment** — A single repo-wide key covers both stage and prod Neon projects. A leaked key would expose both databases. Changed to two separate environment-scoped secrets.
- **`migrate` container needs `linuxParameters.initProcessEnabled: True`** — Consistent with the `backend` container pattern; ensures clean subprocess reaping for the Prisma migration engine binary.
- **ALB deregistration delay and health check path not set** — Added `deregistration_delay: 30` (reduces maintenance window from 300s to ~35s) and `path: /api/health` to the ALB health check in the Pulumi config.
- **Atomicity constraints** — All config YAML changes and workflow `yq` stump changes must land in the same PR. Adding `backend-migrate-stage` to a `needs` array before the job exists causes the entire workflow to fail at parse time.

---

## Test plan

- [ ] Push commit with new migration file — `backend-migrate-stage` runs; `backend-deploy-stage-aws` skipped
- [ ] ECS scales to 0, autoscaler suspended, then Pulumi restores desired_count to 2
- [ ] `migrate` container CloudWatch logs appear before `backend` starts
- [ ] Neon snapshot branch created, deleted on success
- [ ] CDN invalidates after both backend and frontend succeed
- [ ] **Failure test:** broken migration SQL — CI surfaces CloudWatch logs within ~2 min; Neon restored; ECS reverts; autoscaler re-enabled
- [ ] **Cancellation test:** cancel mid-drain — `autoscaler-cleanup-stage` fires independently; desired_count restored to 2
- [ ] Backend-only change (no migration) — normal deploy path, no drain
- [ ] Frontend-only prod release — CDN invalidates despite no `ecr_tag.zip`

🤖 Generated with [Claude Code](https://claude.com/claude-code)