### PR TITLE
don't call api on testing environment

### DIFF
--- a/packages/send/frontend/src/lib/trpc.ts
+++ b/packages/send/frontend/src/lib/trpc.ts
@@ -14,17 +14,77 @@ import {
 import { AppRouter } from '@send-backend/router';
 import { TRPC_WS_PATH } from './config';
 
-// create persistent WebSocket connection
+// Single source for the Send backend host. The host application (Thunderbird)
+// can override this at build/extraction time, and may set it to an empty
+// string to mean "disabled — do not connect" (e.g. in CI/automation, where any
+// non-local connection aborts the whole process). When unset we fall back to
+// whatever the build was configured with.
+const serverUrl = (import.meta.env.VITE_SEND_SERVER_URL ?? '').trim();
 
-const refreshUrl = `${import.meta.env.VITE_SEND_SERVER_URL}/api/auth/refresh`;
-const trpcUrl = `${import.meta.env.VITE_SEND_SERVER_URL}/trpc`;
-const isTesting = import.meta.env.VITE_TESTING === 'true';
-// We create a WebSocket client only if we are not in testing mode
-const wsClient = !isTesting
-  ? createWSClient({
-      url: `${import.meta.env.VITE_SEND_SERVER_URL}${TRPC_WS_PATH}`,
-    })
-  : null;
+const refreshUrl = `${serverUrl}/api/auth/refresh`;
+const trpcUrl = `${serverUrl}/trpc`;
+
+/**
+ * Detect whether we're running in a test/automation context, where the
+ * WebSocket must stay closed.
+ *
+ * Unit tests inject `import.meta.env.VITE_TESTING`. When that build-time flag is
+ * unavailable — as in the shipped background bundle — fall back to the presence
+ * of the WebExtension `browser.test` API, which the Thunderbird/Firefox test
+ * harness only exposes when the add-on is loaded under automation. This keeps a
+ * logged-out automation profile from ever opening the socket at startup.
+ */
+export function detectTesting(): boolean {
+  if (import.meta.env.VITE_TESTING !== undefined) {
+    return import.meta.env.VITE_TESTING === 'true';
+  }
+
+  return (
+    typeof browser !== 'undefined' &&
+    Boolean((browser as { test?: unknown }).test)
+  );
+}
+
+const isTesting = detectTesting();
+
+type WSClientConfig = NonNullable<Parameters<typeof createWSClient>[0]>;
+
+/**
+ * Decide how (and whether) to build the WebSocket client.
+ *
+ * Returns `null` — meaning "do not connect" — when running under unit tests or
+ * when no backend host is configured (empty `serverUrl`). Otherwise returns the
+ * client config with **lazy mode** enabled.
+ *
+ * Lazy mode is critical: the background page of the built-in/system add-on
+ * imports this module on every Thunderbird launch, including fresh,
+ * never-signed-in profiles. A non-lazy client opens the socket as a side effect
+ * of construction (at module load), which under automation triggers a fatal
+ * "non-local network connections are disabled" abort and crashes the process
+ * before any feature is used. With lazy mode the connection is deferred until
+ * the first subscription actually runs (i.e. an authenticated user is using a
+ * feature) and is closed again after inactivity, so a logged-out profile makes
+ * zero outbound connections at startup.
+ */
+export function getWsClientConfig(
+  url: string,
+  testing: boolean
+): WSClientConfig | null {
+  if (testing || url.length === 0) {
+    return null;
+  }
+
+  return {
+    url: `${url}${TRPC_WS_PATH}`,
+    lazy: {
+      enabled: true,
+      closeMs: 1000,
+    },
+  };
+}
+
+const wsClientConfig = getWsClientConfig(serverUrl, isTesting);
+const wsClient = wsClientConfig ? createWSClient(wsClientConfig) : null;
 
 /**
  * We only import the `AppRouter` type from the server - this is not available at runtime

--- a/packages/send/frontend/src/lib/trpc.ts
+++ b/packages/send/frontend/src/lib/trpc.ts
@@ -15,10 +15,9 @@ import { AppRouter } from '@send-backend/router';
 import { TRPC_WS_PATH } from './config';
 
 // Single source for the Send backend host. The host application (Thunderbird)
-// can override this at build/extraction time, and may set it to an empty
-// string to mean "disabled — do not connect" (e.g. in CI/automation, where any
-// non-local connection aborts the whole process). When unset we fall back to
-// whatever the build was configured with.
+// can override this at build/extraction time. An empty or unset value means
+// "disabled — do not connect" (e.g. in CI/automation, where any non-local
+// connection aborts the whole process).
 const serverUrl = (import.meta.env.VITE_SEND_SERVER_URL ?? '').trim();
 
 const refreshUrl = `${serverUrl}/api/auth/refresh`;
@@ -70,12 +69,13 @@ export function getWsClientConfig(
   url: string,
   testing: boolean
 ): WSClientConfig | null {
-  if (testing || url.length === 0) {
+  const normalizedUrl = url.trim();
+  if (testing || normalizedUrl.length === 0) {
     return null;
   }
 
   return {
-    url: `${url}${TRPC_WS_PATH}`,
+    url: `${normalizedUrl}${TRPC_WS_PATH}`,
     lazy: {
       enabled: true,
       closeMs: 1000,

--- a/packages/send/frontend/src/test/lib/trpc.test.ts
+++ b/packages/send/frontend/src/test/lib/trpc.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import { detectTesting, getWsClientConfig } from '@send-frontend/lib/trpc';
+import { TRPC_WS_PATH } from '@send-frontend/lib/config';
+
+/**
+ * Regression guard for Bug 2036665.
+ *
+ * The built-in/system add-on background page imports the trpc module on every
+ * Thunderbird launch. The WebSocket client must never open a connection as a
+ * side effect of module load, otherwise a fresh, logged-out profile reaches the
+ * network at startup and crashes under automation. These tests pin the two
+ * guarantees that prevent that:
+ *   1. an unconfigured (empty) backend URL means "do not connect", and
+ *   2. when configured, the client is created in lazy mode so the socket only
+ *      opens on first subscription, not at construction.
+ */
+describe('getWsClientConfig', () => {
+  it('returns null (no connection) when testing', () => {
+    expect(getWsClientConfig('https://send-backend.tb.pro', true)).toBeNull();
+  });
+
+  it('returns null (no connection) when the backend URL is empty', () => {
+    expect(getWsClientConfig('', false)).toBeNull();
+  });
+
+  it('enables lazy mode when a backend URL is configured', () => {
+    const config = getWsClientConfig('https://send-backend.tb.pro', false);
+
+    expect(config).not.toBeNull();
+    expect(config?.url).toBe(`https://send-backend.tb.pro${TRPC_WS_PATH}`);
+    expect(config?.lazy?.enabled).toBe(true);
+  });
+});
+
+describe('detectTesting', () => {
+  // Under vitest, Vite injects VITE_TESTING='true', so detection reports a test
+  // context (and the WebSocket stays closed). In the shipped bundle the flag is
+  // absent and detection falls back to the WebExtension `browser.test` API.
+  it('reports a test context when VITE_TESTING is set', () => {
+    expect(detectTesting()).toBe(true);
+  });
+});


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

Made the Send tRPC WebSocket client **lazy** and **disable-able**, so the
built-in add-on no longer opens a connection at startup.

In `packages/send/frontend/src/lib/trpc.ts`:

- The WebSocket client is now created with `lazy: { enabled: true, closeMs:
  1000 }`. Construction no longer opens the socket — the connection is deferred
  until the first subscription actually runs (only in the popup/options pages,
  after the user is signed in and using a feature) and is closed again after
  inactivity.
- The backend host is funneled through a single `serverUrl` constant, and an
  **empty/unset value now means "do not connect"** (returns `null` → falls back
  to HTTP, no socket). This gives the host app a seam to disable the add-on's
  networking (e.g. in CI) without disabling the whole add-on.
- Extracted the decision into an exported pure helper `getWsClientConfig(url,
  testing)` so the contract is documented and unit-testable.
- Added `packages/send/frontend/src/test/lib/trpc.test.ts` as a regression
  guard.

AI disclosure: this change was drafted by Claude (agent-written) with the
author directing the investigation, reviewing the diff, and verifying the build
and tests. The author participated at the level of reviewing every changed line
and the verification output.

## Why?

The built-in/system add-on's background page imports this module on every
Thunderbird launch. A non-lazy `createWSClient` opens the socket as a side
effect of construction, so a fresh, never-signed-in profile immediately reached
`https://send-backend.tb.pro/trpc/ws`. Under automation, where non-local
connections are forbidden at the network-stack level, that raised a fatal,
non-catchable abort and crashed the process at launch — failing ~60 jobs across
every platform/suite with the same `PROCESS-CRASH` signature.

After this change a logged-out profile makes zero outbound connections at
startup, which fixes the CI crashes and is the correct privacy/perf behavior
for a default-on built-in add-on, while preserving the feature for signed-in
users.

## Limitations and Notes

- This is the add-on-source fix (Workstream A) plus the add-on side of the
  configurable-backend seam (Workstream B). A production bundle still needs to
  be built and **re-extracted** into
  `comm/mail/extensions/builtin-addons/thundermail/extension/`; the vendored
  minified `background-*.js` is build output and must not be edited directly.
- The "empty = disabled" seam is currently build-time (`VITE_SEND_SERVER_URL`
  is injected at build time). Wiring it to a live runtime pref
  (`extensions.tbpro.send.backendUrl`) so the host app can flip it per-profile
  is a Thunderbird-side follow-up.
- The automation stopgap pref (Workstream C) and the Thunderbird-side pref
  wiring live in comm-central, not in this repo.
- The `/api/auth/refresh` path only fires reactively on a `401`, not at
  startup, so it is unaffected; it should remain gated behind an authenticated
  session.

## Applicable Issues

Closes #852 

## Screenshots

N/A — no UI changes. Verification:

- New regression test passes: empty URL → no connect, testing → no connect,
  configured URL → lazy enabled (3/3).
- Full frontend suite: 222 passed, 2 skipped (24 files); `tsc --noEmit` clean.
- Built the background bundle and confirmed lazy mode (`closeMs: 1e3`) is
  compiled into the shipped output with no module-scope eager connect.
