### PR TITLE
fix(addon): resolve __APP_VERSION__ build failure from logger wiring

### DIFF
--- a/packages/addon/src/background.ts
+++ b/packages/addon/src/background.ts
@@ -1,4 +1,9 @@
 /// <reference types="thunderbird-webext-browser" />
+// Side-effect import: installs the level-gated, version-prefixed console logger
+// for the background script. The extension and management pages get their logger
+// via send-frontend's setup.js; the background entry is standalone, so it must
+// import the logger itself (this must run before other modules log).
+import './lib/logger';
 import { useExtensionStore } from '@send-frontend/apps/send/stores/extension-store';
 import useFolderStore from '@send-frontend/apps/send/stores/folder-store';
 import { useApiStore } from '@send-frontend/stores';

--- a/packages/addon/vite.config.background.js
+++ b/packages/addon/vite.config.background.js
@@ -1,4 +1,3 @@
-import './src/lib/logger';
 import { sentryVitePlugin } from '@sentry/vite-plugin';
 import { fileURLToPath, URL } from 'node:url';
 import { resolve } from 'path';
@@ -23,6 +22,10 @@ export default defineConfig(({ mode }) => {
       }),
     ],
     define: {
+      // Preserve the shared defines (__APP_VERSION__, __APP_NAME__); a bare
+      // `define` here would otherwise shadow the ones spread from
+      // sharedViteConfig and break code that references __APP_VERSION__.
+      ...sharedViteConfig.define,
       'process.env.NODE_ENV': JSON.stringify(mode),
     },
     resolve: {

--- a/packages/addon/vite.config.extension.js
+++ b/packages/addon/vite.config.extension.js
@@ -1,4 +1,3 @@
-import './src/lib/logger';
 import { sentryVitePlugin } from '@sentry/vite-plugin';
 import vue from '@vitejs/plugin-vue';
 import { resolve } from 'path';


### PR DESCRIPTION
## What changed?

Fixes the add-on build failing with `ReferenceError: __APP_VERSION__ is not defined`.

- Removed `import './src/lib/logger';` from the top of `vite.config.extension.js` and `vite.config.background.js`. That import ran when Node *loaded the config*, executing `const version = __APP_VERSION__` in `logger.ts` — but `__APP_VERSION__` is a Vite `define` token, substituted only in bundled app code, never in the config module Node evaluates. Hence the ReferenceError on the extension and background bundles.
- Merged `...sharedViteConfig.define` into the background config's `define` block, which previously declared only `process.env.NODE_ENV` and thereby **shadowed** the shared `__APP_VERSION__` / `__APP_NAME__` defines spread in from `sharedViteConfig`.
- Imported the logger from `background.ts` (the standalone background runtime entry) instead, so #883's intent — a logger in the background script — is preserved. The extension and management pages already load a logger via send-frontend's `setup.js`.

AI disclosure: implemented by an AI agent (Claude) under the author's direction and review. Diagnosis, the fix, and verification (build + tests) were agent-driven; the author reviewed and approved.

## Why?

The build was effectively broken by #883. Because `scripts/build.sh` has no `set -e`, the two failing vite steps (extension + background) were swallowed and the script still printed `Add-on build complete 🎉`, so the build *looked* green while shipping bundles that never compiled.

## Limitations and Notes

- Scope is limited to the build/logger wiring; no runtime behavior change beyond the background script now installing the level-gated logger as originally intended.
- Follow-up worth considering: `build.sh` lacks `set -e`, which is why this regression shipped looking successful. Not addressed here to keep the fix focused.

## Applicable Issues

Closes #908

## Screenshots

N/A — build-time fix. Verified locally: `pnpm build:dev` builds all three bundles (no `__APP_VERSION__` error), the background bundle has the version inlined with zero `__APP_VERSION__` literals remaining, and `pnpm test` passes (29 passed, 1 skipped).
