### PR TITLE
fix: don't auto-open login tab for system add-on on install

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -482,10 +482,12 @@ jobs:
           VERSION_SUFFIX=$(echo "$PROD_XPI" | cut -d'-' -f4-)
           SYSTEM_XPI="tbpro-system-add-on-prod-${VERSION_SUFFIX}"
 
-          # Extract, swap the ID in manifest.json, repack
+          # Extract, swap the ID in manifest.json, repack.
+          # The system add-on id lives in packages/addon/src/addonIds.ts so it is
+          # not hard-coded here; set-system-id.ts rewrites prod -> system id.
           mkdir -p /tmp/system-addon-unpack
           unzip "packages/addon/$PROD_XPI" -d /tmp/system-addon-unpack
-          sed -i 's/"id": "tbpro-add-on@thunderbird.net"/"id": "tbpro-system-add-on@thunderbird.net"/g' /tmp/system-addon-unpack/manifest.json
+          bun run packages/addon/scripts/set-system-id.ts /tmp/system-addon-unpack/manifest.json
           cd /tmp/system-addon-unpack
           zip -r "$GITHUB_WORKSPACE/packages/addon/$SYSTEM_XPI" .
 

--- a/packages/addon/scripts/config.ts
+++ b/packages/addon/scripts/config.ts
@@ -1,8 +1,9 @@
 import dotenv from 'dotenv';
+import { ADDON_ID_PROD, ADDON_ID_STAGE } from '../src/addonIds';
 dotenv.config();
 
-export const ID_FOR_PROD = `"id": "tbpro-add-on@thunderbird.net"`;
-export const ID_FOR_STAGE = ` "id": "tbpro-addon-stage@thunderbird.net"`;
+export const ID_FOR_PROD = `"id": "${ADDON_ID_PROD}"`;
+export const ID_FOR_STAGE = ` "id": "${ADDON_ID_STAGE}"`;
 
 export const NAME_FOR_PROD = `"name": "__MSG_thunderbirdPro__"`;
 export const NAME_FOR_STAGE = `"name": "Thunderbird Pro [STAGE]"`;

--- a/packages/addon/scripts/set-system-id.ts
+++ b/packages/addon/scripts/set-system-id.ts
@@ -1,0 +1,53 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { pathToFileURL } from 'url';
+
+import { ADDON_ID_PROD, ADDON_ID_SYSTEM } from '../src/addonIds';
+
+/**
+ * Rewrite a built add-on manifest's production id to the built-in/system add-on
+ * id, in place. Used by CI when repacking the production XPI into the system
+ * add-on XPI, so the system id is defined once (src/addonIds.ts) instead of being
+ * hard-coded in a shell `sed`.
+ *
+ * Throws if the production id is not present, so a manifest that can't be
+ * rewritten fails loudly instead of silently shipping a non-system XPI.
+ *
+ * Usage: bun run scripts/set-system-id.ts <path/to/manifest.json>
+ * Defaults to this package's public/manifest.json when no path is given.
+ */
+export function setSystemId(manifestPath: string): void {
+  const before = fs.readFileSync(manifestPath, 'utf8');
+  const after = before
+    .split(`"id": "${ADDON_ID_PROD}"`)
+    .join(`"id": "${ADDON_ID_SYSTEM}"`);
+
+  if (after === before) {
+    throw new Error(
+      `Could not find prod id "${ADDON_ID_PROD}" in ${manifestPath}; ` +
+        `manifest not rewritten to the system add-on id.`
+    );
+  }
+
+  fs.writeFileSync(manifestPath, after, 'utf8');
+  console.log(`Set system add-on id (${ADDON_ID_SYSTEM}) in ${manifestPath}`);
+}
+
+// CLI entry — runs only when this file is invoked directly (e.g. `bun run
+// scripts/set-system-id.ts ...`), not when imported by the unit tests.
+function isInvokedDirectly(): boolean {
+  return (
+    !!process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href
+  );
+}
+
+if (isInvokedDirectly()) {
+  const manifestPath =
+    process.argv[2] ?? path.resolve(__dirname, '../public/manifest.json');
+  try {
+    setSystemId(manifestPath);
+  } catch (error) {
+    console.error('Failed to set system add-on id:', error);
+    process.exit(1);
+  }
+}

