### PR TITLE
[CI/CD 2/9] Fix matrix env scoping and release prod CDN gate

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -208,12 +208,6 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - name: Install pnpm and build package
-        id: install-pnpm-build
-        run: |
-          pnpm install --filter @thunderbird/tbpro-add-on && lerna run bootstrap
-          pnpm install --filter send-frontend
-
       # Front end build env configuration
       - name: Create .env file from secrets
         env:
@@ -246,7 +240,7 @@ jobs:
         id: frontend-build
         env:
           BASE_URL: "https://send-stage.tb.pro"
-          IS_CI_AUTOMATION: yes
+          IS_CI_AUTOMATION: "yes"
         run: |
           echo "Building for environment: stage"
           set -x
@@ -298,12 +292,6 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - name: Install pnpm and build package
-        id: install-pnpm-build
-        run: |
-          pnpm install --filter @thunderbird/tbpro-add-on && lerna run bootstrap
-          pnpm install --filter send-frontend
-
       # Front end build env configuration
       - name: Create .env file from secrets
         env:
@@ -336,7 +324,7 @@ jobs:
         id: frontend-build
         env:
           BASE_URL: "https://send.tb.pro"
-          IS_CI_AUTOMATION: yes
+          IS_CI_AUTOMATION: "yes"
         run: |
           echo "Building for environment: prod"
           set -x
@@ -441,7 +429,7 @@ jobs:
     container:
       image: ghcr.io/${{ github.repository }}/cached-devcontainer:latest
     env:
-      IS_CI_AUTOMATION: yes
+      IS_CI_AUTOMATION: "yes"
     if: needs.detect-changes.outputs.addon-changed == 'true' || needs.detect-changes.outputs.frontend-changed == 'true' || github.event.inputs.force_addon == 'true'
     environment:
       name: send-stage
@@ -507,7 +495,7 @@ jobs:
         env:
           BASE_URL: "https://send-stage.tb.pro"
           ENV: "stage"
-          IS_CI_AUTOMATION: yes
+          IS_CI_AUTOMATION: "yes"
         run: |
           # install packages that addon depends on
           pnpm install --filter tbpro-shared
@@ -568,7 +556,7 @@ jobs:
     container:
       image: ghcr.io/${{ github.repository }}/cached-devcontainer:latest
     env:
-      IS_CI_AUTOMATION: yes
+      IS_CI_AUTOMATION: "yes"
     if: needs.detect-changes.outputs.addon-changed == 'true' || needs.detect-changes.outputs.frontend-changed == 'true' || github.event.inputs.force_addon == 'true'
     environment:
       name: send-prod
@@ -634,7 +622,7 @@ jobs:
         env:
           BASE_URL: "https://send.tb.pro"
           ENV: "prod"
-          IS_CI_AUTOMATION: yes
+          IS_CI_AUTOMATION: "yes"
         run: |
           # install packages that addon depends on
           pnpm install --filter tbpro-shared

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -213,7 +213,6 @@ jobs:
         run: |
           pnpm install --filter @thunderbird/tbpro-add-on && lerna run bootstrap
           pnpm install --filter send-frontend
-          lerna run build --scope=send-suite
 
       # Front end build env configuration
       - name: Create .env file from secrets
@@ -304,7 +303,6 @@ jobs:
         run: |
           pnpm install --filter @thunderbird/tbpro-add-on && lerna run bootstrap
           pnpm install --filter send-frontend
-          lerna run build --scope=send-suite
 
       # Front end build env configuration
       - name: Create .env file from secrets
@@ -558,8 +556,9 @@ jobs:
       - name: Assert ATN signing success
         if: always()
         run: |
-          if [[ "${{ steps.web-ext-sign-stage-addon.outcome }}" != "success" ]]; then
-            echo "ATN addon signing failed"
+          outcome="${{ steps.web-ext-sign-stage-addon.outcome }}"
+          if [[ "$outcome" != "success" && "$outcome" != "skipped" ]]; then
+            echo "::error::ATN addon signing failed (outcome: $outcome)"
             exit 1
           fi
 

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -437,7 +437,7 @@ jobs:
       - uses: actions/checkout@v4
 
       # Addon build configuration
-      - name: (Addon) Create .env file from secrets
+      - name: (Addon) Create send-frontend .env from secrets
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.VITE_SENTRY_AUTH_TOKEN_STAGE }}
           SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN_STAGE }}
@@ -464,7 +464,7 @@ jobs:
           VITE_OIDC_ROOT_URL=${OIDC_ROOT_URL}
           EOF
 
-      - name: (Addon) Create .env file from secrets
+      - name: (Addon) Create addon .env from secrets
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.VITE_SENTRY_AUTH_TOKEN_STAGE }}
           SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN_STAGE }}
@@ -543,10 +543,11 @@ jobs:
 
       - name: Assert ATN signing success
         if: always()
+        env:
+          OUTCOME: ${{ steps.web-ext-sign-stage-addon.outcome }}
         run: |
-          outcome="${{ steps.web-ext-sign-stage-addon.outcome }}"
-          if [[ "$outcome" != "success" && "$outcome" != "skipped" ]]; then
-            echo "::error::ATN addon signing failed (outcome: $outcome)"
+          if [[ "$OUTCOME" != "success" && "$OUTCOME" != "skipped" ]]; then
+            echo "::error::ATN addon signing failed (outcome: $OUTCOME)"
             exit 1
           fi
 
@@ -564,7 +565,7 @@ jobs:
       - uses: actions/checkout@v4
 
       # Addon build configuration
