### PR TITLE
Sunset ATN stage/prod add-on at Gecko 153.0.0

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -423,6 +423,7 @@ jobs:
           BASE_URL: ${{ matrix.base_url }}
           SEND_SERVER_URL: ${{ matrix.send_server_url }}
           SEND_CLIENT_URL: ${{ matrix.send_client_url }}
+          DEPRECATION_VERSION: "153.0.0"
         run: |
           echo "Environment: ${{ matrix.env }}"
           cd packages/addon
@@ -435,7 +436,8 @@ jobs:
           VITE_POSTHOG_PROJECT_KEY=${POSTHOG_KEY}
           VITE_POSTHOG_HOST=${POSTHOG_HOST}
           VITE_OIDC_CLIENT_ID=${OIDC_CLIENT_ID}
-          VITE_OIDC_ROOT_URL=${OIDC_ROOT_URL}                    
+          VITE_OIDC_ROOT_URL=${OIDC_ROOT_URL}
+          VITE_DEPRECATION_VERSION=${DEPRECATION_VERSION}
           EOF
 
       - name: Build the frontend's static assets

--- a/packages/addon/src/selfUninstall.ts
+++ b/packages/addon/src/selfUninstall.ts
@@ -1,8 +1,8 @@
 /// <reference types="thunderbird-webext-browser" />
 
-import { ADDON_ID_STAGE } from './addonIds';
+import { ADDON_ID_PROD, ADDON_ID_STAGE } from './addonIds';
 
-const DEPRECATION_ADDON_IDS = [ADDON_ID_STAGE];
+const DEPRECATION_ADDON_IDS = [ADDON_ID_STAGE, ADDON_ID_PROD];
 
 /**
  * Compare two semver strings. Returns true if `a >= b`.
@@ -22,7 +22,7 @@ function semverGte(a: string, b: string): boolean {
  *
  * Uninstall conditions (all must be true):
  * 1. `VITE_DEPRECATION_VERSION` env var is set at build time.
- * 2. The running addon ID matches the designated stage ID.
+ * 2. The running addon ID matches the designated deprecation ID.
  * 3. The Thunderbird (Gecko) version is >= the deprecation cutoff version.
  *
  * Production builds are unaffected because their addon ID differs.

--- a/packages/addon/src/test/selfUninstall.test.ts
+++ b/packages/addon/src/test/selfUninstall.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { ADDON_ID_PROD, ADDON_ID_STAGE } from '../addonIds';
+import { ADDON_ID_PROD, ADDON_ID_STAGE, ADDON_ID_SYSTEM } from '../addonIds';
 import { checkAndUninstallIfDeprecated } from '../selfUninstall';
 
 const STAGE_ADDON_ID = ADDON_ID_STAGE;
 const PROD_ADDON_ID = ADDON_ID_PROD;
+const SYSTEM_ADDON_ID = ADDON_ID_SYSTEM;
 const CUTOFF_VERSION = '140.0';
 
 function setupBrowserMock(addonId: string, geckoVersion = '145.0') {
@@ -56,8 +57,16 @@ describe('checkAndUninstallIfDeprecated', () => {
     expect(browser.management.uninstallSelf).not.toHaveBeenCalled();
   });
 
-  it('does not uninstall when addon ID does not match', async () => {
+  it('uninstalls the prod addon when ID matches and gecko version >= cutoff', async () => {
     setupBrowserMock(PROD_ADDON_ID);
+
+    await checkAndUninstallIfDeprecated();
+
+    expect(browser.management.uninstallSelf).toHaveBeenCalledOnce();
+  });
+
+  it('does not uninstall the built-in system addon', async () => {
+    setupBrowserMock(SYSTEM_ADDON_ID);
 
     await checkAndUninstallIfDeprecated();
 


### PR DESCRIPTION
## What changed?
Ensures the standalone stage and prod add-ons actually self-uninstall once Thunderbird (Gecko) reaches the deprecation cutoff of `153.0.0`:

- **`packages/addon/src/selfUninstall.ts`** — added `ADDON_ID_PROD` to `DEPRECATION_ADDON_IDS` so both the stage and prod add-on IDs are deprecated (previously stage-only), and updated the doc comment to say "deprecation ID" instead of "stage ID".
- **`.github/workflows/merge.yml`** — added `VITE_DEPRECATION_VERSION=153.0.0` to the `.env` that the `(Addon) Create .env file from secrets` step generates for both the stage and prod builds (via a new `DEPRECATION_VERSION` step env var). Without this, CI regenerated `.env` without the variable, so Vite inlined `undefined` and the shipped XPIs skipped the uninstall.

**AI disclosure:** The diagnosis (CI `.env` omission + the prod-ID gap) and the `merge.yml` change were produced by Claude (Claude Code) and reviewed by me; the `selfUninstall.ts` change was authored alongside it. All changes were human-reviewed before commit.

## Why?
The stage/prod add-ons distributed via ATN are superseded by the built-in system add-on shipped in Thunderbird 153+, so they should remove themselves at the cutoff. As shipped, neither path worked: the prod ID was never in the deprecation list, and CI never passed `VITE_DEPRECATION_VERSION` into the build, so `checkAndUninstallIfDeprecated()` short-circuited on the `if (!cutoffVersion)` guard.

## Limitations and Notes
- Only affects builds produced **after** this is merged; already-published XPIs must be rebuilt and re-shipped through this workflow to pick up the cutoff.
- `strict_max_version: "153.*"` in the manifest is a separate, complementary mechanism and is unchanged.
- The cutoff value is currently hardcoded to `153.0.0` as a step-level env var for easy future changes in one place.

## Applicable Issues
Closes #875

## Screenshots
N/A
