### PR TITLE
Update E2E browserstack-node-sdk to latest version

### DIFF
--- a/packages/send/e2e/package.json
+++ b/packages/send/e2e/package.json
@@ -20,9 +20,9 @@
     "test:e2e:nightly:prod:browserstack:mobile:ios:safari": "npx browserstack-node-sdk playwright test --grep mobile-nightly --project=ios-safari --browserstack.buildName 'TB Send Nightly Tests iOS Safari' --browserstack.config 'browserstack-mobile-nightly.yml'"
   },
   "devDependencies": {
-    "@playwright/test": "1.56.1",
+    "@playwright/test": "1.58.2",
     "@types/node": "*",
-    "browserstack-node-sdk": "1.49.10",
+    "browserstack-node-sdk": "^1.52.1",
     "dotenv": "^17.2.1",
     "sort-package-json": "*"
   },


### PR DESCRIPTION
Update the E2E tests `browserstack-node-sdk` dependency from the current 1.49.10 to the latest 1.52.1 (which also required an update to the @playwright/test dependency to the latest version). Fixes #725.

Link showing that with this update the nightly E2E tests still successfully run in BrowserStack on [Firefox Desktop](https://automate.browserstack.com/projects/Thunderbird+Send/builds/TB+Send+Nightly+Tests+Firefox+Desktop/103?tab=sessions).