### PR TITLE
fix css parsing

### DIFF
--- a/packages/addon/scripts/build.sh
+++ b/packages/addon/scripts/build.sh
@@ -70,6 +70,20 @@ echo "=============== rewrite font urls =============================="
 find dist/assets -name '*.css' -exec perl -pi -e 's{url\(/fonts/}{url(../fonts/}g' {} +
 
 echo "================================================================"
+echo "=============== sanitize parsable css =========================="
+### Thunderbird's static browser_parsable_css.js check (Bug 2036665) rejects a
+### handful of declarations that autoprefixer / vendored libs leak into the
+### bundled CSS:
+###   * -moz-column-gap          -> not a real Gecko property (the standard
+###                                 column-gap is emitted right alongside it)
+###   * -webkit-text-size-adjust -> value rejected by Gecko's parser
+###   * :global(...)             -> Vue scoped-CSS wrapper left unprocessed
+### Drop the two dead vendor-prefixed declarations and unwrap :global(X) -> X so
+### the packaged add-on passes the static check.
+find dist/assets -name '*.css' -exec perl -pi -e \
+  's/-moz-column-gap:[^;}]*;?//g; s/-webkit-text-size-adjust:[^;}]*;?//g; s/:global\(([^)]*)\)/$1/g;' {} +
+
+echo "================================================================"
 echo "=============== background.js =================================="
 ### Build `background.js` as a library
 vite build --config vite.config.background.js


### PR DESCRIPTION
## Describe the bug

When the add-on is shipped as the built-in (system) add-on, a try-comm-central
run fails `browser_parsable_css.js` on every platform (Linux, macOS, Windows).
The bundled CSS ships three declarations that Thunderbird's static
`browser_parsable_css.js` check rejects, so the add-on's own stylesheets each
report parse errors and the test fails.

This is the follow-on regression after the earlier absolute-`/fonts/` crash was
fixed (see ISSUE_cloudfile_and_fonts.md): the test now loads the CSS far enough
to parse it, and the parser rejects the offending declarations.

Reference run: try-comm-central revision
`f44985485a1a97b96dc5ac72434019be6dfdf17e`.

## To Reproduce

Steps to reproduce the behavior:

1. Build the add-on and package it as the built-in/system add-on in
   comm-central.
2. Run the Thunderbird mochitest-thunderbird suite (try: `-b o -p all -u all`).
3. See `browser_parsable_css.js` report parse errors for
   `resource://builtin-addons/thundermail/assets/management.css` and
   `.../assets/extension.css`.

## Expected behavior

The packaged add-on ships CSS that passes Thunderbird's static
`browser_parsable_css.js` check — i.e. "All the styles loaded without errors."

## Actual behavior

```
TEST-UNEXPECTED-FAIL | browser_parsable_css.js | checkAllTheCSS - Got error message for resource://builtin-addons/thundermail/assets/management.css: Unknown property ‘-moz-column-gap’.  Declaration dropped.
TEST-UNEXPECTED-FAIL | browser_parsable_css.js | checkAllTheCSS - Got error message for resource://builtin-addons/thundermail/assets/management.css: Error in parsing value for ‘-webkit-text-size-adjust’.  Declaration dropped.
TEST-UNEXPECTED-FAIL | browser_parsable_css.js | checkAllTheCSS - Got error message for resource://builtin-addons/thundermail/assets/management.css: Unknown pseudo-class or pseudo-element ‘global’.  Ruleset ignored due to bad selector.
TEST-UNEXPECTED-FAIL | browser_parsable_css.js | checkAllTheCSS - All the styles (460) loaded without errors. - Got 6, expected +0
```

The same three errors repeat for `assets/extension.css` (6 errors total, 3 per
file). They come from the bundled output, not hand-written source:

1. **`-moz-column-gap:2.25rem;`** — not a real Gecko property (autoprefixer emits
   it; the standard `column-gap:2.25rem` is already present right beside it).
2. **`-webkit-text-size-adjust:100%`** — from a vendored CSS reset; only the
   `-webkit-` form is present and Gecko rejects the value.
3. **`:global(.v-tooltip){…}`** — a Vue/floating-vue scoped-CSS `:global()`
   wrapper that leaked into the bundle unprocessed; Gecko rejects the `:global`
   pseudo-class.

## Screenshots
https://treeherder.mozilla.org/jobs?repo=try-comm-central&revision=f44985485a1a97b96dc5ac72434019be6dfdf17e&selectedTaskRun=FXp7zbznSIOV7JoAYqoKeg.0

N/A — CI failures. See the Treeherder run linked above.

## System

- OS: All (Linux 24.04, macOS 14.7/15.0, Windows 11 32/64) — reproduced on every
  platform.
- Browser Version: Thunderbird (comm-central / try-comm-central), Gecko >= 140.

## Additional context

Tracked upstream under Bug 2036665 (built-in add-on packaging). The fix mirrors
the existing absolute-`/fonts/` rewrite already in
`packages/addon/scripts/build.sh` — a post-build sanitization of `dist/assets/*.css`.

**Not in scope of this issue:** the same run also fails
`browser_cloudfile.js | addRemoveAccounts` because Thundermail's built-in
`cloud_file` provider now appears in the provider list, breaking a core
Thunderbird test that hardcodes a one-provider baseline. That fix lives in the
comm-central test tree (update the baseline to tolerate the built-in provider),
not in this add-on repo, and is tracked separately.

Closes #867 
