### PR TITLE
chore(addon): disable minification for build output

### DIFF
--- a/packages/addon/vite.config.background.js
+++ b/packages/addon/vite.config.background.js
@@ -45,7 +45,7 @@ export default defineConfig(({ mode }) => {
         fileName: () => 'background.mjs',
         formats: ['es'],
       },
-      minify: true,
+      minify: false,
       sourcemap: 'inline',
       outDir: 'dist/background',
       rollupOptions: {

--- a/packages/addon/vite.config.extension.js
+++ b/packages/addon/vite.config.extension.js
@@ -29,7 +29,7 @@ export default defineConfig(({ mode }) => {
       },
     },
     build: {
-      minify: true,
+      minify: false,
       sourcemap: 'hidden',
       outDir: 'dist/extension',
       rollupOptions: {

--- a/packages/addon/vite.config.management.js
+++ b/packages/addon/vite.config.management.js
@@ -39,7 +39,7 @@ export default defineConfig(({ mode }) => {
     build: {
       outDir: 'dist/pages',
       sourcemap: true,
-      minify: true,
+      minify: false,
       rollupOptions: {
         input: {
           management: path.resolve(__dirname, 'index.management.html'),

--- a/packages/send/frontend/vite.config.background.ts
+++ b/packages/send/frontend/vite.config.background.ts
@@ -21,7 +21,7 @@ export default defineConfig(({ mode }) => {
         fileName: 'background',
         formats: ['es'],
       },
-      minify: true,
+      minify: false,
       sourcemap: true,
       outDir: 'dist/background',
       // rollupOptions: {

--- a/packages/send/frontend/vite.config.extension.js
+++ b/packages/send/frontend/vite.config.extension.js
@@ -2,7 +2,11 @@ import { sentryVitePlugin } from '@sentry/vite-plugin';
 import vue from '@vitejs/plugin-vue';
 import { resolve } from 'path';
 import { defineConfig, loadEnv } from 'vite';
-import { packageJson, sharedViteConfig, removeEmptySourcemapsPlugin } from './sharedViteConfig';
+import {
+  packageJson,
+  sharedViteConfig,
+  removeEmptySourcemapsPlugin,
+} from './sharedViteConfig';
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd());
@@ -28,7 +32,7 @@ export default defineConfig(({ mode }) => {
       },
     },
     build: {
-      minify: true,
+      minify: false,
       sourcemap: true,
       outDir: 'dist/extension',
       rollupOptions: {

--- a/packages/send/frontend/vite.config.management.js
+++ b/packages/send/frontend/vite.config.management.js
@@ -2,7 +2,11 @@ import { sentryVitePlugin } from '@sentry/vite-plugin';
 import vue from '@vitejs/plugin-vue';
 import path from 'path';
 import { defineConfig, loadEnv } from 'vite';
-import { packageJson, sharedViteConfig, removeEmptySourcemapsPlugin } from './sharedViteConfig';
+import {
+  packageJson,
+  sharedViteConfig,
+  removeEmptySourcemapsPlugin,
+} from './sharedViteConfig';
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
@@ -35,7 +39,7 @@ export default defineConfig(({ mode }) => {
     build: {
       outDir: 'dist/pages',
       sourcemap: mode === 'production' ? true : 'inline',
-      minify: true,
+      minify: false,
       rollupOptions: {
         input: {
           management: path.resolve(__dirname, 'index.management.html'),


### PR DESCRIPTION
## What changed?

Disabled JavaScript minification (`minify: false`) across the add-on's Vite build configs so the packaged bundles ship as readable, diffable source rather than mangled single-line output.

Affected configs:
- `packages/addon/vite.config.background.js`
- `packages/addon/vite.config.extension.js`
- `packages/addon/vite.config.management.js`
- `packages/send/frontend/vite.config.background.ts`
- `packages/send/frontend/vite.config.extension.js`
- `packages/send/frontend/vite.config.management.js`

These were the only changes. The configuration edits themselves were authored by me; Claude (Claude Code) staged, committed, and opened the PR.

## Why?

The add-on now ships as a built-in **system add-on** vendored into comm-central (`mail/extensions/builtin-addons/thundermail/`). When the bundles are minified, the code that lands in the Thunderbird tree (e.g. `background2.mjs`, `extension.mjs`, `management.mjs`) is effectively unreviewable — single-line, mangled output — which makes Phabricator review of the vendored code difficult and obscures what actually ships to users. Un-minified output produces readable, diffable patches and makes review/debugging far easier.

## Limitations and Notes

- Bundle size will grow; acceptable for a system add-on shipped in-tree (not downloaded over the network).
- Worth verifying Thunderbird's static `browser_parsable_script.js` / `browser_parsable_css.js` checks still pass with un-minified output (Bug 2036665 context).
- Source maps are unchanged here; revisit whether the inline maps are still needed now that the code is readable.

## Applicable Issues

Closes #889