--- a/packages/addon/src/addonIds.ts
+++ b/packages/addon/src/addonIds.ts
@@ -1,0 +1,18 @@
+/**
+ * Single source of truth for the add-on's extension ids.
+ *
+ * The same add-on is shipped under three ids:
+ *   - PROD   — the standalone production add-on (AMO/ATN, manual install).
+ *   - STAGE  — the standalone staging add-on.
+ *   - SYSTEM — the built-in (a.k.a. system) add-on bundled into Thunderbird and
+ *              enabled by default for every user. comm-central packaging
+ *              rewrites the manifest id to this when extracting the build.
+ *
+ * This module has no runtime dependencies so it can be imported both by the
+ * extension bundle (e.g. installGate.ts, selfUninstall.ts) and by the
+ * build/packaging scripts (scripts/config.ts, scripts/set-system-id.ts) — so the
+ * ids never have to be hard-coded in more than one place, including CI.
+ */
+export const ADDON_ID_PROD = 'tbpro-add-on@thunderbird.net';
+export const ADDON_ID_STAGE = 'tbpro-addon-stage@thunderbird.net';
+export const ADDON_ID_SYSTEM = 'tbpro-system-add-on@thunderbird.net';

--- a/packages/addon/src/installGate.ts
+++ b/packages/addon/src/installGate.ts
@@ -1,0 +1,22 @@
+import { ADDON_ID_SYSTEM } from './addonIds';
+
+/**
+ * Whether to auto-open the login tab when the add-on is installed.
+ *
+ * Only the regular (standalone) add-on does first-run onboarding by opening
+ * BASE_URL/login. The built-in system add-on is enabled by default for every
+ * Thunderbird user, so it must make zero outbound connections on a fresh,
+ * never-signed-in profile: opening the login URL is a network connection that
+ * fatally aborts under automation (the non-local-connection guard crashes the
+ * process — Bug 2036665). For the system add-on, login stays user-initiated via
+ * the menu.
+ */
+export function shouldAutoOpenLoginOnInstall(
+  reason: string,
+  runtimeId: string | undefined
+): boolean {
+  if (reason !== 'install') return false;
+  // Unknown id: don't risk a startup network connection.
+  if (!runtimeId) return false;
+  return runtimeId !== ADDON_ID_SYSTEM;
+}

--- a/packages/addon/src/menu.ts
+++ b/packages/addon/src/menu.ts
@@ -2,6 +2,7 @@ import { BASE_URL } from '@send-frontend/apps/common/constants';
 import { getEnvName } from '@send-frontend/lib/clientConfig';
 import { STORAGE_KEY_AUTH } from '@send-frontend/lib/const';
 import { APPOINTMENT_URL } from '@send-frontend/apps/common/constants';
+import { shouldAutoOpenLoginOnInstall } from './installGate';
 
 // Determine environment-specific URLs
 const environmentName = getEnvName();
