### PR TITLE
feat(ci): migrate deploy workflows to GitHub Actions OIDC (#205)

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -30,6 +30,7 @@ on:
 permissions:
   packages: read
   contents: read
+  id-token: write
 
 jobs:
   detect-changes:
@@ -92,8 +93,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: us-east-1
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
 
       - name: Login to Amazon ECR
         # if: needs.detect-changes.outputs.backend-changed == 'true'
@@ -147,8 +147,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: eu-central-1
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
 
       - name: Deploy new image to stage
         # if: needs.detect-changes.outputs.backend-changed == 'true'
@@ -326,8 +325,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: eu-central-1
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
 
       - name: Deploy to stage
         if: needs.detect-changes.outputs.frontend-changed == 'true'
@@ -354,8 +352,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: eu-central-1
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
 
       - name: Invalidate CDN, stage only
         if: needs.frontend-deploy-stage-aws.outputs.s3_deployed == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ on:
 permissions:
   packages: read
   contents: read
+  id-token: write
 
 jobs:
   backend-deploy-prod-aws:
@@ -42,8 +43,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: us-east-1
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
 
       - name: Login to Amazon ECR
         id: login-ecr
@@ -76,8 +76,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: eu-central-1
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
 
       - name: Deploy version-tagged image to prod
         if: contains(github.event.release.assets.*.name, 'ecr_tag.zip')
@@ -145,8 +144,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: eu-central-1
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
 
       - name: Deploy to production
         if: contains(github.event.release.assets.*.name, 'dist-web-prod.zip')
@@ -173,8 +171,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: eu-central-1
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
 
       - name: Invalidate CDN, prod only
         run: |


### PR DESCRIPTION
Part of thunderbird/platform-infrastructure#205.
Closes thunderbird/tbpro-add-on#719.

## Summary

Migrates `merge.yml` and `release.yml` from long-lived IAM access keys to OIDC role assumption via `AWS_ROLE_ARN`.

**What changed:** Added `id-token: write` to top-level `permissions` in both files. Replaced `aws-access-key-id` / `aws-secret-access-key` with `role-to-assume: ${{ secrets.AWS_ROLE_ARN }}` in all 8 `configure-aws-credentials` steps.

**Multi-region note:** Both workflows have jobs with two credential steps — one for us-east-1 (ECR) and one for eu-central-1 (ECS/S3/CloudFront). Both steps use the same `AWS_ROLE_ARN`. IAM roles are global; `aws-region` is only the SDK default region hint, not a role constraint.

**OIDC roles provisioned in platform-infrastructure:**
- `send-stage` → `arn:aws:iam::768512802988:role/thunderbird-legacy-github-oidc-prod-tbpro-send-stage`
- `send-prod` → `arn:aws:iam::768512802988:role/thunderbird-legacy-github-oidc-prod-tbpro-send-prod`

`AWS_ROLE_ARN` is already set on both GitHub Environments.

## Test plan

- [ ] Merge triggers `merge.yml` — confirm all 4 AWS jobs authenticate via `AssumeRoleWithWebIdentity`
- [ ] Publish a release — confirm all 4 `release.yml` AWS jobs authenticate via OIDC
- [ ] Soak: ≥3 successful production deploys across ≥7 calendar days, zero `AccessDenied` on old IAM user
- [ ] After soak: delete `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` from `send-stage` and `send-prod`; remove `AwsAutomationUser` from `packages/send/pulumi/__main__.py:79-81` (tracked in platform-infrastructure#205)

## Test evidence

### merge.yml (deploy-stage-and-create-release)

> To be filled in after merge.

```
Run URL:
backend-build-stage:           ✅ / ❌
backend-deploy-stage-aws:      ✅ / ❌
frontend-deploy-stage-aws:     ✅ / ❌
frontend-invalidate-stage-cdn: ✅ / ❌
```

### release.yml (deploy-production)

> To be filled in after first production release using this PR.

```
Run URL:
backend-deploy-prod-aws:      ✅ / ❌
frontend-deploy-prod-aws:     ✅ / ❌
frontend-invalidate-prod-cdn: ✅ / ❌
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)