### PR TITLE
chore(pulumi): remove legacy IAM automation user

### DIFF
--- a/packages/send/pulumi/__main__.py
+++ b/packages/send/pulumi/__main__.py
@@ -2,7 +2,6 @@
 
 import tb_pulumi
 import tb_pulumi.autoscale
-import tb_pulumi.ci
 import tb_pulumi.cloudfront
 import tb_pulumi.cloudwatch
 import tb_pulumi.fargate
@@ -74,11 +73,6 @@ monitoring = tb_pulumi.cloudwatch.CloudWatchMonitoringGroup(
     notify_emails=monitoring_opts['notify_emails'],
     config=monitoring_opts,
 )
-
-# Set up an IAM user for automation purposes
-auto_users_opts = resources.get('tb:ci:AwsAutomationUser', {})
-for user, user_opts in auto_users_opts.items():
-    tb_pulumi.ci.AwsAutomationUser(f'{project.name_prefix}-{user}', project=project, **user_opts)
 
 # Set up IAM policies and groups to grant environment-bounded access to these resources
 sap = tb_pulumi.iam.StackAccessPolicies(

--- a/packages/send/pulumi/config.prod.yaml
+++ b/packages/send/pulumi/config.prod.yaml
@@ -200,22 +200,3 @@ resources:
     #     cpu_utilization:
     #       enabled: False
     #       threshold: 80
-
-  tb:ci:AwsAutomationUser:
-    ci:
-      access_keys: {}
-      enable_legacy_access_key: True
-      additional_policies:
-        - arn:aws:iam::768512802988:policy/send-suite-prod-frontend-cache-invalidation
-      enable_ecr_image_push: true
-      ecr_repositories:
-        - send
-      enable_fargate_deployments: true
-      fargate_clusters:
-        - send-suite-prod-fargate
-      fargate_task_role_arns:
-        - arn:aws:iam::768512802988:role/send-suite-prod-fargate
-      enable_full_s3_access: false
-      enable_s3_bucket_upload: true
-      s3_upload_buckets:
-        - tb-send-suite-prod-frontend

--- a/packages/send/pulumi/config.stage.yaml
+++ b/packages/send/pulumi/config.stage.yaml
@@ -200,22 +200,3 @@ resources:
     #     cpu_utilization:
     #       enabled: False
     #       threshold: 80
-
-  tb:ci:AwsAutomationUser:
-    ci:
-      access_keys: {}
-      enable_legacy_access_key: True
-      # additional_policies:
-      #   - arn:aws:iam::768512802988:policy/send-suite-stage-frontend-cache-invalidation
-      enable_ecr_image_push: true
-      ecr_repositories:
-        - send
-      enable_fargate_deployments: true
-      fargate_clusters:
-        - send-suite-stage-fargate
-      fargate_task_role_arns:
-        - arn:aws:iam::768512802988:role/send-suite-stage-fargate
-      enable_full_s3_access: false
-      enable_s3_bucket_upload: true
-      s3_upload_buckets:
-        - tb-send-suite-stage-frontend


### PR DESCRIPTION
## Summary

- Removes `tb_pulumi.ci.AwsAutomationUser` from `packages/send/pulumi/__main__.py` and drops the `tb:ci:AwsAutomationUser` config from both `config.prod.yaml` and `config.stage.yaml`
- OIDC soak complete: v1.7.4 (2026-04-27) confirmed successful prod deploy via OIDC; CloudTrail shows zero `AccessDenied` events for `send-suite-{prod,stage}-ci` since cutover (2026-04-22)

## Follow-up (after merge)

- [x] `pulumi up` in the send stack to destroy the IAM user resources
- [x] Confirm IAM users gone: `aws iam get-user --user-name send-suite-{prod,stage}-ci --profile mzla-legacy`
- [x] Delete `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` from `send-stage` and `send-prod` GitHub Environments
- [x] Update `docs/oidc-migration-inventory.md` row 3 — mark migration complete
- [x] Close thunderbird/platform-infrastructure#248 and thunderbird/platform-infrastructure#205

Part of thunderbird/platform-infrastructure#248.

🤖 Generated with [Claude Code](https://claude.com/claude-code)