@@ -217,9 +218,12 @@ function checkLoginStateOnInterval() {
  * Creates the root menu item and registers listeners for all menu actions.
  */
 export function init() {
-  // Register onInstalled handler to open BASE_URL on extension install/update
+  // Register onInstalled handler to open the login page on first install — but
+  // only for the regular (standalone) add-on. The built-in system add-on is
+  // enabled by default for every user and must not make a startup network
+  // connection on a fresh, never-signed-in profile (see installGate.ts).
   browser.runtime.onInstalled.addListener(async (details) => {
-    if (details.reason === 'install') {
+    if (shouldAutoOpenLoginOnInstall(details.reason, browser.runtime.id)) {
       await menuLogin();
     }
   });

--- a/packages/addon/src/selfUninstall.ts
+++ b/packages/addon/src/selfUninstall.ts
@@ -1,6 +1,8 @@
 /// <reference types="thunderbird-webext-browser" />
 
-const DEPRECATION_ADDON_IDS = ['tbpro-addon-stage@thunderbird.net'];
+import { ADDON_ID_STAGE } from './addonIds';
+
+const DEPRECATION_ADDON_IDS = [ADDON_ID_STAGE];
 
 /**
  * Compare two semver strings. Returns true if `a >= b`.

--- a/packages/addon/src/test/installGate.test.ts
+++ b/packages/addon/src/test/installGate.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ADDON_ID_PROD,
+  ADDON_ID_STAGE,
+  ADDON_ID_SYSTEM,
+} from '../addonIds';
+import { shouldAutoOpenLoginOnInstall } from '../installGate';
+
+/**
+ * Regression guard for Bug 2036665: a fresh, never-signed-in profile must make
+ * zero outbound connections at startup. The built-in system add-on installs on
+ * every fresh Thunderbird profile (including under automation), so it must not
+ * auto-open BASE_URL/login. The standalone add-on keeps its first-run onboarding.
+ */
+describe('shouldAutoOpenLoginOnInstall', () => {
+  it('does NOT auto-open for the built-in system add-on on install', () => {
+    expect(shouldAutoOpenLoginOnInstall('install', ADDON_ID_SYSTEM)).toBe(false);
+  });
+
+  it('auto-opens for the standalone prod and stage add-ons on install', () => {
+    expect(shouldAutoOpenLoginOnInstall('install', ADDON_ID_PROD)).toBe(true);
+    expect(shouldAutoOpenLoginOnInstall('install', ADDON_ID_STAGE)).toBe(true);
+  });
+
+  it('never auto-opens on update/browser_update', () => {
+    expect(shouldAutoOpenLoginOnInstall('update', ADDON_ID_PROD)).toBe(false);
+    expect(shouldAutoOpenLoginOnInstall('browser_update', ADDON_ID_PROD)).toBe(
+      false
+    );
+    expect(shouldAutoOpenLoginOnInstall('update', ADDON_ID_SYSTEM)).toBe(false);
+  });
+
+  it('does not auto-open when the runtime id is unavailable', () => {
+    expect(shouldAutoOpenLoginOnInstall('install', undefined)).toBe(false);
+  });
+});

--- a/packages/addon/src/test/selfUninstall.test.ts
+++ b/packages/addon/src/test/selfUninstall.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ADDON_ID_PROD, ADDON_ID_STAGE } from '../addonIds';
 import { checkAndUninstallIfDeprecated } from '../selfUninstall';
 
-const STAGE_ADDON_ID = 'tbpro-addon-stage@thunderbird.net';
-const PROD_ADDON_ID = 'tbpro-add-on@thunderbird.net';
+const STAGE_ADDON_ID = ADDON_ID_STAGE;
+const PROD_ADDON_ID = ADDON_ID_PROD;
 const CUTOFF_VERSION = '140.0';
 
 function setupBrowserMock(addonId: string, geckoVersion = '145.0') {

--- a/packages/addon/src/test/set-system-id.test.ts
+++ b/packages/addon/src/test/set-system-id.test.ts
@@ -1,0 +1,81 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ADDON_ID_PROD, ADDON_ID_STAGE, ADDON_ID_SYSTEM } from '../addonIds';
+import { setSystemId } from '../../scripts/set-system-id';
+
+// A trimmed manifest with the gecko id nested where the real one lives.
+const manifestWithId = (id: string) =>
+  JSON.stringify(
+    {
+      manifest_version: 2,
+      browser_specific_settings: { gecko: { id } },
+      background: { scripts: ['background.mjs'], type: 'module' },
+    },
+    null,
+    2
+  );
+
+let tmpDir: string;
+let manifestPath: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'set-system-id-'));
+  manifestPath = path.join(tmpDir, 'manifest.json');
+  // Keep the console quiet for the success path.
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('setSystemId', () => {
+  it('rewrites the prod id to the system id in place', () => {
+    fs.writeFileSync(manifestPath, manifestWithId(ADDON_ID_PROD));
+
+    setSystemId(manifestPath);
+
+    const result = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    expect(result.browser_specific_settings.gecko.id).toBe(ADDON_ID_SYSTEM);
+  });
+
+  it('leaves the rest of the manifest untouched', () => {
+    fs.writeFileSync(manifestPath, manifestWithId(ADDON_ID_PROD));
+
+    setSystemId(manifestPath);
+
+    const result = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    expect(result.manifest_version).toBe(2);
+    expect(result.background).toEqual({
+      scripts: ['background.mjs'],
+      type: 'module',
+    });
+  });
+
+  it('throws and does not modify the file when the prod id is absent', () => {
+    const original = manifestWithId(ADDON_ID_STAGE);
+    fs.writeFileSync(manifestPath, original);
+
+    expect(() => setSystemId(manifestPath)).toThrow(/Could not find prod id/);
+    // File is left exactly as it was.
+    expect(fs.readFileSync(manifestPath, 'utf8')).toBe(original);
+  });
+
+  it('is a no-op-safe guard against a manifest already on the system id', () => {
+    // The system id is not the prod id, so a re-run finds nothing to replace
+    // and throws rather than silently passing.
+    fs.writeFileSync(manifestPath, manifestWithId(ADDON_ID_SYSTEM));
+
+    expect(() => setSystemId(manifestPath)).toThrow(/Could not find prod id/);
+  });
+
+  it('throws when the manifest file does not exist', () => {
+    expect(() =>
+      setSystemId(path.join(tmpDir, 'does-not-exist.json'))
+    ).toThrow();
+  });
+});


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

