### PR TITLE
ci: don't save a partial Playwright cache on failed install

### DIFF
--- a/.github/workflows/e2e-bucket-test.yml
+++ b/.github/workflows/e2e-bucket-test.yml
@@ -196,6 +196,7 @@ jobs:
           mise exec -- node --version
 
       - name: Install Playwright browsers
+        id: install-playwright-browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         timeout-minutes: 10
         working-directory: packages/send/e2e
@@ -215,8 +216,11 @@ jobs:
           cd packages/send/e2e
           mise exec -- pnpm run test:e2e:ci
 
+      # Only save when the install step actually succeeded. A cancelled or failed
+      # install (e.g. the Node 24 extract-zip hang) would otherwise save a partial
+      # cache that poisons future runs with "Executable doesn't exist".
       - name: Save Playwright browsers cache
-        if: always() && steps.playwright-cache.outputs.cache-hit != 'true'
+        if: always() && steps.playwright-cache.outputs.cache-hit != 'true' && steps.install-playwright-browsers.outcome == 'success'
         uses: actions/cache/save@v4
         with:
           path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -182,6 +182,7 @@ jobs:
           mise exec -- node --version
 
       - name: Install Playwright browsers
+        id: install-playwright-browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         timeout-minutes: 10
         working-directory: packages/send/e2e
@@ -201,8 +202,11 @@ jobs:
           cd packages/send/e2e
           mise exec -- pnpm run test:e2e:ci
 
+      # Only save when the install step actually succeeded. A cancelled or failed
+      # install (e.g. the Node 24 extract-zip hang) would otherwise save a partial
+      # cache that poisons future runs with "Executable doesn't exist".
       - name: Save Playwright browsers cache
-        if: always() && steps.playwright-cache.outputs.cache-hit != 'true'
+        if: always() && steps.playwright-cache.outputs.cache-hit != 'true' && steps.install-playwright-browsers.outcome == 'success'
         uses: actions/cache/save@v4
         with:
           path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}


### PR DESCRIPTION
## What

Gate the `Save Playwright browsers cache` step on the **install step's own success** in both E2E workflows, so a cancelled/failed `Install Playwright browsers` never persists a partial cache.

## Why

The save step ran with `if: always()`. When the original Node 24 `extract-zip`/`yauzl` hang ([nodejs/node#63487](https://github.com/nodejs/node/issues/63487)) caused the install to be cancelled mid-download, the step still saved whatever was in `PLAYWRIGHT_BROWSERS_PATH` — a ~13 MiB partial cache (chromium partially downloaded, firefox/webkit missing).

Future runs on that branch then got a cache **hit**, **skipped** the install, and failed every test with:
```
Error: browserType.launch: Executable doesn't exist at .../firefox-1511/firefox/firefox
```
This is exactly what bit the rebased PR #920 — I had to manually delete the poisoned cache to unblock it (see https://github.com/thunderbird/tbpro-add-on/pull/920#issuecomment-4785064919).

## How

```yaml
- name: Install Playwright browsers
  id: install-playwright-browsers
  ...
- name: Save Playwright browsers cache
  if: always() && steps.playwright-cache.outputs.cache-hit != 'true' && steps.install-playwright-browsers.outcome == 'success'
```

- `always()` — still evaluate even if a later step (the test run) failed.
- `cache-hit != 'true'` — unchanged; only save on a miss.
- `install-playwright-browsers.outcome == 'success'` — **new**; only save when the install actually completed. A cancelled/failed/skipped install no longer poisons the cache.

We still cache after a successful install even if the *tests* later fail (browsers are valid), so cache effectiveness is unchanged for the normal path.

Applies to both `e2e-test.yml` and `e2e-bucket-test.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)