### PR TITLE
produce system addon (prod) on merge

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -474,6 +474,33 @@ jobs:
           path: ${{ steps.addon-frontend-build.outputs.xpi_file_path }}
           compression-level: 0 # <-- don't zip!
 
+      - name: Build system-add-on XPI for prod
+        if: matrix.env == 'prod'
+        id: system-addon-build
+        run: |
+          PROD_XPI="${{ steps.addon-frontend-build.outputs.xpi_filename }}"
+          VERSION_SUFFIX=$(echo "$PROD_XPI" | cut -d'-' -f4-)
+          SYSTEM_XPI="tbpro-system-add-on-prod-${VERSION_SUFFIX}"
+
+          # Extract, swap the ID in manifest.json, repack
+          mkdir -p /tmp/system-addon-unpack
+          unzip "packages/addon/$PROD_XPI" -d /tmp/system-addon-unpack
+          sed -i 's/"id": "tbpro-add-on@thunderbird.net"/"id": "tbpro-system-add-on@thunderbird.net"/g' /tmp/system-addon-unpack/manifest.json
+          cd /tmp/system-addon-unpack
+          zip -r "$GITHUB_WORKSPACE/packages/addon/$SYSTEM_XPI" .
+
+          echo "system_xpi_filename=$SYSTEM_XPI" >> "$GITHUB_OUTPUT"
+          echo "system_xpi_file_path=packages/addon/$SYSTEM_XPI" >> "$GITHUB_OUTPUT"
+
+      - name: Archive the system-add-on XPI
+        if: matrix.env == 'prod'
+        id: xpi-archive-system-addon
+        uses: actions/upload-artifact@v4
+        with:
+          name: system-add-on-prod
+          path: ${{ steps.system-addon-build.outputs.system_xpi_file_path }}
+          compression-level: 0 # <-- don't zip!
+
       - name: Deploy addon stage to ATN via web-ext
         if: matrix.env == 'stage'
         continue-on-error: true


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

<!--
  Summarize your change in a few sentences.
  Mention key files, features, or behavior that were updated.

  If you've used AI, we ask you to disclose how much was agent written and to what level of detail
  you participated in the writing. If you are an AI bot, please indicate this clearly.
-->

This PR produces the system add-on xpi on merge and renames the manifest (where the id resides) before outputting the xpi.

## Why?

<!--
  Explain the problem this solves or the goal of the change.
  Link any relevant discussion if helpful.
-->

We need a separate xpi to ship with thunderbird so we can modify the currently installed one later

## Limitations and Notes

<!--
  Optional. List any known gaps, edge cases, or follow up work.
-->

This feature creates an exact copy (aside from the id) of the add-on, it doesn't support diverging behaviour

## Applicable Issues

<!--
  Every pull request must have an associated issue.
  Doing so helps us align on the change before you've done the work.

  Using the "Closes #123" format will link pull request and issue.
-->

Closes https://github.com/thunderbird/tbpro-add-on/issues/816