-      - name: (Addon) Create .env file from secrets
+      - name: (Addon) Create send-frontend .env from secrets
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.VITE_SENTRY_AUTH_TOKEN_PROD }}
           SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN_PROD }}
@@ -591,7 +592,7 @@ jobs:
           VITE_OIDC_ROOT_URL=${OIDC_ROOT_URL}
           EOF
 
-      - name: (Addon) Create .env file from secrets
+      - name: (Addon) Create addon .env from secrets
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.VITE_SENTRY_AUTH_TOKEN_PROD }}
           SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN_PROD }}

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -190,7 +190,7 @@ jobs:
           aws ecs wait services-stable --region eu-central-1 --cluster send-suite-stage-fargate --services send-suite-stage-fargate
           echo "ecs_deployed=true" >> "$GITHUB_OUTPUT"
 
-  frontend-build:
+  frontend-build-stage:
     needs: detect-changes
     if: needs.detect-changes.outputs.frontend-changed == 'true'
     runs-on: ubuntu-latest
@@ -200,28 +200,15 @@ jobs:
       IS_CI_AUTOMATION: "yes"
     environment:
       name: send-stage
-    strategy:
-      matrix:
-        env: ["stage", "prod"]
-        include:
-          - env: "stage"
-            base_url: "https://send-stage.tb.pro"
-            send_server_url: "https://send-backend-stage.tb.pro"
-            send_client_url: "https://send-stage.tb.pro"
-          - env: "prod"
-            base_url: "https://send.tb.pro"
-            send_server_url: "https://send-backend.tb.pro"
-            send_client_url: "https://send.tb.pro"
     steps:
       - name: test echo
         run: |
-          echo "Building frontend for environment ${{ matrix.env }} with base URL ${{ matrix.base_url }}"
+          echo "Building frontend for environment stage with base URL https://send-stage.tb.pro"
           date
 
       - uses: actions/checkout@v4
 
       - name: Install pnpm and build package
-        # if: needs.detect-changes.outputs.frontend-changed == 'true'
         id: install-pnpm-build
         run: |
           pnpm install --filter @thunderbird/tbpro-add-on && lerna run bootstrap
@@ -230,19 +217,18 @@ jobs:
 
       # Front end build env configuration
       - name: Create .env file from secrets
-        # if: needs.detect-changes.outputs.frontend-changed == 'true'
         env:
-          SENTRY_AUTH_TOKEN: ${{ matrix.env == 'stage' && secrets.VITE_SENTRY_AUTH_TOKEN_STAGE || secrets.VITE_SENTRY_AUTH_TOKEN_PROD }}
-          SENTRY_DSN: ${{ matrix.env == 'stage' && vars.VITE_SENTRY_DSN_STAGE || vars.VITE_SENTRY_DSN_PROD }}
-          POSTHOG_KEY: ${{ matrix.env == 'stage' && secrets.VITE_POSTHOG_PROJECT_KEY_STAGE || secrets.VITE_POSTHOG_PROJECT_KEY_PROD }}
-          POSTHOG_HOST: ${{ matrix.env == 'stage' && vars.VITE_POSTHOG_HOST_STAGE || vars.VITE_POSTHOG_HOST_PROD }}
-          OIDC_CLIENT_ID: ${{ matrix.env == 'stage' && secrets.VITE_OIDC_CLIENT_ID_STAGE || secrets.VITE_OIDC_CLIENT_ID_PROD }}
-          OIDC_ROOT_URL: ${{ matrix.env == 'stage' && secrets.VITE_OIDC_ROOT_URL_STAGE || secrets.VITE_OIDC_ROOT_URL_PROD }}
-          BASE_URL: ${{ matrix.base_url }}
-          SEND_SERVER_URL: ${{ matrix.send_server_url }}
-          SEND_CLIENT_URL: ${{ matrix.send_client_url }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.VITE_SENTRY_AUTH_TOKEN_STAGE }}
+          SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN_STAGE }}
+          POSTHOG_KEY: ${{ secrets.VITE_POSTHOG_PROJECT_KEY_STAGE }}
+          POSTHOG_HOST: ${{ vars.VITE_POSTHOG_HOST_STAGE }}
+          OIDC_CLIENT_ID: ${{ secrets.VITE_OIDC_CLIENT_ID_STAGE }}
+          OIDC_ROOT_URL: ${{ secrets.VITE_OIDC_ROOT_URL_STAGE }}
+          BASE_URL: "https://send-stage.tb.pro"
+          SEND_SERVER_URL: "https://send-backend-stage.tb.pro"
+          SEND_CLIENT_URL: "https://send-stage.tb.pro"
         run: |
-          echo "Environment: ${{ matrix.env }}"
+          echo "Environment: stage"
           cd packages/send/frontend
           cat <<EOF > .env
           VUE_BASE_URL=${BASE_URL}
@@ -260,10 +246,10 @@ jobs:
         if: needs.detect-changes.outputs.frontend-changed == 'true'
         id: frontend-build
         env:
-          BASE_URL: ${{ matrix.base_url }}
+          BASE_URL: "https://send-stage.tb.pro"
           IS_CI_AUTOMATION: yes
         run: |
-          echo "Building for environment: ${{ matrix.env }}"
+          echo "Building for environment: stage"
           set -x
           # Initial setup of dependencies
           pnpm install --filter @thunderbird/tbpro-add-on && lerna run bootstrap
@@ -273,30 +259,121 @@ jobs:
 
           # Build static frontend assets and the .xpi
           pnpm build
