### PR TITLE
fix: resolve built-in add-on font crash and cloudfile account interference

### DIFF
--- a/packages/addon/scripts/build.sh
+++ b/packages/addon/scripts/build.sh
@@ -58,6 +58,18 @@ fi
 
 
 echo "================================================================"
+echo "=============== rewrite font urls =============================="
+### The bundled CSS (from send-frontend's fonts.css) declares @font-face rules
+### with absolute url(/fonts/...). When the add-on is loaded as a built-in
+### add-on, an absolute /fonts/ url resolves against the resource:// protocol
+### root (resource://builtin-addons/fonts/Inter/...) instead of the add-on's own
+### directory, so the fonts 404 and Thunderbird's static browser_parsable_css.js
+### check crashes (Bug 2036665). The CSS lives in dist/assets/ and the fonts in
+### dist/fonts/, so rewrite the absolute url(/fonts/...) to a relative
+### url(../fonts/...) that resolves inside the add-on's own directory.
+find dist/assets -name '*.css' -exec perl -pi -e 's{url\(/fonts/}{url(../fonts/}g' {} +
+
+echo "================================================================"
 echo "=============== background.js =================================="
 ### Build `background.js` as a library
 vite build --config vite.config.background.js

--- a/packages/addon/src/background.ts
+++ b/packages/addon/src/background.ts
@@ -40,6 +40,7 @@ import {
   menuLoggedIn,
   menuLogout,
 } from './menu';
+import { shouldInitCloudFileOnStartup } from './cloudFileGate';
 import { checkAndUninstallIfDeprecated } from './selfUninstall';
 
 // Initialize the shared Pinia instance that will be used by both
