### PR TITLE
fix(send): prevent orphaned containers causing decrypt errors

### DIFF
--- a/packages/send/frontend/src/apps/send/stores/folder-store.ts
+++ b/packages/send/frontend/src/apps/send/stores/folder-store.ts
@@ -199,11 +199,24 @@ const useFolderStore = defineStore('folderManager', () => {
 
     if (containerResponse?.container) {
       const { container } = containerResponse;
-      folders.value = [...folders.value, container];
-      await keychain.newKeyForContainer(container.id);
-      await backupKeys(keychain, api, msg);
-      await keychain.store();
-      return container;
+      try {
+        await keychain.newKeyForContainer(container.id);
+        await backupKeys(keychain, api, msg);
+        await keychain.store();
+        folders.value = [...folders.value, container];
+        return container;
+      } catch (error) {
+        console.error(
+          `Failed to set up key for container ${container.id}, rolling back`,
+          error
+        );
+        try {
+          await api.call(`containers/${container.id}`, {}, 'DELETE');
+        } catch (deleteError) {
+          console.error('Failed to roll back container creation', deleteError);
+        }
+        return null;
+      }
     }
     return null;
   }

--- a/packages/send/frontend/src/lib/helpers.ts
+++ b/packages/send/frontend/src/lib/helpers.ts
@@ -2,6 +2,7 @@ import useFolderStore, {
   FolderStore,
 } from '@send-frontend/apps/send/stores/folder-store';
 import { ProgressTracker } from '@send-frontend/apps/send/stores/status-store';
+import { INIT_ERRORS } from '@send-frontend/apps/send/const';
 import init from '@send-frontend/lib/init';
 import { UserStoreType } from '@send-frontend/stores/user-store';
 import { Canceler, JsonResponse } from '@send-frontend/types';
@@ -244,7 +245,12 @@ export async function dbUserSetup(
   // - loading user from storage
   // - loading keychain from storage
   // - creating the default folder
-  await init(userStore, keychain, folderStore);
+  const initResult = await init(userStore, keychain, folderStore);
+  if (initResult !== INIT_ERRORS.NONE) {
+    console.error(
+      `User setup incomplete — init() returned error: ${Object.keys(INIT_ERRORS)[initResult]}`
+    );
+  }
 }
 
 /* This function is a short hand to get the meta records from the route */
@@ -268,10 +274,7 @@ export const uploadWithTracker = ({
   const HTTP_RETRY_DELAY_MS = 1000;
   const XHR_TIMEOUT_MS = 30000;
 
-  const attemptPut = (
-    blob: Blob,
-    attempt: number
-  ): Promise<string> => {
+  const attemptPut = (blob: Blob, attempt: number): Promise<string> => {
     // Reset progress on retry so the UI gets a clean signal
     // rather than silently jumping backwards
     if (attempt > 0) {
@@ -302,8 +305,7 @@ export const uploadWithTracker = ({
       };
 
       xhr.onerror = () => reject(new Error('XHR: UPLOAD_FAILED'));
-      xhr.ontimeout = () =>
-        reject(new Error('Upload timed out after 30s'));
+      xhr.ontimeout = () => reject(new Error('Upload timed out after 30s'));
 
       xhr.send(blob);
     }).catch((error) => {

--- a/packages/send/frontend/src/lib/init.ts
+++ b/packages/send/frontend/src/lib/init.ts
@@ -28,7 +28,18 @@ async function init(
   }
 
   await folderStore.sync();
-  if (!folderStore?.defaultFolder) {
+  const defaultFolder = folderStore?.defaultFolder;
+  const defaultFolderKeyIsMissing =
+    defaultFolder && !keychain.keys[defaultFolder.id];
+
+  if (defaultFolderKeyIsMissing) {
+    console.warn(
+      `Default folder ${defaultFolder.id} exists but has no key. Deleting orphaned container and recreating.`
+    );
+    await folderStore.deleteFolder(defaultFolder.id);
+  }
+
+  if (!defaultFolder || defaultFolderKeyIsMissing) {
     const createFolderResp = await folderStore.createFolder();
     if (!createFolderResp?.id) {
       return INIT_ERRORS.COULD_NOT_CREATE_DEFAULT_FOLDER;

--- a/packages/send/frontend/src/test/lib/helpers.test.ts
+++ b/packages/send/frontend/src/test/lib/helpers.test.ts
@@ -1,0 +1,144 @@
+import { INIT_ERRORS } from '@send-frontend/apps/send/const';
+import { dbUserSetup } from '@send-frontend/lib/helpers';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock init so we can control the error code it returns without exercising
+// the full init() logic (which has its own test file).
+vi.mock('@send-frontend/lib/init', () => ({
+  default: vi.fn().mockResolvedValue(INIT_ERRORS.NONE),
+}));
+
+// Import after the mock so vi.mocked() resolves correctly.
+import init from '@send-frontend/lib/init';
+
+// ---------------------------------------------------------------------------
+// Helper factories
+// ---------------------------------------------------------------------------
+
+function makeUserStore({ publicKey = 'existing-jwk' as string | null } = {}) {
+  return {
+    populateFromBackend: vi.fn().mockResolvedValue(true),
+    store: vi.fn().mockResolvedValue(undefined),
+    getPublicKey: vi.fn().mockResolvedValue(publicKey),
+    updatePublicKey: vi.fn().mockResolvedValue(true),
+  };
+}
+
+function makeKeychain() {
+  return {
+    rsa: {
+      generateKeyPair: vi.fn().mockResolvedValue({}),
+      getPublicKeyJwk: vi.fn().mockResolvedValue('generated-jwk-string'),
+    },
+    store: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+const stubFolderStore = {} as any;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('dbUserSetup()', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.mocked(init).mockResolvedValue(INIT_ERRORS.NONE);
+    consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  // --- Early exit ---
+
+  it('returns early without calling init when populateFromBackend fails', async () => {
+    const userStore = makeUserStore();
+    userStore.populateFromBackend.mockResolvedValue(false);
+    const keychain = makeKeychain();
+
+    await dbUserSetup(userStore as any, keychain as any, stubFolderStore);
+
+    expect(vi.mocked(init)).not.toHaveBeenCalled();
+    expect(consoleSpy).not.toHaveBeenCalled();
+  });
+
+  // --- Existing user (public key already on backend) ---
+
+  it('skips keypair generation for an existing user that already has a public key', async () => {
+    const userStore = makeUserStore({ publicKey: 'already-stored-key' });
+    const keychain = makeKeychain();
+
+    await dbUserSetup(userStore as any, keychain as any, stubFolderStore);
+
+    expect(keychain.rsa.generateKeyPair).not.toHaveBeenCalled();
+    expect(keychain.store).not.toHaveBeenCalled();
+  });
+
+  // --- New user (no public key on backend yet) ---
+
+  it('generates and stores an RSA keypair for a new user with no public key', async () => {
+    const userStore = makeUserStore({ publicKey: null });
+    const keychain = makeKeychain();
+
+    await dbUserSetup(userStore as any, keychain as any, stubFolderStore);
+
+    expect(keychain.rsa.generateKeyPair).toHaveBeenCalledOnce();
+    expect(keychain.store).toHaveBeenCalledOnce();
+    expect(userStore.updatePublicKey).toHaveBeenCalledWith(
+      'generated-jwk-string'
+    );
+  });
+
+  // --- init() return value handling (new behaviour) ---
+
+  it('does not log an error when init() returns NONE', async () => {
+    vi.mocked(init).mockResolvedValue(INIT_ERRORS.NONE);
+    const userStore = makeUserStore();
+
+    await dbUserSetup(userStore as any, makeKeychain() as any, stubFolderStore);
+
+    expect(consoleSpy).not.toHaveBeenCalled();
+  });
+
+  it('logs an error when init() returns NO_KEYCHAIN', async () => {
+    vi.mocked(init).mockResolvedValue(INIT_ERRORS.NO_KEYCHAIN);
+    const userStore = makeUserStore();
+
+    await dbUserSetup(userStore as any, makeKeychain() as any, stubFolderStore);
+
+    expect(consoleSpy).toHaveBeenCalledOnce();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('NO_KEYCHAIN')
+    );
+  });
+
+  it('logs an error when init() returns COULD_NOT_CREATE_DEFAULT_FOLDER', async () => {
+    vi.mocked(init).mockResolvedValue(
+      INIT_ERRORS.COULD_NOT_CREATE_DEFAULT_FOLDER
+    );
+    const userStore = makeUserStore();
+
+    await dbUserSetup(userStore as any, makeKeychain() as any, stubFolderStore);
+
+    expect(consoleSpy).toHaveBeenCalledOnce();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('COULD_NOT_CREATE_DEFAULT_FOLDER')
+    );
+  });
+
+  it('passes the correct arguments to init()', async () => {
+    const userStore = makeUserStore();
+    const keychain = makeKeychain();
+
+    await dbUserSetup(userStore as any, keychain as any, stubFolderStore);
+
+    expect(vi.mocked(init)).toHaveBeenCalledWith(
+      userStore,
+      keychain,
+      stubFolderStore
+    );
+  });
+});

--- a/packages/send/frontend/src/test/lib/init.test.ts
+++ b/packages/send/frontend/src/test/lib/init.test.ts
@@ -1,0 +1,209 @@
+import { INIT_ERRORS } from '@send-frontend/apps/send/const';
+import init from '@send-frontend/lib/init';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Helper factories — produce minimal duck-typed stand-ins for each dependency
+// ---------------------------------------------------------------------------
+
+function makeUserStore({ hasUser = true } = {}) {
+  return {
+    loadFromLocalStorage: vi.fn().mockResolvedValue(hasUser),
+  };
+}
+
+/**
+ * Build a minimal Keychain stand-in.
+ * @param keysMap - Pre-seeded key map ({ [containerId]: 'wrapped-key' })
+ * @param hasKeychain - What `keychain.load()` resolves to
+ */
+function makeKeychain(
+  keysMap: Record<string, string> = {},
+  { hasKeychain = true } = {}
+) {
+  return {
+    load: vi.fn().mockResolvedValue(hasKeychain),
+    get keys() {
+      return keysMap;
+    },
+  };
+}
+
+function makeFolderStore({
+  defaultFolder = null as { id: string } | null,
+  createFolderResult = { id: 'new-folder-id' } as { id: string } | null,
+} = {}) {
+  // `defaultFolder` is a getter so that tests can observe state changes after
+  // `deleteFolder` is called (mirroring how the real store reacts).
+  let _defaultFolder = defaultFolder;
+  return {
+    sync: vi.fn().mockImplementation(async () => {}),
+    get defaultFolder() {
+      return _defaultFolder;
+    },
+    createFolder: vi.fn().mockResolvedValue(createFolderResult),
+    deleteFolder: vi.fn().mockImplementation(async () => {
+      _defaultFolder = null;
+    }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('init()', () => {
+  // Re-create fresh mocks for every test to avoid cross-test state leakage
+  let userStore: ReturnType<typeof makeUserStore>;
+  let keychain: ReturnType<typeof makeKeychain>;
+  let folderStore: ReturnType<typeof makeFolderStore>;
+
+  beforeEach(() => {
+    userStore = makeUserStore();
+    keychain = makeKeychain();
+    folderStore = makeFolderStore();
+  });
+
+  // --- Early-exit error paths (pre-existing behaviour — regression tests) ---
+
+  it('returns NO_USER when user cannot be loaded from storage', async () => {
+    userStore = makeUserStore({ hasUser: false });
+
+    const result = await init(
+      userStore as any,
+      keychain as any,
+      folderStore as any
+    );
+
+    expect(result).toBe(INIT_ERRORS.NO_USER);
+    // Must not proceed to folder operations
+    expect(folderStore.sync).not.toHaveBeenCalled();
+  });
+
+  it('returns NO_KEYCHAIN when keychain cannot be loaded', async () => {
+    keychain = makeKeychain({}, { hasKeychain: false });
+
+    const result = await init(
+      userStore as any,
+      keychain as any,
+      folderStore as any
+    );
+
+    expect(result).toBe(INIT_ERRORS.NO_KEYCHAIN);
+    expect(folderStore.sync).not.toHaveBeenCalled();
+  });
+
+  // --- Happy path: no existing default folder ---
+
+  it('creates a default folder when none exists and returns NONE', async () => {
+    folderStore = makeFolderStore({ defaultFolder: null });
+
+    const result = await init(
+      userStore as any,
+      keychain as any,
+      folderStore as any
+    );
+
+    expect(folderStore.sync).toHaveBeenCalledOnce();
+    expect(folderStore.createFolder).toHaveBeenCalledOnce();
+    expect(result).toBe(INIT_ERRORS.NONE);
+  });
+
+  it('returns COULD_NOT_CREATE_DEFAULT_FOLDER when createFolder returns null', async () => {
+    folderStore = makeFolderStore({
+      defaultFolder: null,
+      createFolderResult: null,
+    });
+
+    const result = await init(
+      userStore as any,
+      keychain as any,
+      folderStore as any
+    );
+
+    expect(result).toBe(INIT_ERRORS.COULD_NOT_CREATE_DEFAULT_FOLDER);
+  });
+
+  it('returns COULD_NOT_CREATE_DEFAULT_FOLDER when createFolder returns an object without id', async () => {
+    folderStore = makeFolderStore({
+      defaultFolder: null,
+      createFolderResult: {} as any,
+    });
+
+    const result = await init(
+      userStore as any,
+      keychain as any,
+      folderStore as any
+    );
+
+    expect(result).toBe(INIT_ERRORS.COULD_NOT_CREATE_DEFAULT_FOLDER);
+  });
+
+  // --- Happy path: default folder exists with a valid key ---
+
+  it('skips folder creation when default folder has a key in the keychain', async () => {
+    const folderId = 'folder-abc123';
+    folderStore = makeFolderStore({ defaultFolder: { id: folderId } });
+    keychain = makeKeychain({ [folderId]: 'wrapped-key-string' });
+
+    const result = await init(
+      userStore as any,
+      keychain as any,
+      folderStore as any
+    );
+
+    expect(folderStore.deleteFolder).not.toHaveBeenCalled();
+    expect(folderStore.createFolder).not.toHaveBeenCalled();
+    expect(result).toBe(INIT_ERRORS.NONE);
+  });
+
+  // --- New behaviour: orphaned container detection ---
+
+  it('deletes orphaned container and creates a new folder when key is missing', async () => {
+    const orphanId = 'orphaned-container-id';
+    folderStore = makeFolderStore({
+      defaultFolder: { id: orphanId },
+      createFolderResult: { id: 'fresh-folder-id' },
+    });
+    // No key for the orphan in the keychain
+    keychain = makeKeychain({});
+
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = await init(
+      userStore as any,
+      keychain as any,
+      folderStore as any
+    );
+
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining(orphanId));
+    expect(folderStore.deleteFolder).toHaveBeenCalledWith(orphanId);
+    expect(folderStore.createFolder).toHaveBeenCalledOnce();
+    expect(result).toBe(INIT_ERRORS.NONE);
+
+    consoleSpy.mockRestore();
+  });
+
+  it('returns COULD_NOT_CREATE_DEFAULT_FOLDER when recreation fails after orphan deletion', async () => {
+    const orphanId = 'orphaned-container-id';
+    folderStore = makeFolderStore({
+      defaultFolder: { id: orphanId },
+      createFolderResult: null,
+    });
+    keychain = makeKeychain({});
+
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = await init(
+      userStore as any,
+      keychain as any,
+      folderStore as any
+    );
+
+    expect(folderStore.deleteFolder).toHaveBeenCalledWith(orphanId);
+    expect(folderStore.createFolder).toHaveBeenCalledOnce();
+    expect(result).toBe(INIT_ERRORS.COULD_NOT_CREATE_DEFAULT_FOLDER);
+
+    vi.restoreAllMocks();
+  });
+});

--- a/packages/send/frontend/src/test/stores/folder-store.test.ts
+++ b/packages/send/frontend/src/test/stores/folder-store.test.ts
@@ -1,0 +1,237 @@
+import useFolderStore from '@send-frontend/apps/send/stores/folder-store';
+import useApiStore from '@send-frontend/stores/api-store';
+import useKeychainStore from '@send-frontend/stores/keychain-store';
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+// Mock `backupKeys` in-place, but preserve `Keychain` (used for types/instances
+// in the store) by spreading the original module.
+vi.mock('@send-frontend/lib/keychain', async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import('@send-frontend/lib/keychain')>();
+  return {
+    ...original,
+    backupKeys: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+// Prevent real tRPC calls that fire in `onMounted`.
+vi.mock('@send-frontend/lib/trpc', () => ({
+  trpc: {
+    getDefaultFolder: { query: vi.fn().mockResolvedValue({ id: null }) },
+  },
+}));
+
+// Stub heavy classes that are irrelevant to createFolder().
+// Regular (non-arrow) functions must be used so they can be called with `new`.
+vi.mock('@send-frontend/lib/upload', () => ({
+  default: vi.fn(function () {}),
+}));
+vi.mock('@send-frontend/lib/download', () => ({
+  default: vi.fn(function () {}),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+import { backupKeys } from '@send-frontend/lib/keychain';
+
+const CONTAINER_ID = 'container-abc';
+const DEFAULT_CONTAINER = { id: CONTAINER_ID, name: 'Default' };
+
+/** Set up the api.call spy. First call returns a successful POST response. */
+function mockCreateContainerSuccess() {
+  return vi
+    .spyOn(useApiStore().api, 'call')
+    .mockResolvedValue({ container: DEFAULT_CONTAINER });
+}
+
+function mockCreateContainerThenDelete() {
+  return vi
+    .spyOn(useApiStore().api, 'call')
+    .mockResolvedValueOnce({ container: DEFAULT_CONTAINER }) // POST containers
+    .mockResolvedValueOnce(undefined); // DELETE containers/:id
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('FolderStore — createFolder()', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    // Clear call history accumulated by module-level mocks across tests.
+    vi.clearAllMocks();
+    // Suppress expected console.error output so test output stays clean.
+    consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+    vi.restoreAllMocks();
+  });
+
+  // --- Happy path ---
+
+  it('returns the created container when key setup succeeds', async () => {
+    mockCreateContainerSuccess();
+    vi.spyOn(
+      useKeychainStore().keychain,
+      'newKeyForContainer'
+    ).mockResolvedValue(undefined);
+    vi.spyOn(useKeychainStore().keychain, 'store').mockResolvedValue(undefined);
+
+    const folderStore = useFolderStore();
+    const result = await folderStore.createFolder();
+
+    expect(result).toMatchObject({ id: CONTAINER_ID });
+  });
+
+  it('stores keys and backs them up when key setup succeeds', async () => {
+    mockCreateContainerSuccess();
+    const newKeySpy = vi
+      .spyOn(useKeychainStore().keychain, 'newKeyForContainer')
+      .mockResolvedValue(undefined);
+    const storeSpy = vi
+      .spyOn(useKeychainStore().keychain, 'store')
+      .mockResolvedValue(undefined);
+
+    const folderStore = useFolderStore();
+    await folderStore.createFolder();
+
+    expect(newKeySpy).toHaveBeenCalledWith(CONTAINER_ID);
+    expect(vi.mocked(backupKeys)).toHaveBeenCalledOnce();
+    expect(storeSpy).toHaveBeenCalledOnce();
+  });
+
+  it('adds the container to the store so defaultFolder is non-null after success', async () => {
+    mockCreateContainerSuccess();
+    vi.spyOn(
+      useKeychainStore().keychain,
+      'newKeyForContainer'
+    ).mockResolvedValue(undefined);
+    vi.spyOn(useKeychainStore().keychain, 'store').mockResolvedValue(undefined);
+
+    const folderStore = useFolderStore();
+    await folderStore.createFolder();
+
+    expect(folderStore.defaultFolder).not.toBeNull();
+    expect(folderStore.defaultFolder?.id).toBe(CONTAINER_ID);
+  });
+
+  // --- Rollback on key-setup failure ---
+
+  it('returns null when newKeyForContainer throws', async () => {
+    mockCreateContainerThenDelete();
+    vi.spyOn(
+      useKeychainStore().keychain,
+      'newKeyForContainer'
+    ).mockRejectedValue(new Error('WebCrypto failure'));
+
+    const folderStore = useFolderStore();
+    const result = await folderStore.createFolder();
+
+    expect(result).toBeNull();
+  });
+
+  it('issues a DELETE to roll back the orphaned container when newKeyForContainer throws', async () => {
+    const apiCallSpy = mockCreateContainerThenDelete();
+    vi.spyOn(
+      useKeychainStore().keychain,
+      'newKeyForContainer'
+    ).mockRejectedValue(new Error('Key error'));
+
+    const folderStore = useFolderStore();
+    await folderStore.createFolder();
+
+    expect(apiCallSpy).toHaveBeenCalledWith(
+      `containers/${CONTAINER_ID}`,
+      {},
+      'DELETE'
+    );
+  });
+
+  it('does NOT add the container to the store state when key setup fails', async () => {
+    mockCreateContainerThenDelete();
+    vi.spyOn(
+      useKeychainStore().keychain,
+      'newKeyForContainer'
+    ).mockRejectedValue(new Error('crypto failure'));
+
+    const folderStore = useFolderStore();
+    await folderStore.createFolder();
+
+    expect(folderStore.defaultFolder).toBeNull();
+  });
+
+  it('logs an error when rolling back after a key-setup failure', async () => {
+    mockCreateContainerThenDelete();
+    vi.spyOn(
+      useKeychainStore().keychain,
+      'newKeyForContainer'
+    ).mockRejectedValue(new Error('Key error'));
+
+    const folderStore = useFolderStore();
+    await folderStore.createFolder();
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining(CONTAINER_ID),
+      expect.any(Error)
+    );
+  });
+
+  // --- Double failure: rollback also fails ---
+
+  it('still returns null when both key setup and the DELETE rollback fail', async () => {
+    vi.spyOn(useApiStore().api, 'call')
+      .mockResolvedValueOnce({ container: DEFAULT_CONTAINER }) // POST
+      .mockRejectedValueOnce(new Error('Network error')); // DELETE
+    vi.spyOn(
+      useKeychainStore().keychain,
+      'newKeyForContainer'
+    ).mockRejectedValue(new Error('Key error'));
+
+    const folderStore = useFolderStore();
+    const result = await folderStore.createFolder();
+
+    expect(result).toBeNull();
+  });
+
+  it('logs two errors when both key setup and the DELETE rollback fail', async () => {
+    vi.spyOn(useApiStore().api, 'call')
+      .mockResolvedValueOnce({ container: DEFAULT_CONTAINER })
+      .mockRejectedValueOnce(new Error('Network error'));
+    vi.spyOn(
+      useKeychainStore().keychain,
+      'newKeyForContainer'
+    ).mockRejectedValue(new Error('Key error'));
+
+    const folderStore = useFolderStore();
+    await folderStore.createFolder();
+
+    expect(consoleSpy).toHaveBeenCalledTimes(2);
+  });
+
+  // --- No container in response ---
+
+  it('returns null and makes no key operations when the backend returns no container', async () => {
+    vi.spyOn(useApiStore().api, 'call').mockResolvedValue({});
+    const newKeySpy = vi.spyOn(
+      useKeychainStore().keychain,
+      'newKeyForContainer'
+    );
+
+    const folderStore = useFolderStore();
+    const result = await folderStore.createFolder();
+
+    expect(result).toBeNull();
+    expect(newKeySpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

Three code paths were hardened:

1. createFolder() rollback (folder-store.ts) Previously the container was added to local state before the key was set up. If newKeyForContainer() threw, the backend container was left without a key. The container is now only added to local state after key setup succeeds. On failure a DELETE request rolls back the backend container.

2. Orphaned-container detection in init() (init.ts) On every app init, after syncing folders, the default folder's id is looked up in keychain.keys. If the key is missing the orphaned container is deleted and a fresh one is created with a proper key.

3. init() error propagation in dbUserSetup() (helpers.ts) The return value of init() was previously discarded. It is now checked and logged as an error when setup is incomplete, making silent failures visible in the console.

Tests added (25 new cases):
- src/test/lib/init.test.ts       — orphaned-container detection paths
- src/test/lib/helpers.test.ts    — init() error-code logging
- src/test/stores/folder-store.test.ts — createFolder() rollback behaviour

<!--
  Summarize your change in a few sentences.
  Mention key files, features, or behavior that were updated.

  If you've used AI, we ask you to disclose how much was agent written and to what level of detail
  you participated in the writing. If you are an AI bot, please indicate this clearly.
-->

## Why?

new users could end up with a container on the backend that had no corresponding key in the keychain, triggering the 'You don't have the key to decrypt this container' error from Keychain.get() on subsequent logins.


<!--
  Explain the problem this solves or the goal of the change.
  Link any relevant discussion if helpful.
-->

## Limitations and Notes

<!--
  Optional. List any known gaps, edge cases, or follow up work.
-->

## Applicable Issues

<!--
  Every pull request must have an associated issue.
  Doing so helps us align on the change before you've done the work.

  Using the "Closes #123" format will link pull request and issue.
-->

Closes https://github.com/thunderbird/tbpro-add-on/issues/810

