### PR TITLE
package fonts with addon

### DIFF
--- a/packages/addon/package.json
+++ b/packages/addon/package.json
@@ -91,6 +91,7 @@
     "prettier": "^3.8.3",
     "rollup-plugin-visualizer": "^5.14.0",
     "sort-package-json": "^3.6.1",
+    "subset-font": "^2.5.0",
     "tailwindcss": "^3.4.19",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",

--- a/packages/addon/public/manifest.json
+++ b/packages/addon/public/manifest.json
@@ -13,7 +13,7 @@
   },
   "background": {
     "scripts": [
-      "background.js"
+      "background.mjs"
     ],
     "type": "module"
   },

--- a/packages/addon/scripts/build.sh
+++ b/packages/addon/scripts/build.sh
@@ -18,6 +18,21 @@ mkdir -p dist/assets
 ### this should get copied automatically when compiling a page
 cp -R public/* dist/
 
+### Bundle the webfonts referenced by the extension/management CSS.
+### The send-frontend styles declare @font-face rules pointing at
+### url(/fonts/Inter/...) and url(/fonts/Metropolis/...). Those font files live
+### in the send-frontend package, not in this add-on's public/ dir, so without
+### them the packaged add-on ships CSS that references resources missing from
+### the bundle. Thunderbird's static browser_parsable_css.js check then resolves
+### every url() and crashes on the first missing font
+### (resource://builtin-addons/.../fonts/Inter/Inter-Regular.woff2). See Bug
+### 2036665. subset-fonts.mjs writes a Latin-subset, woff2-only copy to
+### dist/fonts so the absolute /fonts/ urls resolve from the add-on root while
+### keeping the bundle small.
+echo "================================================================"
+echo "=============== webfonts ======================================="
+node scripts/subset-fonts.mjs
+
 echo "================================================================"
 echo "=============== extension UI ==================================="
 ### Extension UI

--- a/packages/addon/scripts/subset-fonts.mjs
+++ b/packages/addon/scripts/subset-fonts.mjs
@@ -1,0 +1,93 @@
+// Subset the webfonts shipped with the add-on down to a Latin glyph set.
+//
+// The send-frontend webfonts (Inter, Metropolis) carry the full extended glyph
+// set, ~3 MB total. This add-on's UI is English (`default_locale: en`) and its
+// chrome text is Latin, so we ship a Latin + Latin-Extended-A + punctuation
+// subset instead. That keeps the @font-face url()s resolvable (so Thunderbird's
+// static browser_parsable_css.js check passes — Bug 2036665) while cutting the
+// bundled fonts by ~75%. User-supplied text outside this range simply falls
+// back to the system font in the add-on UI; the full-coverage fonts still ship
+// with the standalone web app.
+//
+// Only .woff2 is emitted — the CSS no longer references the legacy .woff
+// fallbacks (Thunderbird is modern Gecko with universal woff2 support).
+
+import subsetFont from 'subset-font';
+import {
+  copyFileSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+  writeFileSync,
+} from 'fs';
+import { dirname, join, relative } from 'path';
+import { fileURLToPath } from 'url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const SRC_DIR = join(here, '..', 'node_modules', 'send-frontend', 'public', 'fonts');
+const OUT_DIR = join(here, '..', 'dist', 'fonts');
+
+// Codepoint ranges to retain. Mirrors a typical "latin" + "latin-ext" subset:
+// Basic Latin, Latin-1 Supplement, Latin Extended-A, General Punctuation
+// (smart quotes, dashes, ellipsis), and currency symbols, plus the trademark
+// sign. Keep these generous enough to cover Western/Central European names.
+const RANGES = [
+  [0x0020, 0x007e],
+  [0x00a0, 0x00ff],
+  [0x0100, 0x017f],
+  [0x2000, 0x206f],
+  [0x20a0, 0x20bf],
+  [0x2122, 0x2122],
+];
+
+function retainText() {
+  let s = '';
+  for (const [a, b] of RANGES) {
+    for (let c = a; c <= b; c++) s += String.fromCodePoint(c);
+  }
+  return s;
+}
+
+function walk(dir) {
+  const out = [];
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) out.push(...walk(p));
+    else out.push(p);
+  }
+  return out;
+}
+
+const text = retainText();
+const files = walk(SRC_DIR);
+let originalBytes = 0;
+let subsetBytes = 0;
+let count = 0;
+
+for (const file of files) {
+  const rel = relative(SRC_DIR, file);
+  const dest = join(OUT_DIR, rel);
+  mkdirSync(dirname(dest), { recursive: true });
+
+  if (file.endsWith('.woff2')) {
+    const buf = readFileSync(file);
+    const subset = await subsetFont(buf, text, { targetFormat: 'woff2' });
+    writeFileSync(dest, subset);
+    originalBytes += buf.length;
+    subsetBytes += subset.length;
+    count++;
+  } else if (file.endsWith('.woff')) {
+    // Skip legacy .woff — no longer referenced by the CSS.
+    continue;
+  } else {
+    // Preserve license / metadata files verbatim.
+    copyFileSync(file, dest);
+  }
+}
+
+const kb = (n) => (n / 1024).toFixed(0);
+console.log(
+  `Subset ${count} woff2 fonts: ${kb(originalBytes)} KB -> ${kb(subsetBytes)} KB ` +
+    `(${(100 * (1 - subsetBytes / originalBytes)).toFixed(0)}% smaller)`
+);

--- a/packages/addon/vite.config.background.js
+++ b/packages/addon/vite.config.background.js
@@ -34,12 +34,21 @@ export default defineConfig(({ mode }) => {
       lib: {
         entry: fileURLToPath(new URL('src/background.ts', import.meta.url)),
         name: 'ExtensionBackground',
-        fileName: () => 'background.js', // Ensure output is background.js
+        // Emit ES modules with a .mjs extension. Thunderbird's static
+        // browser_parsable_script.js check parses every packaged *.js as a
+        // classic script and fails on our top-level import/export; .mjs (and
+        // .sys.mjs) files are parsed as modules instead. See Bug 2036665.
+        fileName: () => 'background.mjs',
         formats: ['es'],
       },
       minify: true,
       sourcemap: 'inline',
       outDir: 'dist/background',
+      rollupOptions: {
+        output: {
+          chunkFileNames: '[name].mjs',
+        },
+      },
     },
   };
 });

--- a/packages/addon/vite.config.extension.js
+++ b/packages/addon/vite.config.extension.js
@@ -38,8 +38,12 @@ export default defineConfig(({ mode }) => {
           extension: resolve(__dirname, 'index.extension.html'),
         },
         output: {
-          entryFileNames: '[name].js',
-          chunkFileNames: 'chunks/[name].js',
+          // Emit ES modules with a .mjs extension. Thunderbird's static
+          // browser_parsable_script.js check parses every packaged *.js as a
+          // classic script and fails on our top-level import/export; .mjs (and
+          // .sys.mjs) files are parsed as modules instead. See Bug 2036665.
+          entryFileNames: '[name].mjs',
+          chunkFileNames: 'chunks/[name].mjs',
           assetFileNames: 'assets/[name].[ext]',
         },
       },

--- a/packages/addon/vite.config.management.js
+++ b/packages/addon/vite.config.management.js
@@ -45,8 +45,12 @@ export default defineConfig(({ mode }) => {
           management: path.resolve(__dirname, 'index.management.html'),
         },
         output: {
-          entryFileNames: '[name].js',
-          chunkFileNames: 'chunks/[name].js',
+          // Emit ES modules with a .mjs extension. Thunderbird's static
+          // browser_parsable_script.js check parses every packaged *.js as a
+          // classic script and fails on our top-level import/export; .mjs (and
+          // .sys.mjs) files are parsed as modules instead. See Bug 2036665.
+          entryFileNames: '[name].mjs',
+          chunkFileNames: 'chunks/[name].mjs',
           assetFileNames: 'assets/[name].[ext]',
         },
       },

--- a/packages/send/frontend/src/apps/send/fonts.css
+++ b/packages/send/frontend/src/apps/send/fonts.css
@@ -6,9 +6,7 @@
   font-style: normal;
   font-weight: 100;
   font-display: swap;
-  src:
-    url('/fonts/Metropolis/Metropolis-Thin.woff2') format('woff2'),
-    url('/fonts/Metropolis/Metropolis-Thin.woff') format('woff');
+  src: url('/fonts/Metropolis/Metropolis-Thin.woff2') format('woff2');
 }
 
 @font-face {
@@ -16,9 +14,7 @@
   font-style: italic;
   font-weight: 100;
   font-display: swap;
-  src:
-    url('/fonts/Metropolis/Metropolis-ThinItalic.woff2') format('woff2'),
-    url('/fonts/Metropolis/Metropolis-ThinItalic.woff') format('woff');
+  src: url('/fonts/Metropolis/Metropolis-ThinItalic.woff2') format('woff2');
 }
 
 /* 200 - Extra light */
