### PR TITLE
Get the nightly E2E tests running on BrowserStack once again

### DIFF
--- a/.github/workflows/e2e-desktop-nightly-chrome.yml
+++ b/.github/workflows/e2e-desktop-nightly-chrome.yml
@@ -32,6 +32,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
       - name: Install dependencies
         run: |
           cd ./packages/send/e2e

--- a/.github/workflows/e2e-desktop-nightly-firefox.yml
+++ b/.github/workflows/e2e-desktop-nightly-firefox.yml
@@ -32,6 +32,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
       - name: Install dependencies
         run: |
           cd ./packages/send/e2e

--- a/.github/workflows/e2e-desktop-nightly-safari.yml
+++ b/.github/workflows/e2e-desktop-nightly-safari.yml
@@ -32,6 +32,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
       - name: Install dependencies
         run: |
           cd ./packages/send/e2e

--- a/.github/workflows/e2e-mobile-nightly-android.yml
+++ b/.github/workflows/e2e-mobile-nightly-android.yml
@@ -32,6 +32,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
       - name: Install dependencies
         run: |
           cd ./packages/send/e2e

--- a/.github/workflows/e2e-mobile-nightly-ios.yml
+++ b/.github/workflows/e2e-mobile-nightly-ios.yml
@@ -32,6 +32,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
       - name: Install dependencies
         run: |
           cd ./packages/send/e2e

--- a/packages/send/e2e/browserstack-desktop-nightly.yml
+++ b/packages/send/e2e/browserstack-desktop-nightly.yml
@@ -90,7 +90,7 @@ framework: playwright
 # and mobile browsers; and therefore must be the same in all of our browserstack-*.yml config files
 # for playwright ver we need one compatible with our desktop and mobile browsers, see:
 # https://www.browserstack.com/docs/automate/playwright/browsers-and-os?fw-lang=nodejs
-browserstack.playwrightVersion: 1.56.1 # must match our client playwright version in package.json
+browserstack.playwrightVersion: 1.59.1 # must match our client playwright version in package.json
 browserstack.playwrightLogs: false # disable playwright logs appearing on browserstack builds as may contain sensitive info like credentials
 # CUSTOM_TAG_<INT>: # <string> (Default: parent folder name of the test file) Custom tag for your test suite
 browserstack.maskBasicAuth: true # mask username and passwords from browserstack session logs

--- a/packages/send/e2e/browserstack-mobile-nightly.yml
+++ b/packages/send/e2e/browserstack-mobile-nightly.yml
@@ -79,7 +79,7 @@ idleTimeout: 500 # seeing if this helps rid BROWSERSTACK_IDLE_TIMEOUTs on ios
 # and mobile browsers; and therefore must be the same in all of our browserstack-*.yml config files
 # for playwright ver we need one compatible with our desktop and mobile browsers, see:
 # https://www.browserstack.com/docs/automate/playwright/browsers-and-os?fw-lang=nodejs
-browserstack.playwrightVersion: 1.56.1 # must match ver in package.json
+browserstack.playwrightVersion: 1.59.1 # must match ver in package.json
 browserstack.playwrightLogs: false # disable playwright logs appearing on browserstack builds as may contain sensitive info like credentials
 # CUSTOM_TAG_<INT>: # <string> (Default: parent folder name of the test file) Custom tag for your test suite
 browserstack.maskBasicAuth: true # mask username and passwords from browserstack session logs


### PR DESCRIPTION
## What changed?
Forcing the E2E test job to use Node version 20 when running the E2E tests in BrowserStack.

## Why?
The E2E tests stopped running in BrowserStack last night 'out of the blue'. Unfortunately BrowserStack has issues with newer Node versions, so we have to use Node 20 in the GHA job that runs the BrowserStack E2E tests job. In the other services we have this set to Node 20 already but it was missing in the GHA workflows here. Also updating the playwright version in the BrowserStack configs to match the version in the e2e/package.json (this should match and can potentially cause issues if it doesn't).

## Limitations and Notes
This doesn't change the Node version in the actual Send service, only the version used in the GHA job when running the E2E tests on BrowserStack.

## Applicable Issues
Fixes #888.

## QA Log
Ran the nightly E2E BrowserStack jobs on this branch, via their corresponding GHA workflows (all tests passed). BrowserStack links:

- [Chromium desktop](https://automate.browserstack.com/projects/Thunderbird+Send/builds/TB+Send+Nightly+Tests+Chromium+Desktop/147?tab=sessions&bls_localTimezone=true&bls_projects=2009245%7CThunderbird%2520Send) on Win11
- [Firefox desktop](https://automate.browserstack.com/projects/Thunderbird+Send/builds/TB+Send+Nightly+Tests+Firefox+Desktop/165?tab=sessions&testListView=spec) on OSX
- [Safari desktop](https://automate.browserstack.com/projects/Thunderbird+Send/builds/TB+Send+Nightly+Tests+Safari+Desktop/158?tab=sessions&bls_localTimezone=true&bls_projects=2009245%7CThunderbird%2520Send) on OSX
- [Chrome on Android](https://automate.browserstack.com/projects/Thunderbird+Send/builds/TB+Send+Nightly+Tests+Android+Chrome/175?tab=sessions&bls_localTimezone=true&bls_projects=2009245%7CThunderbird%2520Send) (Google Pixel 10)
- [Safari on iOS](https://automate.browserstack.com/projects/Thunderbird+Send/builds/TB+Send+Nightly+Tests+iOS+Safari/201?tab=sessions&bls_localTimezone=true&bls_projects=2009245%7CThunderbird%2520Send) (iPhone 17)