### PR TITLE
auto install the add-on when version and ID match marked deprecated

### DIFF
--- a/packages/addon/src/background.ts
+++ b/packages/addon/src/background.ts
@@ -40,6 +40,7 @@ import {
   menuLoggedIn,
   menuLogout,
 } from './menu';
+import { checkAndUninstallIfDeprecated } from './selfUninstall';
 
 // Initialize the shared Pinia instance that will be used by both
 // background and extension contexts
@@ -743,6 +744,7 @@ function initAccountHubListener() {
 }
 
 (async function main() {
+  await checkAndUninstallIfDeprecated();
   initMenu();
   initCloudFile();
   initStorageWatcher();

--- a/packages/addon/src/selfUninstall.ts
+++ b/packages/addon/src/selfUninstall.ts
@@ -1,0 +1,62 @@
+/// <reference types="thunderbird-webext-browser" />
+
+const DEPRECATION_ADDON_IDS = ['tbpro-addon-stage@thunderbird.net'];
+
+/**
+ * Compare two semver strings. Returns true if `a >= b`.
+ * Handles standard MAJOR.MINOR.PATCH format.
+ */
+function semverGte(a: string, b: string): boolean {
+  const parse = (v: string) => v.split('.').map(Number);
+  const [aMaj = 0, aMin = 0, aPatch = 0] = parse(a);
+  const [bMaj = 0, bMin = 0, bPatch = 0] = parse(b);
+  if (aMaj !== bMaj) return aMaj > bMaj;
+  if (aMin !== bMin) return aMin > bMin;
+  return aPatch >= bPatch;
+}
+
+/**
+ * On startup, checks whether this addon instance should uninstall itself.
+ *
+ * Uninstall conditions (all must be true):
+ * 1. `VITE_DEPRECATION_VERSION` env var is set at build time.
+ * 2. The running addon ID matches the designated stage ID.
+ * 3. The Thunderbird (Gecko) version is >= the deprecation cutoff version.
+ *
+ * Production builds are unaffected because their addon ID differs.
+ */
+export async function checkAndUninstallIfDeprecated(): Promise<void> {
+  const cutoffVersion = import.meta.env.VITE_DEPRECATION_VERSION;
+
+  if (!cutoffVersion) {
+    console.log(
+      '[self-uninstall] VITE_DEPRECATION_VERSION not set — skipping.'
+    );
+    return;
+  }
+
+  const currentId = browser.runtime.id;
+  if (!DEPRECATION_ADDON_IDS.includes(currentId)) {
+    console.log(
+      `[self-uninstall] Addon ID "${currentId}" does not match any deprecation ID — skipping.`
+    );
+    return;
+  }
+
+  const { version: geckoVersion } = await browser.runtime.getBrowserInfo();
+  console.log(
+    `[self-uninstall] Gecko version: ${geckoVersion}, cutoff: ${cutoffVersion}`
+  );
+
+  if (!semverGte(geckoVersion, cutoffVersion)) {
+    console.log(
+      `[self-uninstall] Version ${geckoVersion} is below cutoff ${cutoffVersion} — skipping.`
+    );
+    return;
+  }
+
+  console.warn(
+    `[self-uninstall] Gecko ${geckoVersion} >= cutoff ${cutoffVersion} and ID matches — uninstalling addon.`
+  );
+  await browser.management.uninstallSelf({ showConfirmDialog: false });
+}

--- a/packages/addon/src/test/selfUninstall.test.ts
+++ b/packages/addon/src/test/selfUninstall.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { checkAndUninstallIfDeprecated } from '../selfUninstall';
+
+const STAGE_ADDON_ID = 'tbpro-addon-stage@thunderbird.net';
+const PROD_ADDON_ID = 'tbpro-add-on@thunderbird.net';
+const CUTOFF_VERSION = '140.0';
+
+function setupBrowserMock(addonId: string, geckoVersion = '145.0') {
+  vi.stubGlobal('browser', {
+    runtime: {
+      id: addonId,
+      getBrowserInfo: vi.fn().mockResolvedValue({ version: geckoVersion }),
+    },
+    management: { uninstallSelf: vi.fn().mockResolvedValue(undefined) },
+  });
+}
+
+function setEnvCutoff(version: string | undefined) {
+  vi.stubEnv('VITE_DEPRECATION_VERSION', version ?? '');
+}
+
+beforeEach(() => {
+  setEnvCutoff(CUTOFF_VERSION);
+  setupBrowserMock(STAGE_ADDON_ID);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+
+describe('checkAndUninstallIfDeprecated', () => {
+  it('uninstalls when ID matches and gecko version >= cutoff', async () => {
+    await checkAndUninstallIfDeprecated();
+
+    expect(browser.management.uninstallSelf).toHaveBeenCalledOnce();
+    expect(browser.management.uninstallSelf).toHaveBeenCalledWith({
+      showConfirmDialog: false,
+    });
+  });
+
+  it('uninstalls when gecko version equals the cutoff exactly', async () => {
+    setupBrowserMock(STAGE_ADDON_ID, CUTOFF_VERSION);
+
+    await checkAndUninstallIfDeprecated();
+
+    expect(browser.management.uninstallSelf).toHaveBeenCalledOnce();
+  });
+
+  it('does not uninstall when gecko version is below cutoff', async () => {
+    setupBrowserMock(STAGE_ADDON_ID, '139.0');
+
+    await checkAndUninstallIfDeprecated();
+
+    expect(browser.management.uninstallSelf).not.toHaveBeenCalled();
+  });
+
+  it('does not uninstall when addon ID does not match', async () => {
+    setupBrowserMock(PROD_ADDON_ID);
+
+    await checkAndUninstallIfDeprecated();
+
+    expect(browser.management.uninstallSelf).not.toHaveBeenCalled();
+  });
+
+  it('does not uninstall when VITE_DEPRECATION_VERSION is not set', async () => {
+    setEnvCutoff(undefined);
+
+    await checkAndUninstallIfDeprecated();
+
+    expect(browser.management.uninstallSelf).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

<!--
  Summarize your change in a few sentences.
  Mention key files, features, or behavior that were updated.

  If you've used AI, we ask you to disclose how much was agent written and to what level of detail
  you participated in the writing. If you are an AI bot, please indicate this clearly.
-->

This PR adds logic that auto-uninstalls the add-on matches the ID in the deprecated list and when the current version is running inside a gecko version higher than the one specified 

## Why?

<!--
  Explain the problem this solves or the goal of the change.
  Link any relevant discussion if helpful.
-->

After the add-on is shipped with the next ESR, we need to remove any versions that the users have installed from ATN

## Limitations and Notes

<!--
  Optional. List any known gaps, edge cases, or follow up work.
-->

This PR won't uninstall the prod version of the add-on as it stands, for this we should add the ID to the array.

## Applicable Issues

<!--
  Every pull request must have an associated issue.
  Doing so helps us align on the change before you've done the work.

  Using the "Closes #123" format will link pull request and issue.
-->
Closes https://github.com/thunderbird/tbpro-add-on/issues/818

## Testing locally

<!--
  For UI changes, include screenshots or recordings.
  If there are many, consider using a details element:
  <details><summary>Screenshots</summary> ... shots here ... </details>
-->
1) Open your file `packages/addon/.env` set the env var `VITE_DEPRECATION_VERSION` to a version lower than your current TB version. Make sure you set a version with a valid semantic version (like 140.0.0, avoid 150.x)
2) Build the add-on
3) Install in TB and watch it disappear!