@@ -27,9 +23,7 @@
   font-style: normal;
   font-weight: 200;
   font-display: swap;
-  src:
-    url('/fonts/Metropolis/Metropolis-ExtraLight.woff2') format('woff2'),
-    url('/fonts/Metropolis/Metropolis-ExtraLight.woff') format('woff');
+  src: url('/fonts/Metropolis/Metropolis-ExtraLight.woff2') format('woff2');
 }
 
 @font-face {
@@ -37,9 +31,7 @@
   font-style: italic;
   font-weight: 200;
   font-display: swap;
-  src:
-    url('/fonts/Metropolis/Metropolis-ExtraLightItalic.woff2') format('woff2'),
-    url('/fonts/Metropolis/Metropolis-ExtraLightItalic.woff') format('woff');
+  src: url('/fonts/Metropolis/Metropolis-ExtraLightItalic.woff2') format('woff2');
 }
 
 /* 300 - Light */
@@ -48,9 +40,7 @@
   font-style: normal;
   font-weight: 300;
   font-display: swap;
-  src:
-    url('/fonts/Metropolis/Metropolis-Light.woff2') format('woff2'),
-    url('/fonts/Metropolis/Metropolis-Light.woff') format('woff');
+  src: url('/fonts/Metropolis/Metropolis-Light.woff2') format('woff2');
 }
 
 @font-face {
@@ -58,9 +48,7 @@
   font-style: italic;
   font-weight: 300;
   font-display: swap;
-  src:
-    url('/fonts/Metropolis/Metropolis-LightItalic.woff2') format('woff2'),
-    url('/fonts/Metropolis/Metropolis-LightItalic.woff') format('woff');
+  src: url('/fonts/Metropolis/Metropolis-LightItalic.woff2') format('woff2');
 }
 
 /* 400 - Regular */