Stopped the built-in (system) add-on from auto-opening a login tab on first
install, so a fresh profile no longer makes a startup network connection.

- [src/installGate.ts](packages/addon/src/installGate.ts) (new): a pure,
  dependency-free module exporting the predicate
  `shouldAutoOpenLoginOnInstall(reason, runtimeId)`. It returns `true` only for
  the standalone add-on on `reason === 'install'`; it returns `false` for the
  built-in system add-on, for any non-install reason, and defensively when the
  runtime id is unavailable.
- [src/menu.ts](packages/addon/src/menu.ts): the `onInstalled` handler now gates
  `menuLogin()` through that predicate instead of opening the login tab for
  every install.
- [src/test/installGate.test.ts](packages/addon/src/test/installGate.test.ts)
  (new): regression guard — system id → no open, prod/stage id → open,
  update/`browser_update`/unknown id → no open.

The predicate lives in its own module (rather than inline in `menu.ts`) because
`menu.ts` runs `getEnvName()` at import time, which throws in the unit-test
environment; extracting it keeps the logic cleanly testable, mirroring the
`getWsClientConfig` / `detectTesting` helpers from the earlier startup-crash fix.

### Centralized the add-on ids (no more hard-coding)

The gate needs to know the built-in/system add-on id, which had been hard-coded
in several places (including a shell `sed` in CI). This change makes the ids live
in one place:

- [src/addonIds.ts](packages/addon/src/addonIds.ts) (new): single source of truth
  exporting `ADDON_ID_PROD`, `ADDON_ID_STAGE`, and `ADDON_ID_SYSTEM`. No runtime
  deps, so both the extension bundle and the build/CI scripts can import it.
- [src/installGate.ts](packages/addon/src/installGate.ts) and
  [src/selfUninstall.ts](packages/addon/src/selfUninstall.ts) now import their ids
  from it; [scripts/config.ts](packages/addon/scripts/config.ts) derives
  `ID_FOR_PROD` / `ID_FOR_STAGE` from it (byte-identical strings, so the existing
  `set-id.ts` manifest rewrite is unchanged); the unit tests import the ids too.
- [scripts/set-system-id.ts](packages/addon/scripts/set-system-id.ts) (new):
  rewrites a built manifest's prod id → system id using the centralized constants,
  and **fails loudly (exit 1)** if the prod id isn't found (so a future manifest
  change can't silently ship a non-system XPI).
