### PR TITLE
fix: repair AccountHub auto-login experiment for upstream Thunderbird API changes

### DIFF
--- a/packages/addon/public/api/AccountHub/implementation.js
+++ b/packages/addon/public/api/AccountHub/implementation.js
@@ -39,20 +39,11 @@
                 async onServerLoaded(server) {
                   try {
                     const hostname = server.hostname;
-                    console.log(
-                      `[AccountHub] onServerLoaded fired for host: ${hostname}`
-                    );
                     if (!THUNDERMAIL_HOST_PATTERN.test(hostname)) {
-                      console.log(
-                        `[AccountHub] Host ${hostname} is not a Thundermail host — ignoring.`
-                      );
                       return;
                     }
 
                     const email = server.username;
-                    console.log(
-                      `[AccountHub] Thundermail host matched. email=${email}`
-                    );
 
                     const oauth2Module = new OAuth2Module();
                     if (!oauth2Module.initFromMail(server)) {
@@ -61,20 +52,13 @@
                       );
                       return;
                     }
-                    console.log('[AccountHub] OAuth2Module initialized.');
 
                     // getRefreshToken() asynchronously reads the stored token
                     // from the Thunderbird login manager (password manager).
                     // The token is guaranteed to be stored already because
                     // verifyConfig() (which runs OAuth2 auth) completes before
                     // createAccountInBackend() fires NotifyServerLoaded.
-                    console.log('[AccountHub] Awaiting getRefreshToken()...');
                     const token = await oauth2Module.getRefreshToken();
-                    console.log(
-                      `[AccountHub] getRefreshToken() resolved. type=${typeof token}, hasToken=${!!token}, length=${
-                        token ? token.length : 0
-                      }`
-                    );
 
                     if (!token) {
                       console.warn(
@@ -87,14 +71,8 @@
                     const account =
                       MailServices.accounts.findAccountForServer(server);
                     const name = account?.defaultIdentity?.fullName ?? '';
-                    console.log(
-                      `[AccountHub] Resolved name="${name}". Firing onAccountAdded for ${email}.`
-                    );
 
                     fire.async({ token, email, name });
-                    console.log(
-                      `[AccountHub] fire.async dispatched for ${email}.`
-                    );
                   } catch (e) {
                     console.error(
                       '[AccountHub] Error in onServerLoaded handler:',

--- a/packages/addon/public/api/AccountHub/implementation.js
+++ b/packages/addon/public/api/AccountHub/implementation.js
@@ -36,14 +36,23 @@
                   'nsIIncomingServerListener',
                 ]),
 
-                onServerLoaded(server) {
+                async onServerLoaded(server) {
                   try {
-                    const hostname = server.hostName;
+                    const hostname = server.hostname;
+                    console.log(
+                      `[AccountHub] onServerLoaded fired for host: ${hostname}`
+                    );
                     if (!THUNDERMAIL_HOST_PATTERN.test(hostname)) {
+                      console.log(
+                        `[AccountHub] Host ${hostname} is not a Thundermail host — ignoring.`
+                      );
                       return;
                     }
 
                     const email = server.username;
+                    console.log(
+                      `[AccountHub] Thundermail host matched. email=${email}`
+                    );
 
                     const oauth2Module = new OAuth2Module();
                     if (!oauth2Module.initFromMail(server)) {
@@ -52,13 +61,20 @@
                       );
                       return;
                     }
+                    console.log('[AccountHub] OAuth2Module initialized.');
 
-                    // getRefreshToken() reads the stored token directly from
-                    // the Thunderbird login manager (password manager).
+                    // getRefreshToken() asynchronously reads the stored token
+                    // from the Thunderbird login manager (password manager).
                     // The token is guaranteed to be stored already because
                     // verifyConfig() (which runs OAuth2 auth) completes before
                     // createAccountInBackend() fires NotifyServerLoaded.
-                    const token = oauth2Module.getRefreshToken();
+                    console.log('[AccountHub] Awaiting getRefreshToken()...');
+                    const token = await oauth2Module.getRefreshToken();
+                    console.log(
+                      `[AccountHub] getRefreshToken() resolved. type=${typeof token}, hasToken=${!!token}, length=${
+                        token ? token.length : 0
+                      }`
+                    );
 
                     if (!token) {
                       console.warn(
@@ -71,8 +87,14 @@
                     const account =
                       MailServices.accounts.findAccountForServer(server);
                     const name = account?.defaultIdentity?.fullName ?? '';
+                    console.log(
+                      `[AccountHub] Resolved name="${name}". Firing onAccountAdded for ${email}.`
+                    );
 
                     fire.async({ token, email, name });
+                    console.log(
+                      `[AccountHub] fire.async dispatched for ${email}.`
+                    );
                   } catch (e) {
                     console.error(
                       '[AccountHub] Error in onServerLoaded handler:',
@@ -82,8 +104,8 @@
                 },
 
                 // Required by nsIMsgIncomingServerListener but not used here.
-                onServerUnloaded(_server) {},
-                onServerChanged(_server) {},
+                onServerUnloaded(_server) { },
+                onServerChanged(_server) { },
               };
 
               MailServices.accounts.addIncomingServerListener(serverListener);

--- a/packages/addon/public/manifest.json
+++ b/packages/addon/public/manifest.json
@@ -8,7 +8,7 @@
     "gecko": {
       "id": "tbpro-addon-stage@thunderbird.net",
       "strict_min_version": "140.0",
-      "strict_max_version": "153.*"
+      "strict_max_version": "155.*"
     }
   },
   "background": {

--- a/packages/addon/src/background.ts
+++ b/packages/addon/src/background.ts
@@ -740,31 +740,24 @@ function initStorageWatcher() {
 function initAccountHubListener() {
   browser.AccountHub.onAccountAdded.addListener(async ({ token, email }) => {
     console.log(
-      `[AccountHub] onAccountAdded fired for ${email}. Logging in add-on. ` +
-        `tokenType=${typeof token}, hasToken=${!!token}, tokenLength=${
-          token ? token.length : 0
-        }`
+      `[AccountHub] onAccountAdded fired for ${email}. Logging in add-on.`
     );
 
     // Ensure the OAuth2 token is registered against the TB mail account.
     try {
-      const result = await addThundermailToken(token, email, THUNDERMAIL_HOST);
-      console.log('[AccountHub] addThundermailToken result:', result);
+      await addThundermailToken(token, email, THUNDERMAIL_HOST);
     } catch (e) {
       console.error('[AccountHub] Failed to store OIDC token:', e);
     }
 
     // Update the add-on menu to reflect the logged-in state.
-    console.log('[AccountHub] Updating menu to logged-in state.');
     menuLoggedIn({ username: email });
 
     // Trigger Add-On to Web: stage the token in storage and open /addon-auth.
     // AccountHub provides a refresh token only; authenticateWithAddonToken
     // will exchange it for a full token set via signinSilent.
     try {
-      console.log('[AccountHub] Calling triggerAddonLogin...');
       await triggerAddonLogin({ refresh_token: token });
-      console.log('[AccountHub] triggerAddonLogin completed.');
     } catch (e) {
       console.error('[AccountHub] Failed to trigger addon login:', e);
     }

--- a/packages/addon/src/background.ts
+++ b/packages/addon/src/background.ts
@@ -740,24 +740,31 @@ function initStorageWatcher() {
 function initAccountHubListener() {
   browser.AccountHub.onAccountAdded.addListener(async ({ token, email }) => {
     console.log(
-      `[AccountHub] onAccountAdded fired for ${email}. Logging in add-on.`
+      `[AccountHub] onAccountAdded fired for ${email}. Logging in add-on. ` +
+        `tokenType=${typeof token}, hasToken=${!!token}, tokenLength=${
+          token ? token.length : 0
+        }`
     );
 
     // Ensure the OAuth2 token is registered against the TB mail account.
     try {
-      await addThundermailToken(token, email, THUNDERMAIL_HOST);
+      const result = await addThundermailToken(token, email, THUNDERMAIL_HOST);
+      console.log('[AccountHub] addThundermailToken result:', result);
     } catch (e) {
       console.error('[AccountHub] Failed to store OIDC token:', e);
     }
 
     // Update the add-on menu to reflect the logged-in state.
+    console.log('[AccountHub] Updating menu to logged-in state.');
     menuLoggedIn({ username: email });
 
     // Trigger Add-On to Web: stage the token in storage and open /addon-auth.
     // AccountHub provides a refresh token only; authenticateWithAddonToken
     // will exchange it for a full token set via signinSilent.
     try {
+      console.log('[AccountHub] Calling triggerAddonLogin...');
       await triggerAddonLogin({ refresh_token: token });
+      console.log('[AccountHub] triggerAddonLogin completed.');
     } catch (e) {
       console.error('[AccountHub] Failed to trigger addon login:', e);
     }


### PR DESCRIPTION
## What changed?

Fixes the AccountHub auto-login experiment in [`packages/addon/public/api/AccountHub/implementation.js`](packages/addon/public/api/AccountHub/implementation.js) for two upstream Thunderbird API changes:

- `server.hostName` → `server.hostname` — `nsIMsgIncomingServer` renamed the property, so the old name returned `undefined` and the Thundermail host regex never matched.
- `onServerLoaded` is now `async` and `getRefreshToken()` is `await`ed — the method became async upstream; without `await` a Promise was being dispatched instead of the refresh-token string.

Also:
- Added step-by-step `[AccountHub]` diagnostic logging through the handler (and matching logs in `background.ts`) so this experiment, which runs in the field and is hard to debug, reports exactly where it stops.
- Raised `manifest.json` `strict_max_version` to `155.*` to cover the Thunderbird versions where these changes landed.

**AI disclosure:** Investigated and written with Claude Code (agent-driven). The agent root-caused the breakage by diffing the experiment code against the live Thunderbird source, then proposed and applied the fixes. I reviewed every change, ran it in Thunderbird, and confirmed the Accounts-Hub auto-login flow works end-to-end before merging.

## Why?

The feature — automatically logging the add-on in when a Thundermail account is added through Thunderbird's Accounts Hub — silently stopped working. After the upstream `hostName`→`hostname` rename and the move of `getRefreshToken()` to async, `onServerLoaded` bailed at its first gate on every account, so the add-on never signed in.

## Limitations and Notes

- The verbose `[AccountHub]` logging is intentionally left in to aid field diagnosis of the experiment; happy to trim it if preferred.
- The timing assumption (refresh token stored before `onServerLoaded` fires) is unchanged. The new `hasToken`/`length` log makes any future read/write race obvious, and a short retry is the fallback if it ever surfaces.

## Applicable Issues

Closes #884

## Screenshots

N/A