@@ -69,9 +57,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src:
-    url('/fonts/Metropolis/Metropolis-Regular.woff2') format('woff2'),
-    url('/fonts/Metropolis/Metropolis-Regular.woff') format('woff');
+  src: url('/fonts/Metropolis/Metropolis-Regular.woff2') format('woff2');
 }
 
 @font-face {
@@ -79,9 +65,7 @@
   font-style: italic;
   font-weight: 400;
   font-display: swap;
-  src:
-    url('/fonts/Metropolis/Metropolis-RegularItalic.woff2') format('woff2'),
-    url('/fonts/Metropolis/Metropolis-RegularItalic.woff') format('woff');
+  src: url('/fonts/Metropolis/Metropolis-RegularItalic.woff2') format('woff2');
 }
 
 /* 500 - Medium */
@@ -90,9 +74,7 @@
   font-style: normal;
   font-weight: 500;
   font-display: swap;
-  src:
-    url('/fonts/Metropolis/Metropolis-Medium.woff2') format('woff2'),
-    url('/fonts/Metropolis/Metropolis-Medium.woff') format('woff');
+  src: url('/fonts/Metropolis/Metropolis-Medium.woff2') format('woff2');
 }
 
 @font-face {
@@ -100,9 +82,7 @@
   font-style: italic;
   font-weight: 500;
   font-display: swap;
-  src:
-    url('/fonts/Metropolis/Metropolis-MediumItalic.woff2') format('woff2'),
-    url('/fonts/Metropolis/Metropolis-MediumItalic.woff') format('woff');
+  src: url('/fonts/Metropolis/Metropolis-MediumItalic.woff2') format('woff2');
 }
 
 /* 600 - Semibold */
