### PR TITLE
fix: only register Send cloud file provider when signed in

### DIFF
--- a/packages/addon/public/api/CloudFileAccounts/implementation.js
+++ b/packages/addon/public/api/CloudFileAccounts/implementation.js
@@ -11,10 +11,26 @@
 
   exports.CloudFileAccounts = class extends ExtensionCommon.ExtensionAPI {
     onStartup() {
-      // Ensure provider is checked during startup.
-      this._cloudProviderRegistered = this._cloudProviderRegistered.bind(this);
-      cloudFileAccounts.on('providerRegistered', this._cloudProviderRegistered);
-      this._cloudProviderRegistered('ext-' + this.extension.id);
+      this._providerType = 'ext-' + this.extension.id;
+
+      // The "Thunderbird Send" cloud file provider is declared via the manifest
+      // `cloud_file` key, so Thunderbird registers it automatically on every
+      // startup — including on fresh, never-signed-in profiles where the
+      // built-in system add-on runs under automation. We keep a reference to the
+      // provider object so the background script can unregister it while signed
+      // out (hiding Send from the cloud file provider list and preferences) and
+      // re-register the very same instance on sign-in, which keeps the
+      // browser.cloudFile.onFileUpload binding intact. See Bug 2036665.
+      this._capturedProvider =
+        cloudFileAccounts.getProviderForType(this._providerType) || null;
+
+      // When true, the provider must stay hidden even if Thunderbird registers
+      // it after the background script has already asked us to unregister it
+      // (the manifest registration and the background script race at startup).
+      this._keepUnregistered = false;
+
+      this._onProviderRegistered = this._onProviderRegistered.bind(this);
+      cloudFileAccounts.on('providerRegistered', this._onProviderRegistered);
     }
 
     onShutdown(isAppShutdown) {
@@ -22,22 +38,35 @@
         return;
       }
 
-      cloudFileAccounts.off(
-        'providerRegistered',
-        this._cloudProviderRegistered
-      );
+      cloudFileAccounts.off('providerRegistered', this._onProviderRegistered);
     }
 
-    _cloudProviderRegistered(providerType) {
-      if (providerType == 'ext-' + this.extension.id) {
-        cloudFileAccounts.getProviderForType('ext-' + this.extension.id);
+    // EventEmitter invokes listeners as (eventName, ...args), so rather than
+    // depend on the emitted argument we re-check the registry by our type.
+    _onProviderRegistered() {
+      const provider = cloudFileAccounts.getProviderForType(this._providerType);
+      if (!provider) {
+        return;
+      }
+
+      // Remember the provider instance so it can be re-registered on sign-in.
+      this._capturedProvider = provider;
+
+      // If we are meant to stay signed out, immediately undo the registration.
+      if (this._keepUnregistered) {
+        cloudFileAccounts.unregisterProvider(this._providerType);
       }
     }
 
     getAPI(_context) {
+      const providerType = 'ext-' + this.extension.id;
+
+      // Arrow functions keep `this` bound to the ExtensionAPI instance so the
+      // register/unregister handlers can read and update the captured provider
+      // and the _keepUnregistered flag set up in onStartup().
       return {
         CloudFileAccounts: {
-          async createAccount(type, configured) {
+          createAccount: async (type, configured) => {
             try {
               // Check if the provider is registered
               const provider = cloudFileAccounts.getProviderForType(type);
@@ -84,6 +113,62 @@
               return {
                 success: false,
                 error: `Error creating cloud file account: ${error.message}`,
+              };
+            }
+          },
+
+          // Re-register the Send provider (e.g. on sign-in). Idempotent: a
+          // no-op if the provider is already in the registry.
+          registerProvider: async () => {
+            this._keepUnregistered = false;
+
+            if (cloudFileAccounts.getProviderForType(providerType)) {
+              return { success: true, alreadyRegistered: true };
+            }
+
+            if (!this._capturedProvider) {
+              return {
+                success: false,
+                error: `No cloud file provider '${providerType}' available to register.`,
+              };
+            }
+
+            try {
+              cloudFileAccounts.registerProvider(
+                providerType,
+                this._capturedProvider
+              );
+              return { success: true };
+            } catch (error) {
+              return {
+                success: false,
+                error: `Error registering cloud file provider: ${error.message}`,
+              };
+            }
+          },
+
+          // Hide the Send provider while signed out. Idempotent: a no-op if the
+          // provider is not currently registered.
+          unregisterProvider: async () => {
+            // Stay hidden even if Thunderbird registers the provider after this
+            // call (manifest registration vs. background script startup race).
+            this._keepUnregistered = true;
+
+            const provider = cloudFileAccounts.getProviderForType(providerType);
+            if (!provider) {
+              return { success: true, alreadyUnregistered: true };
+            }
+
+            // Keep the instance so we can re-register it on sign-in.
+            this._capturedProvider = provider;
+
+            try {
+              cloudFileAccounts.unregisterProvider(providerType);
+              return { success: true };
+            } catch (error) {
+              return {
+                success: false,
+                error: `Error unregistering cloud file provider: ${error.message}`,
               };
             }
           },

--- a/packages/addon/public/api/CloudFileAccounts/schema.json
+++ b/packages/addon/public/api/CloudFileAccounts/schema.json
@@ -48,6 +48,58 @@
             }
           }
         }
+      },
+      {
+        "name": "registerProvider",
+        "type": "function",
+        "description": "Re-registers the Send cloud file provider (the same instance Thunderbird created from the manifest) so it appears in the provider list. Idempotent. Used on sign-in.",
+        "async": true,
+        "parameters": [],
+        "returns": {
+          "type": "object",
+          "properties": {
+            "success": {
+              "type": "boolean",
+              "description": "Whether the operation was successful."
+            },
+            "alreadyRegistered": {
+              "type": "boolean",
+              "optional": true,
+              "description": "True if the provider was already registered."
+            },
+            "error": {
+              "type": "string",
+              "optional": true,
+              "description": "Error message if the operation failed."
+            }
+          }
+        }
+      },
+      {
+        "name": "unregisterProvider",
+        "type": "function",
+        "description": "Unregisters the Send cloud file provider so it is hidden from the provider list while the user is signed out. Idempotent. The provider instance is retained for re-registration on sign-in.",
+        "async": true,
+        "parameters": [],
+        "returns": {
+          "type": "object",
+          "properties": {
+            "success": {
+              "type": "boolean",
+              "description": "Whether the operation was successful."
+            },
+            "alreadyUnregistered": {
+              "type": "boolean",
+              "optional": true,
+              "description": "True if the provider was not registered to begin with."
+            },
+            "error": {
+              "type": "string",
+              "optional": true,
+              "description": "Error message if the operation failed."
+            }
+          }
+        }
       }
     ]
   }

