### PR TITLE
fix: hide Send cloudfile provider by default to close startup race

### DIFF
--- a/packages/addon/package.json
+++ b/packages/addon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "addon",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "private": false,
   "description": "",
   "keywords": [],

--- a/packages/addon/public/api/CloudFileAccounts/implementation.js
+++ b/packages/addon/public/api/CloudFileAccounts/implementation.js
@@ -17,20 +17,33 @@
       // `cloud_file` key, so Thunderbird registers it automatically on every
       // startup — including on fresh, never-signed-in profiles where the
       // built-in system add-on runs under automation. We keep a reference to the
-      // provider object so the background script can unregister it while signed
-      // out (hiding Send from the cloud file provider list and preferences) and
-      // re-register the very same instance on sign-in, which keeps the
-      // browser.cloudFile.onFileUpload binding intact. See Bug 2036665.
+      // provider object so it can be re-registered on sign-in (via
+      // registerProvider()), which keeps the browser.cloudFile.onFileUpload
+      // binding intact. See Bug 2036665.
       this._capturedProvider =
         cloudFileAccounts.getProviderForType(this._providerType) || null;
 
-      // When true, the provider must stay hidden even if Thunderbird registers
-      // it after the background script has already asked us to unregister it
-      // (the manifest registration and the background script race at startup).
-      this._keepUnregistered = false;
+      // Hide the provider by default and only reveal it on explicit sign-in
+      // (registerProvider() clears this flag). The manifest registration and the
+      // background script's async startup race at startup; on slow debug builds
+      // the manifest can register Send before the background script reads the
+      // login state and asks us to hide it, briefly exposing Send and breaking
+      // Thunderbird's cloudfile tests which assert a clean provider baseline
+      // ("Got 2, expected 1"). Defaulting to keepUnregistered removes that race:
+      // the provider is hidden synchronously the moment it is registered,
+      // independent of the background script. See Bug 2048823.
+      this._keepUnregistered = true;
 
       this._onProviderRegistered = this._onProviderRegistered.bind(this);
       cloudFileAccounts.on('providerRegistered', this._onProviderRegistered);
+
+      // If the manifest already registered the provider before this ran, the
+      // providerRegistered listener won't fire for it, so unregister it now.
+      // (When the manifest registers later, the listener handles it inline,
+      // since cloudFileAccounts.emit() invokes listeners synchronously.)
+      if (cloudFileAccounts.getProviderForType(this._providerType)) {
+        cloudFileAccounts.unregisterProvider(this._providerType);
+      }
     }
 
     onShutdown(isAppShutdown) {

--- a/packages/addon/public/manifest.json
+++ b/packages/addon/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "version": "1.9.1",
+  "version": "1.9.2",
   "author": "Thunderbird Team",
   "name": "__MSG_thunderbirdPro__",
   "description": "__MSG_extensionDescription__",

--- a/packages/addon/src/background.ts
+++ b/packages/addon/src/background.ts
@@ -776,11 +776,12 @@ function initAccountHubListener() {
   if (shouldInitCloudFileOnStartup(isLoggedIn)) {
     initCloudFile();
   } else {
-    // Signed out: the manifest `cloud_file` key makes Thunderbird register the
-    // Send provider on every startup, so on a fresh/never-signed-in profile it
-    // would still appear in the cloud file provider list and break Thunderbird's
-    // own cloudfile tests (Bug 2036665). Unregister it until the user signs in;
-    // initCloudFile() re-registers it on sign-in.
+    // Signed out: the CloudFileAccounts experiment already hides the Send
+    // provider by default at startup (it unregisters as soon as the manifest
+    // `cloud_file` key registers it), so a fresh/never-signed-in profile shows
+    // no Send entry and Thunderbird's own cloudfile tests stay green (Bug
+    // 2036665, Bug 2048823). This call is therefore idempotent defense-in-depth;
+    // initCloudFile() re-registers the provider on sign-in.
     try {
       await browser.CloudFileAccounts.unregisterProvider();
     } catch (error) {


### PR DESCRIPTION
## What changed?

`CloudFileAccounts/implementation.js` `onStartup()` now defaults `_keepUnregistered = true` (hidden-until-signed-in) and eagerly unregisters the "Thunderbird Send" provider if Thunderbird's manifest `cloud_file` key already registered it. Because `cloudFileAccounts.emit()` invokes listeners synchronously, the existing `providerRegistered` listener removes the provider inline for the manifest-registers-later ordering — so the provider is hidden synchronously the moment it is registered, with no dependency on the background script's async startup. Sign-in re-registers it via `registerProvider()` as before.

Also updated the now-redundant signed-out comment in `background.ts` and bumped `package.json` / `manifest.json` to 1.9.2.

**AI disclosure:** Investigation, implementation, and this PR were drafted by Claude (Opus 4.8) under close human review. The author reviewed the root-cause analysis, the synchronous-emit reasoning, and each diff before submitting.

## Why?

On a signed-out profile the Send provider was only hidden once the background script finished its async startup (`checkAndUninstallIfDeprecated()` → `getLoginState()` reading `browser.storage.local`) and called `unregisterProvider()`. On slow debug builds the manifest registration won that race, briefly exposing Send and breaking Thunderbird's own cloudfile tests, which assert a clean provider baseline — surfacing as the intermittent `browser_cloudfile.js | addRemoveAccounts` failure ("Got 2, expected 1").

Upstream: https://bugzilla.mozilla.org/show_bug.cgi?id=2048823 (regressed by Bug 2048069; related baseline Bug 2036665).

## Limitations and Notes

- A signed-in user gets a brief hidden window between `onStartup()` and the background's `initCloudFile()`, then the provider reappears. The account is pref-backed, so nothing is lost.
- The experiment API isn't unit-testable under vitest (uses `ChromeUtils`); the race is covered at the integration level. Authoritative verification: `./mach test comm/mail/components/preferences/test/browser/browser_cloudfile.js --debug --repeat 20` in a comm-central debug build.
- Version bump included here; if the release bot normally owns that, it can be dropped.

## Applicable Issues

Closes #897

🤖 Generated with [Claude Code](https://claude.com/claude-code)