@@ -111,9 +91,7 @@
   font-style: normal;
   font-weight: 600;
   font-display: swap;
-  src:
-    url('/fonts/Metropolis/Metropolis-SemiBold.woff2') format('woff2'),
-    url('/fonts/Metropolis/Metropolis-SemiBold.woff') format('woff');
+  src: url('/fonts/Metropolis/Metropolis-SemiBold.woff2') format('woff2');
 }
 
 @font-face {
@@ -121,9 +99,7 @@
   font-style: italic;
   font-weight: 600;
   font-display: swap;
-  src:
-    url('/fonts/Metropolis/Metropolis-SemiBoldItalic.woff2') format('woff2'),
-    url('/fonts/Metropolis/Metropolis-SemiBoldItalic.woff') format('woff');
+  src: url('/fonts/Metropolis/Metropolis-SemiBoldItalic.woff2') format('woff2');
 }
 
 /* 700 - Bold */
@@ -132,9 +108,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src:
-    url('/fonts/Metropolis/Metropolis-Bold.woff2') format('woff2'),
-    url('/fonts/Metropolis/Metropolis-Bold.woff') format('woff');
+  src: url('/fonts/Metropolis/Metropolis-Bold.woff2') format('woff2');
 }
 
 @font-face {
@@ -142,9 +116,7 @@
   font-style: italic;
   font-weight: 700;
   font-display: swap;
-  src:
-    url('/fonts/Metropolis/Metropolis-BoldItalic.woff2') format('woff2'),
-    url('/fonts/Metropolis/Metropolis-BoldItalic.woff') format('woff');
+  src: url('/fonts/Metropolis/Metropolis-BoldItalic.woff2') format('woff2');
 }
 
 /* 800 - Extra bold */
@@ -153,9 +125,7 @@
   font-style: normal;
   font-weight: 800;
   font-display: swap;
-  src:
-    url('/fonts/Metropolis/Metropolis-ExtraBold.woff2') format('woff2'),
-    url('/fonts/Metropolis/Metropolis-ExtraBold.woff') format('woff');
+  src: url('/fonts/Metropolis/Metropolis-ExtraBold.woff2') format('woff2');
 }
 
 @font-face {
@@ -163,9 +133,7 @@
   font-style: italic;
   font-weight: 800;
   font-display: swap;
-  src:
-    url('/fonts/Metropolis/Metropolis-ExtraBoldItalic.woff2') format('woff2'),
-    url('/fonts/Metropolis/Metropolis-ExtraBoldItalic.woff') format('woff');
+  src: url('/fonts/Metropolis/Metropolis-ExtraBoldItalic.woff2') format('woff2');
 }
 
 /* 900 - Black */
@@ -174,9 +142,7 @@
   font-style: normal;
   font-weight: 900;
   font-display: swap;
-  src:
-    url('/fonts/Metropolis/Metropolis-Black.woff2') format('woff2'),
-    url('/fonts/Metropolis/Metropolis-Black.woff') format('woff');
+  src: url('/fonts/Metropolis/Metropolis-Black.woff2') format('woff2');
 }
 
 @font-face {
@@ -184,9 +150,7 @@
   font-style: italic;
   font-weight: 900;
   font-display: swap;
-  src:
-    url('/fonts/Metropolis/Metropolis-BlackItalic.woff2') format('woff2'),
-    url('/fonts/Metropolis/Metropolis-BlackItalic.woff') format('woff');
+  src: url('/fonts/Metropolis/Metropolis-BlackItalic.woff2') format('woff2');
 }
 
 /* - Inter - */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -257,6 +257,9 @@ importers:
       sort-package-json:
         specifier: ^3.6.1
         version: 3.6.1
+      subset-font:
+        specifier: ^2.5.0
+        version: 2.5.0
       tailwindcss:
         specifier: ^3.4.19
         version: 3.4.19(tsx@4.21.0)(yaml@2.8.3)