@@ -749,7 +750,15 @@ function initAccountHubListener() {
 (async function main() {
   await checkAndUninstallIfDeprecated();
   initMenu();
-  initCloudFile();
+  // Only create the Send cloudfile account when the user is already signed in.
+  // A fresh, never-signed-in profile (e.g. the built-in system add-on under
+  // automation) must leave the cloudfile account list untouched so it doesn't
+  // pollute the default profile or break Thunderbird's cloudfile tests
+  // (Bug 2036665). The account is otherwise created on explicit sign-in.
+  const { isLoggedIn } = await getLoginState();
+  if (shouldInitCloudFileOnStartup(isLoggedIn)) {
+    initCloudFile();
+  }
   initStorageWatcher();
   initAccountHubListener();
 })().catch((error) => {

--- a/packages/addon/src/cloudFileGate.ts
+++ b/packages/addon/src/cloudFileGate.ts
@@ -1,0 +1,20 @@
+/**
+ * Whether to create/register the Thunderbird Send cloudfile account eagerly on
+ * background startup.
+ *
+ * The Send cloudfile account must only exist once the user has actually signed
+ * in. The built-in system add-on is enabled by default for every Thunderbird
+ * user, so on a fresh, never-signed-in profile (including under automation) it
+ * must not touch the cloudfile account list at all. Otherwise it leaves a
+ * "Thunderbird Send" account in the default profile and breaks Thunderbird's own
+ * cloudfile tests — browser_ext_cloudFile.js, browser_repeat_upload.js and the
+ * addRemoveAccounts checks — which assert a clean account baseline (e.g.
+ * "Should have no cloudfile accounts starting off. - 1 == 0"). See Bug 2036665.
+ *
+ * The account is still created on explicit sign-in via the SIGN_IN_COMPLETE
+ * flow in background.ts, so signed-in users (standalone or system) keep the Send
+ * cloudfile provider configured.
+ */
+export function shouldInitCloudFileOnStartup(isLoggedIn: boolean): boolean {
+  return isLoggedIn;
+}

--- a/packages/addon/src/test/cloudFileGate.test.ts
+++ b/packages/addon/src/test/cloudFileGate.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { shouldInitCloudFileOnStartup } from '../cloudFileGate';
+
+/**
+ * Regression guard for Bug 2036665: a fresh, never-signed-in profile must not
+ * create a Send cloudfile account at startup. The built-in system add-on runs on
+ * every fresh Thunderbird profile (including under automation), so eagerly
+ * creating an account there pollutes the default profile and breaks
+ * Thunderbird's own cloudfile tests (browser_ext_cloudFile.js,
+ * browser_repeat_upload.js, addRemoveAccounts), which assert a clean baseline.
+ */
+describe('shouldInitCloudFileOnStartup', () => {
+  it('does NOT init the cloudfile account when signed out', () => {
+    expect(shouldInitCloudFileOnStartup(false)).toBe(false);
+  });
+
+  it('inits the cloudfile account when already signed in', () => {
+    expect(shouldInitCloudFileOnStartup(true)).toBe(true);
+  });
+});


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

Fixes two independent regressions that surface when the add-on ships as the
built-in (system) add-on, both seen on the try-comm-central run for revision
`415994bfe103c55a68cf4682c5812082a9b41949`.

1. **Font URL resolution (`browser_parsable_css.js` crash).** Added a post-build
   step in `packages/addon/scripts/build.sh` that rewrites the bundled CSS's
   absolute `url(/fonts/...)` to a relative `url(../fonts/...)`. The CSS lives in
   `dist/assets/` and the fonts in `dist/fonts/`, so the relative url resolves to
   the add-on's own directory (`resource://builtin-addons/<addon>/fonts/...`)
   instead of the protocol root (`resource://builtin-addons/fonts/...`).

2. **Cloudfile account interference (`browser_ext_cloudFile.js`,
   `browser_repeat_upload.js`, addRemoveAccounts).** Gated the eager
   `initCloudFile()` call in `background.ts`'s `main()` behind login state via a
   new pure helper `shouldInitCloudFileOnStartup()` (`src/cloudFileGate.ts`). A
   never-signed-in profile now creates zero cloudfile accounts at startup; the
   account is still created on explicit sign-in through the existing
   `SIGN_IN_COMPLETE` flow. Added `src/test/cloudFileGate.test.ts`.

**AI disclosure:** Implemented with the assistance of Claude (Claude Code). The
agent diagnosed the Treeherder run, wrote the code/tests/build changes, and ran
the build + test suite; the author reviewed and directed the work, including
explicitly flagging the `addRemoveAccounts` check.

## Why?

Shipping tbpro as a default-enabled built-in add-on made it active in every
Thunderbird test profile, exposing two problems (tracked under Bug 2036665):

- The packaged CSS referenced fonts by an absolute `/fonts/` path that doesn't
  resolve under `resource://builtin-addons/<addon>/`, so the static
  `browser_parsable_css.js` check crashed the test process on every platform.
- The background script eagerly created a "Thunderbird Send" cloudfile account on
  startup, polluting the default profile and breaking Thunderbird's own cloudfile
  tests, which assert a clean account baseline.

## Limitations and Notes

- The pre-existing intermittents in the same run are out of scope: a11y-checks
  `browser_calendarUnifinder.js` (Bug 2027530) and the xpcshell `selftest.py`
  `this_test_will_fail` self-test (Bugs 1967418 / 2018465 / 1999404).
- The cloudfile fix targets the **account** baseline. If any remaining
  cloudfile assertion turns out to be perturbed merely by the `cloud_file`
  manifest entry registering a **provider type** (independent of accounts), that
  can't be gated at runtime and would need the comm-central side to skip/disable
  the built-in add-on for those test manifests. Confirm on the next try push.
- `npx tsc --noEmit` reports pre-existing errors in unrelated files
  (`linkHandler`, `MailAccounts`, folder-store `.at()`, `@send-backend/router`);
  this change introduces none.

## Applicable Issues

Closes #862

## Verification

- `npm run build` — confirmed `dist/assets/*.css` contains no absolute
  `url(/fonts/` and that `dist/assets/../fonts/Inter/Inter-Regular.woff2`
  resolves to a real file.
- `npm run test` — full add-on suite passes (16 passed, 1 skipped), including the
  new `cloudFileGate` gate test.
- Next step: re-push to try-comm-central and confirm `browser_parsable_css.js`,
  `browser_ext_cloudFile.js`, `browser_repeat_upload.js`, and the
  addRemoveAccounts subtest go green.

## Screenshots

N/A — build/CI change.
