### PR TITLE
skip api call on bucket storage

### DIFF
--- a/packages/send/frontend/src/lib/api.ts
+++ b/packages/send/frontend/src/lib/api.ts
@@ -28,8 +28,15 @@ export class ApiConnection {
     if (process.env.NODE_ENV === 'test') {
       return true;
     }
-    const { isBucketStorage } = await trpc.getStorageType.query();
-    return isBucketStorage;
+    // In production, bucket storage is always assumed true — skip the network call.
+    if (import.meta.env.MODE === 'production') {
+      return true;
+    } else {
+      // Only in development do we query the backend,
+      // which may be configured with filesystem storage instead.
+      const { isBucketStorage } = await trpc.getStorageType.query();
+      return isBucketStorage;
+    }
   }
 
   toString(): string {


### PR DESCRIPTION
This PR skips the api call to figure out if the backend is using bucket storage (unless we're using development)
Closes https://github.com/thunderbird/tbpro-add-on/issues/846