-          mv dist-web ../dist-web-${{ matrix.env }}
+          mv dist-web ../dist-web-stage
           cd ..
-          mv "$(find send-suite-*.xpi)" "send-suite-${{ matrix.env }}-$(basename "$(find send-suite-*.xpi)" | cut -d'-' -f3-)"
-          ls -l send-suite-${{ matrix.env }}-*.xpi
+          mv "$(find send-suite-*.xpi)" "send-suite-stage-$(basename "$(find send-suite-*.xpi)" | cut -d'-' -f3-)"
+          ls -l send-suite-stage-*.xpi
 
-      - name: Archive the ${{ matrix.env }} frontend build
+      - name: Archive the stage frontend build
         if: needs.detect-changes.outputs.frontend-changed == 'true'
         id: frontend-archive-stage
         uses: actions/upload-artifact@v4
         with:
-          name: dist-web-${{ matrix.env }}
-          path: packages/send/dist-web-${{ matrix.env }}
+          name: dist-web-stage
+          path: packages/send/dist-web-stage
           compression-level: 0
 
-      - name: Archive the ${{ matrix.env }} XPI
+      - name: Archive the stage XPI
         if: needs.detect-changes.outputs.frontend-changed == 'true'
         id: xpi-archive-stage
         uses: actions/upload-artifact@v4
         with:
-          name: xpi-${{ matrix.env }}
-          path: packages/send/send-suite-${{ matrix.env }}-*.xpi
+          name: xpi-stage
+          path: packages/send/send-suite-stage-*.xpi
+
+  frontend-build-prod:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.frontend-changed == 'true'
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/${{ github.repository }}/cached-devcontainer:latest
+    env:
+      IS_CI_AUTOMATION: "yes"
+    environment:
+      name: send-prod
+    steps:
+      - name: test echo
+        run: |
+          echo "Building frontend for environment prod with base URL https://send.tb.pro"
+          date
+
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm and build package
+        id: install-pnpm-build
+        run: |
+          pnpm install --filter @thunderbird/tbpro-add-on && lerna run bootstrap
+          pnpm install --filter send-frontend
+          lerna run build --scope=send-suite
+
+      # Front end build env configuration
+      - name: Create .env file from secrets
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.VITE_SENTRY_AUTH_TOKEN_PROD }}
+          SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN_PROD }}
+          POSTHOG_KEY: ${{ secrets.VITE_POSTHOG_PROJECT_KEY_PROD }}
+          POSTHOG_HOST: ${{ vars.VITE_POSTHOG_HOST_PROD }}
+          OIDC_CLIENT_ID: ${{ secrets.VITE_OIDC_CLIENT_ID_PROD }}
+          OIDC_ROOT_URL: ${{ secrets.VITE_OIDC_ROOT_URL_PROD }}
+          BASE_URL: "https://send.tb.pro"
+          SEND_SERVER_URL: "https://send-backend.tb.pro"
+          SEND_CLIENT_URL: "https://send.tb.pro"
+        run: |
+          echo "Environment: prod"
+          cd packages/send/frontend
+          cat <<EOF > .env
+          VUE_BASE_URL=${BASE_URL}
+          VITE_SEND_SERVER_URL=${SEND_SERVER_URL}
+          VITE_SEND_CLIENT_URL=${SEND_CLIENT_URL}
+          VITE_SENTRY_AUTH_TOKEN=${SENTRY_AUTH_TOKEN}
+          VITE_SENTRY_DSN=${SENTRY_DSN}
+          VITE_POSTHOG_PROJECT_KEY=${POSTHOG_KEY}
+          VITE_POSTHOG_HOST=${POSTHOG_HOST}
+          VITE_OIDC_CLIENT_ID=${OIDC_CLIENT_ID}
+          VITE_OIDC_ROOT_URL=${OIDC_ROOT_URL}
+          EOF
+
+      - name: Build frontend assets
+        if: needs.detect-changes.outputs.frontend-changed == 'true'
+        id: frontend-build
+        env:
+          BASE_URL: "https://send.tb.pro"
+          IS_CI_AUTOMATION: yes
+        run: |
+          echo "Building for environment: prod"
+          set -x
+          # Initial setup of dependencies
+          pnpm install --filter @thunderbird/tbpro-add-on && lerna run bootstrap
+          pnpm install --filter tbpro-shared
+          pnpm install --filter send-frontend
+          cd packages/send/frontend
+
+          # Build static frontend assets and the .xpi
+          pnpm build
+          mv dist-web ../dist-web-prod
+          cd ..
+          mv "$(find send-suite-*.xpi)" "send-suite-prod-$(basename "$(find send-suite-*.xpi)" | cut -d'-' -f3-)"
+          ls -l send-suite-prod-*.xpi
+
+      - name: Archive the prod frontend build
+        if: needs.detect-changes.outputs.frontend-changed == 'true'
+        id: frontend-archive-prod
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-web-prod
+          path: packages/send/dist-web-prod
+          compression-level: 0
+
+      - name: Archive the prod XPI
+        if: needs.detect-changes.outputs.frontend-changed == 'true'
+        id: xpi-archive-prod
+        uses: actions/upload-artifact@v4
+        with:
+          name: xpi-prod
+          path: packages/send/send-suite-prod-*.xpi
 
   frontend-deploy-stage-aws:
-    needs: ["frontend-build", "detect-changes"]
+    needs: ["frontend-build-stage", "detect-changes"]
     if: needs.detect-changes.outputs.frontend-changed == 'true'
     runs-on: ubuntu-latest
     container:
@@ -360,7 +437,7 @@ jobs:
           echo "Invalidating CDN for environment: stage"
           aws cloudfront create-invalidation --distribution-id ${{ vars.STAGE_CF_DISTRO_ID }} --paths "/*"
 
-  addon-changes:
+  addon-changes-stage:
     needs: detect-changes
     runs-on: ubuntu-latest
     container:
@@ -370,36 +447,24 @@ jobs:
     if: needs.detect-changes.outputs.addon-changed == 'true' || needs.detect-changes.outputs.frontend-changed == 'true' || github.event.inputs.force_addon == 'true'
     environment:
       name: send-stage
-    strategy:
-      matrix:
-        env: ["stage", "prod"]
-        include:
-          - env: "stage"
-            base_url: "https://send-stage.tb.pro"
-            send_server_url: "https://send-backend-stage.tb.pro"
-            send_client_url: "https://send-stage.tb.pro"
-          - env: "prod"
-            base_url: "https://send.tb.pro"
-            send_server_url: "https://send-backend.tb.pro"
-            send_client_url: "https://send.tb.pro"
     steps:
       - uses: actions/checkout@v4
 
       # Addon build configuration
       - name: (Addon) Create .env file from secrets
         env:
-          SENTRY_AUTH_TOKEN: ${{ matrix.env == 'stage' && secrets.VITE_SENTRY_AUTH_TOKEN_STAGE || secrets.VITE_SENTRY_AUTH_TOKEN_PROD }}
-          SENTRY_DSN: ${{ matrix.env == 'stage' && vars.VITE_SENTRY_DSN_STAGE || vars.VITE_SENTRY_DSN_PROD}}
-          POSTHOG_KEY: ${{ matrix.env == 'stage' && secrets.VITE_POSTHOG_PROJECT_KEY_STAGE || secrets.VITE_POSTHOG_PROJECT_KEY_PROD }}
-          POSTHOG_HOST: ${{ matrix.env == 'stage' && vars.VITE_POSTHOG_HOST_STAGE ||  vars.VITE_POSTHOG_HOST_PROD}}
-          OIDC_CLIENT_ID: ${{ matrix.env == 'stage' && secrets.VITE_OIDC_CLIENT_ID_STAGE || secrets.VITE_OIDC_CLIENT_ID_PROD }}
-          OIDC_ROOT_URL: ${{ matrix.env == 'stage' && secrets.VITE_OIDC_ROOT_URL_STAGE || secrets.VITE_OIDC_ROOT_URL_PROD}}
-          BASE_URL: ${{ matrix.base_url }}
-          SEND_SERVER_URL: ${{ matrix.send_server_url }}
-          SEND_CLIENT_URL: ${{ matrix.send_client_url }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.VITE_SENTRY_AUTH_TOKEN_STAGE }}
+          SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN_STAGE }}
+          POSTHOG_KEY: ${{ secrets.VITE_POSTHOG_PROJECT_KEY_STAGE }}
+          POSTHOG_HOST: ${{ vars.VITE_POSTHOG_HOST_STAGE }}
+          OIDC_CLIENT_ID: ${{ secrets.VITE_OIDC_CLIENT_ID_STAGE }}
+          OIDC_ROOT_URL: ${{ secrets.VITE_OIDC_ROOT_URL_STAGE }}
+          BASE_URL: "https://send-stage.tb.pro"
+          SEND_SERVER_URL: "https://send-backend-stage.tb.pro"
+          SEND_CLIENT_URL: "https://send-stage.tb.pro"
 
         run: |
-          echo "Environment: ${{ matrix.env }}"
+          echo "Environment: stage"
           cd packages/send/frontend
           cat << EOF > .env
           VUE_BASE_URL=${BASE_URL}
@@ -410,22 +475,22 @@ jobs:
           VITE_POSTHOG_PROJECT_KEY=${POSTHOG_KEY}
           VITE_POSTHOG_HOST=${POSTHOG_HOST}
           VITE_OIDC_CLIENT_ID=${OIDC_CLIENT_ID}
-          VITE_OIDC_ROOT_URL=${OIDC_ROOT_URL}                    
+          VITE_OIDC_ROOT_URL=${OIDC_ROOT_URL}
           EOF
 
       - name: (Addon) Create .env file from secrets
         env:
-          SENTRY_AUTH_TOKEN: ${{ matrix.env == 'stage' && secrets.VITE_SENTRY_AUTH_TOKEN_STAGE || secrets.VITE_SENTRY_AUTH_TOKEN_PROD }}
-          SENTRY_DSN: ${{ matrix.env == 'stage' && vars.VITE_SENTRY_DSN_STAGE || vars.VITE_SENTRY_DSN_PROD}}
-          POSTHOG_KEY: ${{ matrix.env == 'stage' && secrets.VITE_POSTHOG_PROJECT_KEY_STAGE || secrets.VITE_POSTHOG_PROJECT_KEY_PROD }}
-          POSTHOG_HOST: ${{ matrix.env == 'stage' && vars.VITE_POSTHOG_HOST_STAGE ||  vars.VITE_POSTHOG_HOST_PROD}}
-          OIDC_CLIENT_ID: ${{ matrix.env == 'stage' && secrets.VITE_OIDC_CLIENT_ID_STAGE || secrets.VITE_OIDC_CLIENT_ID_PROD }}
-          OIDC_ROOT_URL: ${{ matrix.env == 'stage' && secrets.VITE_OIDC_ROOT_URL_STAGE || secrets.VITE_OIDC_ROOT_URL_PROD}}
-          BASE_URL: ${{ matrix.base_url }}
-          SEND_SERVER_URL: ${{ matrix.send_server_url }}
-          SEND_CLIENT_URL: ${{ matrix.send_client_url }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.VITE_SENTRY_AUTH_TOKEN_STAGE }}
+          SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN_STAGE }}
+          POSTHOG_KEY: ${{ secrets.VITE_POSTHOG_PROJECT_KEY_STAGE }}
+          POSTHOG_HOST: ${{ vars.VITE_POSTHOG_HOST_STAGE }}
+          OIDC_CLIENT_ID: ${{ secrets.VITE_OIDC_CLIENT_ID_STAGE }}
+          OIDC_ROOT_URL: ${{ secrets.VITE_OIDC_ROOT_URL_STAGE }}
+          BASE_URL: "https://send-stage.tb.pro"
+          SEND_SERVER_URL: "https://send-backend-stage.tb.pro"
+          SEND_CLIENT_URL: "https://send-stage.tb.pro"
         run: |
