### PR TITLE
Close login tab after sign-in and stop opening the options page

### DIFF
--- a/packages/addon/src/background.ts
+++ b/packages/addon/src/background.ts
@@ -399,10 +399,9 @@ browser.runtime.onMessage.addListener(async (message, sender) => {
         await initCloudFile();
       } catch (e) {
         console.error('Error during SIGN_IN_COMPLETE handling:', e);
-      } finally {
-        // Open the add-on options page after successful login
-        await browser.runtime.openOptionsPage();
       }
+      // The system add-on no longer relies on the options page, so there is
+      // nothing to open after a successful login.
       break;
 
     case SEND_MESSAGE_TO_BRIDGE: {
@@ -422,7 +421,7 @@ browser.runtime.onMessage.addListener(async (message, sender) => {
             });
         }
       });
-      await browser.runtime.openOptionsPage();
+      // The system add-on no longer relies on the options page.
       break;
     }
 
@@ -482,11 +481,8 @@ browser.runtime.onMessage.addListener(async (message, sender) => {
 
     case OPEN_MANAGEMENT_PAGE: {
       console.log(`[onMessage] Received OPEN_MANAGEMENT_PAGE request`);
-      try {
-        await browser.runtime.openOptionsPage();
-      } catch (error) {
-        console.error('[onMessage] Failed to open management page:', error);
-      }
+      // The system add-on no longer relies on the options page, so there is
+      // no management page to open here.
       break;
     }
 

--- a/packages/send/frontend/src/apps/send/pages/ClosePage.vue
+++ b/packages/send/frontend/src/apps/send/pages/ClosePage.vue
@@ -1,27 +1,60 @@
 <script lang="ts" setup>
-import { SIGN_IN_COMPLETE } from '@send-frontend/lib/const';
-import { useApiStore } from '@send-frontend/stores';
+import { FORCE_CLOSE_WINDOW, SIGN_IN_COMPLETE } from '@send-frontend/lib/const';
 import { onMounted } from 'vue';
-import { useRouter } from 'vue-router';
 
-const { api } = useApiStore();
-const router = useRouter();
+// Removed as we re-evaluate the system add-on FTUE
+// Tracked on https://github.com/thunderbird/tbpro-add-on/issues/915
+// async function checkForFTUE() {
+//   const ftueResponse = await api.call<{ isFTUEComplete: boolean }>(
+//     'users/ftue'
+//   );
 
-async function checkForFTUE() {
-  const ftueResponse = await api.call<{ isFTUEComplete: boolean }>(
-    'users/ftue'
-  );
+//   if (!ftueResponse?.isFTUEComplete) {
+//     router.push(`/ftue`);
+//     return;
+//   }
+// }
 
-  if (!ftueResponse?.isFTUEComplete) {
-    router.push(`/ftue`);
-    return;
+/**
+ * Signal a completed sign-in to the add-on, then close this tab.
+ *
+ * The token-bridge content script relays window messages to the background
+ * script, which owns tab teardown — so the order matters:
+ *   1. SIGN_IN_COMPLETE  — lets the background run its post-login work
+ *      (FTUE check, register Send, close the tracked login tab).
+ *   2. FORCE_CLOSE_WINDOW — explicitly closes *this* tab (the message sender),
+ *      in case the background's closeLoginTab() doesn't match it.
+ *   3. window.close()     — last-resort fallback if no bridge/background is
+ *      listening (e.g. the page is open in a plain browser tab).
+ *
+ * Both messages must be posted before the tab is torn down; the bridge relays
+ * them to the background, which performs the actual close.
+ */
+async function closeOnSignInComplete() {
+  try {
+    window.postMessage({ type: SIGN_IN_COMPLETE }, window.location.origin);
+  } catch (error) {
+    console.error('Error posting SIGN_IN_COMPLETE message:', error);
   }
-  window.close();
-  window.postMessage({ type: SIGN_IN_COMPLETE }, window.location.origin);
+
+  try {
+    window.postMessage({ type: FORCE_CLOSE_WINDOW }, window.location.origin);
+  } catch (error) {
+    console.error('Error posting FORCE_CLOSE_WINDOW message:', error);
+  }
+
+  // Fallback for contexts without the token bridge. This is a no-op in a normal
+  // Thunderbird tab (which only the background can close), but harmless here.
+  try {
+    window.close();
+  } catch (error) {
+    console.error('Error closing window:', error);
+  }
 }
 
 onMounted(async () => {
-  await checkForFTUE();
+  // await checkForFTUE();
+  await closeOnSignInComplete();
 });
 </script>
 

--- a/packages/send/frontend/src/apps/send/stores/config-store.ts
+++ b/packages/send/frontend/src/apps/send/stores/config-store.ts
@@ -70,11 +70,8 @@ export const useConfigStore = defineStore('config', () => {
   }
 
   async function openManagementPage() {
-    try {
-      await browser.runtime.openOptionsPage();
-    } catch (error) {
-      console.error('Failed to open management page:', error);
-    }
+    // The system add-on no longer relies on the options page, so there is no
+    // management page to open here.
   }
 
   return {


### PR DESCRIPTION
## What changed?

Two related changes that stop the system add-on from surfacing its own pages/windows during the Account Hub (Thundermail) sign-in flow:

- **Close the login tab after sign-in instead of redirecting to FTUE.** [`ClosePage.vue`](packages/send/frontend/src/apps/send/pages/ClosePage.vue) now runs a deterministic teardown on sign-in: post `SIGN_IN_COMPLETE` (so the background performs its post-login work), then `FORCE_CLOSE_WINDOW` to close this specific tab, with `window.close()` as a last-resort fallback for non-bridge contexts. The FTUE redirect (`checkForFTUE`) is commented out pending re-evaluation in #915.
- **Stop opening the options page.** Removed every `browser.runtime.openOptionsPage()` call in [`background.ts`](packages/addon/src/background.ts) (the `SIGN_IN_COMPLETE`, `SEND_MESSAGE_TO_BRIDGE`, and `OPEN_MANAGEMENT_PAGE` handlers) and in `openManagementPage()` in [`config-store.ts`](packages/send/frontend/src/apps/send/stores/config-store.ts), with comments noting the system add-on no longer relies on the options page.

**AI disclosure:** Agent-written with Claude Code under close human direction. The author reviewed and directed every change; commits were split and scoped deliberately by the author.

## Why?

In the built-in (system) add-on, sign-in goes through Thunderbird's Account Hub, so Send-specific surfaces — the options page and the FTUE redirect — interrupt the Thundermail flow and shouldn't appear. Removing them lets adding an account complete cleanly without Send UI getting in the way.

## Limitations and Notes

- The FTUE flow is only commented out, not deleted, pending the redesign in #915.
- `OPEN_MANAGEMENT_PAGE` and `openManagementPage()` are left as no-op stubs since they're still referenced; they can be removed in a follow-up along with their callers.

## Applicable Issues

Part of #906. Follow-up tracked in #915.