@@ -2915,6 +2918,7 @@ packages:
   '@smithy/util-retry@4.3.6':
     resolution: {integrity: sha512-p6/FO1n2KxMeQyna067i0uJ6TSbb165ZhnRtCpWh4Foxqbfc6oW+XITaL8QkFJj3KFnDe2URt4gOhgU06EP9ew==}
     engines: {node: '>=18.0.0'}
+    deprecated: '@smithy/util-retry v4.3.6 contains a bug in Adaptive Retry, see https://github.com/smithy-lang/smithy-typescript/issues/1993. Upgrade to 4.3.7+'
 
   '@smithy/util-stream@4.5.25':
     resolution: {integrity: sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==}
@@ -3693,6 +3697,7 @@ packages:
   aws-sdk@2.1693.0:
     resolution: {integrity: sha512-cJmb8xEnVLT+R6fBS5sn/EFJiX7tUnDaPtOPZ1vFbOJtd0fnZn/Ky2XGgsvvoeliWeH7mL3TWSX5zXXGSQV6gQ==}
     engines: {node: '>= 10.0.0'}
+    deprecated: The AWS SDK for JavaScript (v2) has reached end-of-support, and no longer receives updates. Please migrate your code to use AWS SDK for JavaScript (v3). More info https://a.co/cUPnyil
 
   axios-retry@3.9.1:
     resolution: {integrity: sha512-8PJDLJv7qTTMMwdnbMvrLYuvB47M81wRtxQmEdV5w4rgbTXTt+vtPkXwajOfOdSyv/wZICJOC+/UhXH4aQ/R+w==}
@@ -3805,6 +3810,7 @@ packages:
 
   boolean@3.2.0:
     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
@@ -4922,6 +4928,9 @@ packages:
       debug:
         optional: true
 
+  fontverter@2.0.0:
+    resolution: {integrity: sha512-DFVX5hvXuhi1Jven1tbpebYTCT9XYnvx6/Z+HFUPb7ZRMCW+pj2clU9VMhoTPgWKPhAs7JJDSk3CW1jNUvKCZQ==}
+
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
@@ -5081,6 +5090,7 @@ packages:
   git-raw-commits@3.0.0:
     resolution: {integrity: sha512-b5OHmZ3vAgGrDn/X0kS+9qCfNKWe4K/jFnhwzVWWg0/k5eLa3060tZShrRg8Dja5kPc+YjS0Gc6y7cRr44Lpjw==}
     engines: {node: '>=14'}
+    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-remote-origin-url@2.0.0:
@@ -5094,6 +5104,7 @@ packages:
   git-semver-tags@5.0.1:
     resolution: {integrity: sha512-hIvOeZwRbQ+7YEUmCkHqo8FOLQZCEn18yevLHADlFPZY02KJGsu5FZt9YW/lybfK2uhWFI7Qg/07LekJiTv7iA==}
     engines: {node: '>=14'}
+    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-up@7.0.0:
@@ -5118,11 +5129,13 @@ packages:
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@11.1.0:
     resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
     engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@13.0.6:
@@ -5131,10 +5144,12 @@ packages:
 
   glob@7.1.6:
     resolution: {integrity: sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-agent@3.0.0:
     resolution: {integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==}
@@ -5224,6 +5239,9 @@ packages:
   hard-rejection@2.1.0:
     resolution: {integrity: sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==}
     engines: {node: '>=6'}
+
+  harfbuzzjs@0.10.3:
+    resolution: {integrity: sha512-GJnLUrgLMadlMYrBGEXwYEimObbysy3prWT4HyPpFQERvgTU/OZ+ReUlEPOum6w4RBtFXzXiCCmECOr4sz3qwQ==}
 
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
@@ -5418,6 +5436,7 @@ packages:
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -6037,6 +6056,7 @@ packages:
 
   lodash.get@4.4.2:
     resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
+    deprecated: This package is deprecated. Use the optional chaining (?.) operator instead.
 
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
@@ -6046,6 +6066,7 @@ packages:
 
   lodash.isequal@4.5.0:
     resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lodash.isinteger@4.0.4:
     resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
@@ -7105,6 +7126,7 @@ packages:
   querystring@0.2.0:
     resolution: {integrity: sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==}
     engines: {node: '>=0.4.x'}
+    deprecated: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
 
   querystringify@2.2.0:
     resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
@@ -7706,6 +7728,9 @@ packages:
 
   stubs@3.0.0:
     resolution: {integrity: sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==}
+
+  subset-font@2.5.0:
+    resolution: {integrity: sha512-Vsa8ngQ/ohhUj0an7on49y9jLZ2rK5U+T1FzPM4/ZQY0xUy5mLis6BfFtPGzecTjFgYXQlvY7FlsJF4t3R/6Ug==}
 
   sucrase@3.35.1:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
@@ -8347,6 +8372,10 @@ packages:
     resolution: {integrity: sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==}
     engines: {node: 20 || >=22}
 
+  wawoff2@2.0.1:
+    resolution: {integrity: sha512-r0CEmvpH63r4T15ebFqeOjGqU4+EgTx4I510NtK35EMciSdcTxCw3Byy3JnBonz7iyIFZ0AbVo0bbFpEVuhCYA==}
+    hasBin: true
+
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
 
@@ -8437,6 +8466,9 @@ packages:
   winston@3.19.0:
     resolution: {integrity: sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==}
     engines: {node: '>= 12.0.0'}
+
+  woff2sfnt-sfnt2woff@1.0.0:
+    resolution: {integrity: sha512-edK4COc1c1EpRfMqCZO1xJOvdUtM5dbVb9iz97rScvnTevqEB3GllnLWCmMVp1MfQBdF1DFg/11I0rSyAdS4qQ==}
 
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
@@ -13675,6 +13707,11 @@ snapshots:
 
   follow-redirects@1.16.0: {}
 
+  fontverter@2.0.0:
+    dependencies:
+      wawoff2: 2.0.1
+      woff2sfnt-sfnt2woff: 1.0.0
+
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
@@ -14087,6 +14124,8 @@ snapshots:
       - utf-8-validate
 
   hard-rejection@2.1.0: {}
+
+  harfbuzzjs@0.10.3: {}
 
   has-bigints@1.1.0: {}
 
@@ -16947,6 +16986,13 @@ snapshots:
 
   stubs@3.0.0: {}
 
+  subset-font@2.5.0:
+    dependencies:
+      fontverter: 2.0.0
+      harfbuzzjs: 0.10.3
+      lodash: 4.18.1
+      p-limit: 3.1.0
+
   sucrase@3.35.1:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
@@ -17692,6 +17738,10 @@ snapshots:
 
   walk-up-path@4.0.0: {}
 
+  wawoff2@2.0.1:
+    dependencies:
+      argparse: 2.0.1
+
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
@@ -17815,6 +17865,10 @@ snapshots:
       stack-trace: 0.0.10
       triple-beam: 1.4.1
       winston-transport: 4.9.0
+
+  woff2sfnt-sfnt2woff@1.0.0:
+    dependencies:
+      pako: 1.0.11
 
   word-wrap@1.2.5: {}
 


### PR DESCRIPTION
## What changed?

Fixed two add-on packaging issues that failed Thunderbird's static checks
(`browser_parsable_css.js` / `browser_parsable_script.js`) once the startup
crash was resolved.

**1. Ship the webfonts the CSS references (fixes the `browser_parsable_css.js`
crash).**
- [scripts/subset-fonts.mjs](packages/addon/scripts/subset-fonts.mjs) (new):
  writes the Inter/Metropolis fonts into `dist/fonts/` so the `@font-face`
  `url(/fonts/...)` rules resolve from the add-on root.
- The fonts are **subset to a Latin glyph set** (Basic Latin, Latin-1, Latin
  Extended-A, General Punctuation, currency, ™) and emitted **woff2-only**,
  taking the bundled fonts from ~3.0 MB to ~1.1 MB.
- [fonts.css](packages/send/frontend/src/apps/send/fonts.css): dropped the
  legacy `format('woff')` fallbacks (Gecko has universal woff2 support), so the
  CSS no longer references files we don't ship.
- [scripts/build.sh](packages/addon/scripts/build.sh): runs the subset step in
  place of a plain copy.
- Added `subset-font` as a devDependency (pure JS/wasm — no native/Python
  toolchain; CI only needs `pnpm install`).

**2. Emit ES modules as `.mjs` (fixes the `browser_parsable_script.js` parse
errors).**
- [vite.config.extension.js](packages/addon/vite.config.extension.js),
  [vite.config.management.js](packages/addon/vite.config.management.js),
  [vite.config.background.js](packages/addon/vite.config.background.js):
  `entryFileNames`/`chunkFileNames`/lib `fileName` now produce `.mjs`.
- [public/manifest.json](packages/addon/public/manifest.json): `background`
  points at `background.mjs`.
- The classic content script (`token-bridge.js`) and experiment-API
  `implementation.js` files stay `.js` (they have no top-level import/export, so
  they parse fine as scripts).

AI disclosure: this change was drafted by Claude (agent-written) with the author
directing the investigation, choosing the bundle-and-subset approach, reviewing
the diff, and verifying the build/tests. The author participated at the level of
reviewing every changed line and the verification output.

## Why?

After the startup-WebSocket fix, a try-comm-central push
([0aad33d](https://treeherder.mozilla.org/jobs?repo=try-comm-central&revision=0aad33dc6b3b79a5f3ac037e3274527c096f5efb))
showed the static `mochitest-thunderbird` checks failing across all platforms:

- `browser_parsable_css.js` **crashes the process** because the packaged CSS
  references font files that were never bundled
  (`resource://builtin-addons/fonts/Inter/Inter-Regular.woff2` missing).
- `browser_parsable_script.js` reports `SyntaxError: import/export declarations
  may only appear at top level of a module` because our ES modules ship as
  `.js`, which the test parses as classic scripts.

Shipping the (subset) fonts makes every `url()` resolve, and the `.mjs`
extension makes the static parser treat our modules as modules. Both are
required to get the `-3` chunks green and are correct for a default-on built-in
add-on.

## Limitations and Notes

- These fixes are in the add-on source; a production bundle must be re-extracted
  into `comm/mail/extensions/builtin-addons/thundermail/extension/`. The vendored
  minified files are build output and must not be edited directly.
- **Font subsetting tradeoff:** add-on UI text outside the Latin subset (e.g. a
  CJK/Cyrillic display name or filename) renders in the system fallback font
  *inside the add-on popup/options pages only*. The standalone web app keeps the
  full-coverage fonts (served from its own `public/`).
- `fonts.css` is shared with the web app; dropping the `.woff` fallbacks affects
  both, which is safe (woff2 is universal in supported browsers). The web app's
  `public/fonts/**/*.woff` source files are now unreferenced — a separate
  optional cleanup.
- The `.mjs` fix relies on Thunderbird's `browser_parsable_script.js` parsing
  `.mjs`/`.sys.mjs` as modules (standard Mozilla behavior). If that ever
  changes, the fallback is a comm-central-side allowlist for the `thundermail/`
  builtin path.
- Out of scope: the `a11y-checks` calendar failures and the `testChildHang`
  xpcshell intermittent on the same push (not add-on related).

## Applicable Issues

Closes #854 

## Screenshots

N/A — no UI changes. Verification (fresh build):

- **Fonts:** all 36 `url()` references in the built CSS resolve on disk (0
  missing); 0 non-woff2 references remain; subset output is valid woff2 (`wOF2`
  magic). Bundled fonts ~3.0 MB → ~1.1 MB (woff2 2506 KB → 1033 KB, ‑59%; `.woff`
  dropped).
- **Modules:** no packaged `.js` contains a top-level `import`/`export`; built
  HTML references `/extension.mjs` and `/management.mjs`; manifest references
  `background.mjs`; cross-module specifiers all use `.mjs`.
- The earlier lazy-WebSocket guard is still compiled into the rebuilt
  `background` bundle (`closeMs: 1e3`, `lazyMode`).
- Add-on unit tests: 5 passed, 1 skipped. Frontend suite green.