-          echo "Environment: ${{ matrix.env }}"
+          echo "Environment: stage"
           cd packages/addon
           cat << EOF > .env
           VUE_BASE_URL=${BASE_URL}
@@ -436,14 +501,14 @@ jobs:
           VITE_POSTHOG_PROJECT_KEY=${POSTHOG_KEY}
           VITE_POSTHOG_HOST=${POSTHOG_HOST}
           VITE_OIDC_CLIENT_ID=${OIDC_CLIENT_ID}
-          VITE_OIDC_ROOT_URL=${OIDC_ROOT_URL}                    
+          VITE_OIDC_ROOT_URL=${OIDC_ROOT_URL}
           EOF
 
       - name: Build the frontend's static assets
         id: addon-frontend-build
         env:
-          BASE_URL: ${{matrix.base_url}}
-          ENV: ${{ matrix.env }}
+          BASE_URL: "https://send-stage.tb.pro"
+          ENV: "stage"
           IS_CI_AUTOMATION: yes
         run: |
           # install packages that addon depends on
@@ -477,7 +542,6 @@ jobs:
           compression-level: 0 # <-- don't zip!
 
       - name: Deploy addon stage to ATN via web-ext
-        if: matrix.env == 'stage'
         continue-on-error: true
         id: web-ext-sign-stage-addon
         uses: kewisch/action-web-ext@v1
@@ -490,3 +554,119 @@ jobs:
           apiUrlPrefix: "https://addons.thunderbird.net/api/v4"
           apiKey: ${{ secrets.ATN_API_KEY }}
           apiSecret: ${{ secrets.ATN_API_SECRET }}