- [.github/workflows/merge.yml](.github/workflows/merge.yml): the "Build
  system-add-on XPI for prod" step now calls `set-system-id.ts` instead of a
  hard-coded `sed 's/...tbpro-system-add-on@thunderbird.net.../'`.

The literal `tbpro-system-add-on@thunderbird.net` now appears in exactly one code
location (`addonIds.ts`). (Out of scope: a `send-frontend` `config-store.ts`
fallback hard-codes the `ext-`-prefixed prod/stage ids; it is a separate package
and importing the add-on constant there would be a backwards dependency.)

AI disclosure: this change was drafted by Claude (agent-written) with the author
diagnosing the behavior, confirming the intended product rule (only the regular
add-on auto-opens login), reviewing the diff, and verifying the build/tests. The
author participated at the level of reviewing every changed line and the
verification output.

## Why?

`menu.ts`'s `onInstalled` handler opened `${BASE_URL}/login?isExtension=true`
(production `https://send.tb.pro/login`) on first install. The built-in add-on
is enabled by default for every user and installs on every fresh profile, so it
hit the network at startup before any user action. Under automation — where
non-local connections are a fatal, non-catchable abort — this crashed the
process at launch:

```
PROCESS-CRASH | Attempting to connect to non-local address!
  uri is [https://send.tb.pro/login?isExtension=true]
```

That failed ~24 jobs (`marionette`, `mochitest-thunderbird`) across all
platforms on try-comm-central
([a643603](https://treeherder.mozilla.org/jobs?repo=try-comm-central&revision=a6436038eb25b4e3e384bf91a9a8a7da1f3403b6)).
Auto-opening login on install is intended onboarding for the **standalone**
add-on (manually installed); it is wrong for the built-in add-on, which should
make zero startup connections for a logged-out profile and leave login
user-initiated via the menu.

## Limitations and Notes

- This is the add-on-source fix; a production bundle must be re-extracted into
  `comm/mail/extensions/builtin-addons/thundermail/extension/`. The vendored
  minified files are build output and must not be edited directly.
- Detection is by **runtime add-on id**, not an automation flag, deliberately: a
  `browser.test` check would miss marionette (which drives the browser
  externally and doesn't expose `browser.test`), whereas the system-add-on id
  holds across every harness because they all run the built-in build.
- Other `BASE_URL` startup tab-opens (`menuLogout()` → `/logout`, and
  `getLoginState()` calling it when a stored token is expired) share the same
  hazard but are not reached by a fresh CI profile (no auth token). A broader
  "no `BASE_URL` tab-opens when the backend is disabled" guard would harden
  against a future regression — tracked as follow-up.

## Applicable Issues

Closes #858

## Screenshots

N/A — no UI changes. Verification:

- Add-on unit tests: 14 passed, 1 skipped (was 5 passed; +4 from the new
  `installGate` suite, +5 from the new `set-system-id` suite). ESLint clean on all
  changed files.
- Built the background bundle; the compiled predicate is exactly
  `reason !== "install" || !id ? false : id !== "tbpro-system-add-on@thunderbird.net"`
  (id sourced from `addonIds.ts`).
- `scripts/config.ts` still emits byte-identical `ID_FOR_PROD` / `ID_FOR_STAGE`
  strings, so the `set-id.ts` manifest rewrite is unchanged.
- [scripts/set-system-id.ts](packages/addon/scripts/set-system-id.ts) is unit
  tested ([src/test/set-system-id.test.ts](packages/addon/src/test/set-system-id.test.ts)):
  rewrites the prod id → system id in place, leaves the rest of the manifest
  untouched, and throws (leaving the file unchanged) when the prod id is absent /
  the file is missing. The CLI entry is guarded so importing it in tests has no
  side effect, and still runs when invoked via `bun run`.
- No new typecheck errors introduced (the pre-existing `tsc` errors are unrelated
  experiment-API / `@send-backend/router` / `folder-store` items resolved by Vite
  in the real build).
