### PR TITLE
let user know it deleted all

### DIFF
--- a/packages/send/frontend/src/apps/send/composables/useBackupAndRestore.ts
+++ b/packages/send/frontend/src/apps/send/composables/useBackupAndRestore.ts
@@ -133,7 +133,12 @@ export const useBackupAndRestore = () => {
       return await trpc.deleteFiles.mutate();
     },
     onSuccess: async () => {
-      router.push('/send/profile');
+      await router.push('/send/profile');
+      // hard reload to force a new default folder to be created since all previous ones are now deleted
+      window.location.reload();
+      window.alert(
+        'All your files have been deleted. You can start fresh now!'
+      );
     },
   });
 


### PR DESCRIPTION
This PR refreshes the page after deleting all files and shows a modal that tells the user it's been successful
This fixes the problem of the default folder being empty post delete
Closes https://github.com/thunderbird/tbpro-add-on/issues/702
Closes https://github.com/thunderbird/tbpro-add-on/issues/701