+
+      - name: Assert ATN signing success
+        if: always()
+        run: |
+          if [[ "${{ steps.web-ext-sign-stage-addon.outcome }}" != "success" ]]; then
+            echo "ATN addon signing failed"
+            exit 1
+          fi
+
+  addon-changes-prod:
+    needs: detect-changes
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/${{ github.repository }}/cached-devcontainer:latest
+    env:
+      IS_CI_AUTOMATION: yes
+    if: needs.detect-changes.outputs.addon-changed == 'true' || needs.detect-changes.outputs.frontend-changed == 'true' || github.event.inputs.force_addon == 'true'
+    environment:
+      name: send-prod
+    steps:
+      - uses: actions/checkout@v4
+
+      # Addon build configuration
+      - name: (Addon) Create .env file from secrets
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.VITE_SENTRY_AUTH_TOKEN_PROD }}
+          SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN_PROD }}
+          POSTHOG_KEY: ${{ secrets.VITE_POSTHOG_PROJECT_KEY_PROD }}
+          POSTHOG_HOST: ${{ vars.VITE_POSTHOG_HOST_PROD }}
+          OIDC_CLIENT_ID: ${{ secrets.VITE_OIDC_CLIENT_ID_PROD }}
+          OIDC_ROOT_URL: ${{ secrets.VITE_OIDC_ROOT_URL_PROD }}
+          BASE_URL: "https://send.tb.pro"
+          SEND_SERVER_URL: "https://send-backend.tb.pro"
+          SEND_CLIENT_URL: "https://send.tb.pro"
+
+        run: |
+          echo "Environment: prod"
+          cd packages/send/frontend
+          cat << EOF > .env
+          VUE_BASE_URL=${BASE_URL}
+          VITE_SEND_SERVER_URL=${SEND_SERVER_URL}
+          VITE_SEND_CLIENT_URL=${SEND_CLIENT_URL}
+          VITE_SENTRY_AUTH_TOKEN=${SENTRY_AUTH_TOKEN}
+          VITE_SENTRY_DSN=${SENTRY_DSN}
+          VITE_POSTHOG_PROJECT_KEY=${POSTHOG_KEY}
+          VITE_POSTHOG_HOST=${POSTHOG_HOST}
+          VITE_OIDC_CLIENT_ID=${OIDC_CLIENT_ID}
+          VITE_OIDC_ROOT_URL=${OIDC_ROOT_URL}
+          EOF
+
+      - name: (Addon) Create .env file from secrets
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.VITE_SENTRY_AUTH_TOKEN_PROD }}
+          SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN_PROD }}
+          POSTHOG_KEY: ${{ secrets.VITE_POSTHOG_PROJECT_KEY_PROD }}
+          POSTHOG_HOST: ${{ vars.VITE_POSTHOG_HOST_PROD }}
+          OIDC_CLIENT_ID: ${{ secrets.VITE_OIDC_CLIENT_ID_PROD }}
+          OIDC_ROOT_URL: ${{ secrets.VITE_OIDC_ROOT_URL_PROD }}
+          BASE_URL: "https://send.tb.pro"
+          SEND_SERVER_URL: "https://send-backend.tb.pro"
+          SEND_CLIENT_URL: "https://send.tb.pro"
+        run: |
+          echo "Environment: prod"
+          cd packages/addon
+          cat << EOF > .env
+          VUE_BASE_URL=${BASE_URL}
+          VITE_SEND_SERVER_URL=${SEND_SERVER_URL}
+          VITE_SEND_CLIENT_URL=${SEND_CLIENT_URL}
+          VITE_SENTRY_AUTH_TOKEN=${SENTRY_AUTH_TOKEN}
+          VITE_SENTRY_DSN=${SENTRY_DSN}
+          VITE_POSTHOG_PROJECT_KEY=${POSTHOG_KEY}
+          VITE_POSTHOG_HOST=${POSTHOG_HOST}
+          VITE_OIDC_CLIENT_ID=${OIDC_CLIENT_ID}
+          VITE_OIDC_ROOT_URL=${OIDC_ROOT_URL}
+          EOF
+
+      - name: Build the frontend's static assets
+        id: addon-frontend-build
+        env:
+          BASE_URL: "https://send.tb.pro"
+          ENV: "prod"
+          IS_CI_AUTOMATION: yes
+        run: |
+          # install packages that addon depends on
+          pnpm install --filter tbpro-shared
+          pnpm install --filter addon
+          pnpm install --filter send-frontend
+
+          lerna run build --scope=addon
+
+          cd packages/addon/
+
+          # Find build addon xpi file
+          XPI="$(find tbpro-addon-*.xpi)"
+
+          # create now file name for env
+          RENAMED_XPI="tbpro-addon-${ENV}-$(basename "$XPI" | cut -d "-" -f3-)"
+
+          # rename the file by moving
+          mv -v "${XPI}" "${RENAMED_XPI}"
+
+          # export outputs for use in next steps
+          echo "xpi_filename=$RENAMED_XPI" >> "$GITHUB_OUTPUT"
+          echo "xpi_file_path=packages/addon/$RENAMED_XPI" >> "$GITHUB_OUTPUT"
+
+      - name: Archive the XPI
+        id: xpi-archive-addon
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.addon-frontend-build.outputs.xpi_filename }}
+          path: ${{ steps.addon-frontend-build.outputs.xpi_file_path }}
+          compression-level: 0 # <-- don't zip!
+
+      # NOTE: No ATN sign step here — prod ATN publishing happens in release.yml
+      # (deploy-addon-prod-atn). This preserves existing behavior from the
+      # original matrix job where the ATN step was gated to stage only.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,7 +157,13 @@ jobs:
 
   frontend-invalidate-prod-cdn:
     needs: ["frontend-deploy-prod-aws", "backend-deploy-prod-aws"]
-    if: ${{ needs.frontend-deploy-prod-aws.result == 'success' && needs.backend-deploy-prod-aws.result == 'success' && needs.frontend-deploy-prod-aws.outputs.s3_deployed == 'true' && needs.backend-deploy-prod-aws.outputs.ecs_deployed == 'true' }}
+    if: |
+      ${{
+        needs.frontend-deploy-prod-aws.result == 'success' &&
+        needs.backend-deploy-prod-aws.result == 'success' &&
+        needs.frontend-deploy-prod-aws.outputs.s3_deployed == 'true' &&
+        needs.backend-deploy-prod-aws.outputs.ecs_deployed == 'true'
+      }}
     runs-on: ubuntu-latest
     environment:
       name: send-prod

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,13 +157,8 @@ jobs:
 
   frontend-invalidate-prod-cdn:
     needs: ["frontend-deploy-prod-aws", "backend-deploy-prod-aws"]
-    if: |
-      ${{
-        needs.frontend-deploy-prod-aws.result == 'success' &&
-        needs.backend-deploy-prod-aws.result == 'success' &&
-        needs.frontend-deploy-prod-aws.outputs.s3_deployed == 'true' &&
-        needs.backend-deploy-prod-aws.outputs.ecs_deployed == 'true'
-      }}
+    # yamllint disable-line rule:line-length
+    if: ${{ needs.frontend-deploy-prod-aws.result == 'success' && needs.backend-deploy-prod-aws.result == 'success' && needs.frontend-deploy-prod-aws.outputs.s3_deployed == 'true' && needs.backend-deploy-prod-aws.outputs.ecs_deployed == 'true' }}
     runs-on: ubuntu-latest
     environment:
       name: send-prod

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,8 +157,8 @@ jobs:
 
   frontend-invalidate-prod-cdn:
     needs: ["frontend-deploy-prod-aws", "backend-deploy-prod-aws"]
-    # yamllint disable-line rule:line-length
-    if: ${{ needs.frontend-deploy-prod-aws.result == 'success' && needs.backend-deploy-prod-aws.result == 'success' && needs.frontend-deploy-prod-aws.outputs.s3_deployed == 'true' && needs.backend-deploy-prod-aws.outputs.ecs_deployed == 'true' }}
+    # yamllint disable-next-line rule:line-length
+    if: needs.frontend-deploy-prod-aws.result == 'success' && needs.backend-deploy-prod-aws.result == 'success' && needs.frontend-deploy-prod-aws.outputs.s3_deployed == 'true' && needs.backend-deploy-prod-aws.outputs.ecs_deployed == 'true'
     runs-on: ubuntu-latest
     environment:
       name: send-prod
