### PR TITLE
ci: add mise to devcontainer image

### DIFF
--- a/.devcontainer/check_binaries.sh
+++ b/.devcontainer/check_binaries.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # Quick check for required CLI binaries used by this project.
 # Exits 0 if all found, non-zero if any are missing.
 
-bins=(python pulumi aws vim docker npm lerna pnpm bun ruff yq jq actionlint)
+bins=(python pulumi aws vim docker npm lerna pnpm bun ruff yq jq actionlint mise)
 
 missing=()
 for b in "${bins[@]}"; do

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,6 +17,7 @@
     "ghcr.io/guiyomh/features/vim:0": {},
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/node:1": {},
+    "ghcr.io/devcontainers-extra/features/mise:1": {},
     "ghcr.io/devcontainers-extra/features/lerna-npm:1": {},
     "ghcr.io/shyim/devcontainers-features/bun:0": {},
     "ghcr.io/larsnieuwenhuizen/features/jqyq:0": {},


### PR DESCRIPTION
## What

Adds the [`mise`](https://mise.jdx.dev/) version manager to the `cached-devcontainer` image via the `ghcr.io/devcontainers-extra/features/mise:1` devcontainer feature.

## Why

This is **PR 1 of 2** in fixing the hung E2E `Install Playwright browsers` step (e.g. [run 28044173296](https://github.com/thunderbird/tbpro-add-on/actions/runs/28044173296/job/83018815344), which hung ~1h16m before being canceled).

**Root cause:** the install runs inside the `cached-devcontainer` container, whose default Node is the current LTS (24.x). Node **24.16.0+** has a stream `pause()/resume()` regression ([nodejs/node#63487](https://github.com/nodejs/node/issues/63487)) that deadlocks `extract-zip`/`yauzl` — the Playwright browser download reaches 100%, then extraction hangs forever. Playwright fixes this in **≥ 1.60.0**, but **we can't bump Playwright**: BrowserStack Automate caps Playwright at **1.59** as of June 2026 (both `browserstack-*.yml` pin `playwrightVersion: 1.59.1` and must match `package.json`).

So the fix is to run the E2E install/tests on a **safe Node (22 LTS)** while keeping Playwright at 1.59.1. `mise` lets us pin that Node version per-run via a `.tool-versions` file — uv-style — decoupled from the image's default Node, so future version changes need no image rebuild.

## Sequencing

Merging this to `main` triggers `build-and-push-devcontainer` to rebuild `cached-devcontainer:latest` **with `mise` baked in**. The follow-up PR (wiring the E2E workflows to `mise install` / `mise exec` + the `.tool-versions` pin) depends on that rebuilt image, so it must land after this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)