--- a/packages/addon/src/background.ts
+++ b/packages/addon/src/background.ts
@@ -103,6 +103,16 @@ function logAccountCreationResult(result: {
 // ==============================================
 // Initialize the cloudFile accounts, keychain, and stores.
 async function initCloudFile() {
+  // Make sure the Send provider is registered before creating an account. While
+  // signed out we unregister it (see main()), so a sign-in must re-register the
+  // provider first; createAccount fails otherwise. This is a no-op when the
+  // provider is already registered.
+  try {
+    await browser.CloudFileAccounts.registerProvider();
+  } catch (error) {
+    console.warn('Error registering cloud file provider:', error);
+  }
+
   try {
     const result = await browser.CloudFileAccounts.createAccount(
       getAddonId(),
@@ -334,6 +344,13 @@ browser.runtime.onMessage.addListener(async (message, sender) => {
 
     case SIGN_OUT:
       menuLogout();
+      // Hide the Send provider again so a signed-out profile matches the
+      // fresh-install baseline (provider only exists while signed in).
+      try {
+        await browser.CloudFileAccounts.unregisterProvider();
+      } catch (e) {
+        console.warn('Error unregistering cloud file provider on sign-out:', e);
+      }
       break;
 
     case SIGN_IN:
@@ -758,6 +775,17 @@ function initAccountHubListener() {
   const { isLoggedIn } = await getLoginState();
   if (shouldInitCloudFileOnStartup(isLoggedIn)) {
     initCloudFile();
+  } else {
+    // Signed out: the manifest `cloud_file` key makes Thunderbird register the
+    // Send provider on every startup, so on a fresh/never-signed-in profile it
+    // would still appear in the cloud file provider list and break Thunderbird's
+    // own cloudfile tests (Bug 2036665). Unregister it until the user signs in;
+    // initCloudFile() re-registers it on sign-in.
+    try {
+      await browser.CloudFileAccounts.unregisterProvider();
+    } catch (error) {
+      console.warn('Error unregistering cloud file provider:', error);
+    }
   }
   initStorageWatcher();
   initAccountHubListener();

--- a/packages/addon/src/cloudFileGate.ts
+++ b/packages/addon/src/cloudFileGate.ts
@@ -14,6 +14,12 @@
  * The account is still created on explicit sign-in via the SIGN_IN_COMPLETE
  * flow in background.ts, so signed-in users (standalone or system) keep the Send
  * cloudfile provider configured.
+ *
+ * The manifest `cloud_file` key also makes Thunderbird register the Send
+ * provider itself on every startup, independently of the account. When this
+ * returns false, background.ts additionally unregisters that provider (via the
+ * CloudFileAccounts experiment API) so a signed-out profile shows no Send entry
+ * in the cloud file provider list at all; it is re-registered on sign-in.
  */
 export function shouldInitCloudFileOnStartup(isLoggedIn: boolean): boolean {
   return isLoggedIn;

--- a/packages/addon/src/env.d.ts
+++ b/packages/addon/src/env.d.ts
@@ -157,5 +157,33 @@ declare namespace browser {
       type: string,
       configured: boolean
     ): Promise<CreateAccountResult>;
+
+    /**
+     * Result returned when toggling the provider's registration.
+     */
+    interface ProviderRegistrationResult {
+      /** Whether the operation was successful */
+      success: boolean;
+      /** True if the provider was already registered */
+      alreadyRegistered?: boolean;
+      /** True if the provider was not registered to begin with */
+      alreadyUnregistered?: boolean;
+      /** Error message if the operation failed */
+      error?: string;
+    }
+
+    /**
+     * Re-registers the Send cloud file provider (the instance Thunderbird
+     * created from the manifest `cloud_file` key) so it appears in the provider
+     * list. Idempotent. Called on sign-in.
+     */
+    function registerProvider(): Promise<ProviderRegistrationResult>;
+
+    /**
+     * Unregisters the Send cloud file provider so it is hidden from the provider
+     * list while the user is signed out. Idempotent. The provider instance is
+     * retained internally for re-registration on sign-in.
+     */
+    function unregisterProvider(): Promise<ProviderRegistrationResult>;
   }
 }


### PR DESCRIPTION
## What changed?

Gates the **Send cloud file provider** registration (not just account creation) on login state, so a signed-out or fresh/system-add-on profile shows no "Thunderbird Send" entry in the cloud file provider list.

Key changes:
- `packages/addon/public/api/CloudFileAccounts/implementation.js` — captures the provider instance Thunderbird creates from the manifest `cloud_file` key and adds idempotent `registerProvider()` / `unregisterProvider()` functions. A `_keepUnregistered` flag plus a `providerRegistered` listener handles the startup race where the manifest registration can land after the background script asks to hide it. Re-registering the *same* instance keeps the `browser.cloudFile.onFileUpload` binding intact.
- `packages/addon/public/api/CloudFileAccounts/schema.json` and `packages/addon/src/env.d.ts` — declare the two new experiment API functions.
- `packages/addon/src/background.ts` — on startup, unregister the provider when signed out; `initCloudFile()` re-registers it before creating the account (covers sign-in); `SIGN_OUT` re-hides the provider.
- `packages/addon/src/cloudFileGate.ts` — expanded doc comment to cover provider gating.

**AI disclosure:** This change was largely agent-written (Claude Code / Claude Opus) under human direction. The human verified the approach against Thunderbird's real `cloudFileAccounts.sys.mjs` API, reviewed the diff, and ran typecheck/lint/tests. I am an AI assistant.

## Why?

The add-on exposes a WebExtension cloud file provider (`ext-tbpro-system-add-on@thunderbird.net`) via the manifest `cloud_file` key, which Thunderbird registers on every startup regardless of login state. The pre-existing guard only prevented account creation, not provider registration, so on fresh/never-signed-in profiles the provider still appeared in the provider list. That broke Thunderbird's own `browser_cloudfile.js` (and related cloudfile tests), which assume a clean provider/account baseline. Related to Bug 2036665.

## Limitations and Notes

- Provider register/unregister only executes inside Thunderbird's chrome process, so the experiment-API behavior should be confirmed on the next try run (the `bct5` `browser_cloudfile.js` group). Unit tests cover the pure startup gate; the chrome-side logic is not unit-testable here.
- `dist/` is gitignored and rebuilt from `public/`, so only `public/api` (the source of truth) was edited.

## Applicable Issues

Closes #869

## Screenshots

N/A — no UI changes; behavior change is the absence of the Send provider while signed out.