@@ -223,9 +223,10 @@ jobs:
 
       - name: Assert ATN signing success
         if: always() && steps.find-addon.outputs.xpi_name != ''
+        env:
+          OUTCOME: ${{ steps.web-ext-sign-prod-addon.outcome }}
         run: |
-          outcome="${{ steps.web-ext-sign-prod-addon.outcome }}"
-          if [[ "$outcome" != "success" && "$outcome" != "skipped" ]]; then
-            echo "::error::ATN addon signing failed (outcome: $outcome)"
+          if [[ "$OUTCOME" != "success" && "$OUTCOME" != "skipped" ]]; then
+            echo "::error::ATN addon signing failed (outcome: $OUTCOME)"
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,7 +223,8 @@ jobs:
       - name: Assert ATN signing success
         if: always() && steps.find-addon.outputs.xpi_name != ''
         run: |
-          if [[ "${{ steps.web-ext-sign-prod-addon.outcome }}" != "success" ]]; then
-            echo "ATN addon signing failed"
+          outcome="${{ steps.web-ext-sign-prod-addon.outcome }}"
+          if [[ "$outcome" != "success" && "$outcome" != "skipped" ]]; then
+            echo "::error::ATN addon signing failed (outcome: $outcome)"
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,7 +157,7 @@ jobs:
 
   frontend-invalidate-prod-cdn:
     needs: ["frontend-deploy-prod-aws", "backend-deploy-prod-aws"]
-    if: ${{ needs.frontend-deploy-prod-aws.outputs.s3_deployed == 'true' && needs.backend-deploy-prod-aws.outputs.ecs_deployed == 'true' }}
+    if: ${{ needs.frontend-deploy-prod-aws.result == 'success' && needs.backend-deploy-prod-aws.result == 'success' && needs.frontend-deploy-prod-aws.outputs.s3_deployed == 'true' && needs.backend-deploy-prod-aws.outputs.ecs_deployed == 'true' }}
     runs-on: ubuntu-latest
     environment:
       name: send-prod
@@ -219,3 +219,11 @@ jobs:
           apiUrlPrefix: "https://addons.thunderbird.net/api/v4"
           apiKey: ${{ secrets.ATN_API_KEY }}
           apiSecret: ${{ secrets.ATN_API_SECRET }}
+
+      - name: Assert ATN signing success
+        if: always() && steps.find-addon.outputs.xpi_name != ''
+        run: |
+          if [[ "${{ steps.web-ext-sign-prod-addon.outcome }}" != "success" ]]; then
+            echo "ATN addon signing failed"
+            exit 1
+          fi


### PR DESCRIPTION
Closes #730

Part of CI/CD umbrella #728.

## Summary

Three fixes to CI/CD workflows (`merge.yml`, `release.yml`) addressing silent failures and environment-context mis-scoping on deploy.

### Fix 1 — Matrix env scoping in merge.yml

The `frontend-build` and `addon-changes` matrix jobs (two entries each: `stage`/`prod`) were declared with a single top-level `environment: send-stage`. In GitHub Actions the job-level `environment:` field is not parameterizable by matrix, so both iterations ran under `send-stage`, pulling stage-scoped environment variables and secrets at runtime. Matrix-gated ternary expressions (`matrix.env == 'stage' && secrets.X_STAGE || secrets.X_PROD`) were required to fake the split, and the "prod" artifact was still being built under a stage environment context.

Both matrix jobs are split into dedicated per-environment jobs:

- `frontend-build` -> `frontend-build-stage` (environment: `send-stage`, literal stage URLs, `*_STAGE` secrets) and `frontend-build-prod` (environment: `send-prod`, literal prod URLs, `*_PROD` secrets). Artifacts remain `dist-web-stage`/`xpi-stage` and `dist-web-prod`/`xpi-prod` — consumed unchanged by `release.yml`.
- `addon-changes` -> `addon-changes-stage` (keeps the ATN sign step; env: `send-stage`) and `addon-changes-prod` (env: `send-prod`; NO ATN sign — matches current behavior, as prod ATN publishing happens in `release.yml`'s `deploy-addon-prod-atn`).

Downstream `needs:` updated: `frontend-deploy-stage-aws` now depends on `frontend-build-stage`. `backend-deploy-stage-aws` and `frontend-invalidate-stage-cdn` did not directly reference the build jobs — no change required.

### Fix 2 — release.yml prod CDN gate

`frontend-invalidate-prod-cdn` at `release.yml:160` previously only checked `*.outputs.*_deployed == 'true'`. If a deploy job set its output but then failed in a later step, the gate would still trigger a CDN invalidation over a half-deployed release. Added `.result == 'success'` conjuncts for both `frontend-deploy-prod-aws` and `backend-deploy-prod-aws`.

### Fix 3 — ATN signing assertion

`kewisch/action-web-ext@v1` invocations in both workflows use `continue-on-error: true`, so ATN upload failures were reported as green. Added an `Assert ATN signing success` step after each sign step (ids: `web-ext-sign-stage-addon` in merge.yml and `web-ext-sign-prod-addon` in release.yml) that inspects `steps.<id>.outcome` and fails the job loudly if the sign step did not succeed.

## Verification

- [x] `frontend-build-stage` runs under `send-stage` with stage secrets; `frontend-build-prod` runs under `send-prod` with prod secrets
- [x] `frontend-invalidate-prod-cdn` only fires when both prod deploy jobs report `result == 'success'` and their `*_deployed` outputs are `true`
- [x] An ATN signing failure causes the containing job to fail rather than silently pass
- [x] `actionlint` passes clean on both workflows

Draft for review — part of CI/CD umbrella #728.

## Deployment stage graph — before (current main, matrix bug)

```mermaid
flowchart TD
    Push[Push to main]:::evt
    Push --> DC[detect-changes]:::job

    DC --> BBS[backend-build-stage<br/>env: send-stage]:::stage
    BBS --> BDS[backend-deploy-stage-aws<br/>env: send-stage]:::stage
    BDS --> ECS[ECS stage stable]:::res

    DC --> FBM["frontend-build<br/>⚠️ env: send-stage<br/>matrix: [stage, prod]"]:::bug
    FBM -->|matrix=stage| DWS[(dist-web-stage<br/>xpi-stage)]:::art
    FBM -->|"matrix=prod<br/>🐛 runs under send-stage env<br/>pulls _STAGE secrets"| DWP[(dist-web-prod<br/>xpi-prod)]:::bugart

    DWS --> FDS[frontend-deploy-stage-aws<br/>env: send-stage]:::stage
    FDS --> S3S[S3 stage bucket]:::res
    FDS --> FICS[frontend-invalidate-stage-cdn]:::stage
    BDS --> FICS
    FICS --> CFS[CloudFront stage invalidated]:::res

    DC --> ACM["addon-changes<br/>⚠️ env: send-stage<br/>matrix: [stage, prod]"]:::bug
    ACM -->|matrix=stage| ATNSIG[web-ext sign → ATN<br/>continue-on-error: true]:::stage
    ACM -->|"matrix=prod<br/>🐛 prod XPI built under stage env"| XPP[(prod XPI artifact)]:::bugart
    ATNSIG -.silent fail possible.-> ATN[addons.thunderbird.net]:::res

    DWP -.attached to draft release.-> Release[(GitHub release<br/>manually created)]:::manual

    classDef job fill:#1f2937,color:#fff,stroke:#374151
    classDef stage fill:#065f46,color:#fff,stroke:#10b981
    classDef bug fill:#7f1d1d,color:#fff,stroke:#ef4444,stroke-width:3px
    classDef bugart fill:#7f1d1d,color:#fff,stroke:#ef4444,stroke-dasharray: 5 5
    classDef art fill:#1e3a8a,color:#fff,stroke:#3b82f6
    classDef res fill:#374151,color:#fff,stroke:#6b7280
    classDef evt fill:#000,color:#fff,stroke:#fff
    classDef manual fill:#78350f,color:#fff,stroke:#f59e0b
```

## Deployment stage graph — after (this change)

```mermaid
flowchart TD
    Push[Push to main]:::evt
    Push --> DC[detect-changes]:::job

    DC --> BBS[backend-build-stage<br/>env: send-stage]:::stage
    BBS --> BDS[backend-deploy-stage-aws<br/>env: send-stage]:::stage
    BDS --> ECS[ECS stage stable]:::res

    DC --> FBS[frontend-build-stage<br/>env: send-stage<br/>literal stage URLs<br/>_STAGE secrets]:::stage
    FBS --> DWS[(dist-web-stage<br/>xpi-stage)]:::art

    DC --> FBP[frontend-build-prod<br/>env: send-prod<br/>literal prod URLs<br/>_PROD secrets]:::prod
    FBP --> DWP[(dist-web-prod<br/>xpi-prod)]:::art

    DWS --> FDS[frontend-deploy-stage-aws<br/>env: send-stage]:::stage
    FDS --> S3S[S3 stage bucket]:::res
    FDS --> FICS[frontend-invalidate-stage-cdn]:::stage
    BDS --> FICS
    FICS --> CFS[CloudFront stage invalidated]:::res

    DC --> ACS[addon-changes-stage<br/>env: send-stage<br/>_STAGE secrets]:::stage
    ACS --> ATNSIG[web-ext sign → ATN<br/>continue-on-error: true]:::stage
    ATNSIG --> ASSERT[Assert ATN signing success<br/>if: always<br/>fails job on outcome ≠ success/skipped]:::gate
    ASSERT --> ATN[addons.thunderbird.net]:::res

    DC --> ACP[addon-changes-prod<br/>env: send-prod<br/>_PROD secrets<br/>no ATN sign here]:::prod
    ACP --> PXPI[(prod XPI artifact<br/>awaits release.yml)]:::art

    DWP -.attached to draft release.-> Release[(GitHub release<br/>TODO: auto-draft in #735)]:::future
    PXPI -.attached to draft release.-> Release

    classDef job fill:#1f2937,color:#fff,stroke:#374151
    classDef stage fill:#065f46,color:#fff,stroke:#10b981
    classDef prod fill:#1e40af,color:#fff,stroke:#60a5fa
    classDef art fill:#312e81,color:#fff,stroke:#6366f1
    classDef res fill:#374151,color:#fff,stroke:#6b7280
    classDef gate fill:#9a3412,color:#fff,stroke:#fb923c,stroke-width:2px
    classDef evt fill:#000,color:#fff,stroke:#fff
    classDef future fill:#4c1d95,color:#fff,stroke:#a78bfa,stroke-dasharray: 5 5
```

Key before→after: single matrixed `frontend-build` (red, misrouted prod) → two explicit per-env jobs (green=stage, blue=prod). Same pattern for `addon-changes`. New orange `Assert ATN signing` gate closes the silent-failure path.