### PR TITLE
fix(send): stop init() destroying the default folder; harden container create & flaky E2E (#930)

### DIFF
--- a/packages/send/backend/src/models/containers.ts
+++ b/packages/send/backend/src/models/containers.ts
@@ -1,5 +1,6 @@
 import { ContainerType, PrismaClient } from '@prisma/client';
 import {
+  BaseError,
   CONTAINER_NOT_CREATED,
   CONTAINER_NOT_FOUND,
   CONTAINER_NOT_UPDATED,
@@ -23,45 +24,47 @@ export async function createContainer(
   parentId: string | null,
   shareOnly: boolean
 ) {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let query: Record<string, any> = {
-    data: {},
-  };
-  const group = await fromPrismaV2(
-    prisma.group.create,
-    query,
-    GROUP_NOT_CREATED
-  );
+  // Create the group, the owner's membership, and the container atomically.
+  // Doing these as separate calls left a window where a partially-created
+  // container (e.g. group without membership) could be observed, surfacing as
+  // a spurious 403 / "No Group found". See issue #930.
+  return prisma.$transaction(async (tx) => {
+    const group = await tx.group.create({ data: {} }).catch((err) => {
+      console.error(err);
+      throw new BaseError(GROUP_NOT_CREATED);
+    });
 
-  query = {
-    data: {
-      groupId: group.id,
-      userId: ownerId,
-      permission: PermissionType.ADMIN, // Owner has full permissions
-    },
-  };
-  await fromPrismaV2(prisma.membership.create, query, MEMBERSHIP_NOT_CREATED);
+    await tx.membership
+      .create({
+        data: {
+          groupId: group.id,
+          userId: ownerId,
+          permission: PermissionType.ADMIN, // Owner has full permissions
+        },
+      })
+      .catch((err) => {
+        console.error(err);
+        throw new BaseError(MEMBERSHIP_NOT_CREATED);
+      });
 
-  query = {
-    data: {
-      name,
-      ownerId,
-      groupId: group.id,
-      type,
-      shareOnly,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    },
-  };
-  if (parentId) {
-    query.data['parentId'] = parentId;
-  }
-
-  return await fromPrismaV2(
-    prisma.container.create,
-    query,
-    CONTAINER_NOT_CREATED
-  );
+    return tx.container
+      .create({
+        data: {
+          name,
+          ownerId,
+          groupId: group.id,
+          type,
+          shareOnly,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          ...(parentId ? { parentId } : {}),
+        },
+      })
+      .catch((err) => {
+        console.error(err);
+        throw new BaseError(CONTAINER_NOT_CREATED);
+      });
+  });
 }
 
 export async function getItemsInContainer(id: string) {

--- a/packages/send/e2e/pages/dev/myFiles.ts
+++ b/packages/send/e2e/pages/dev/myFiles.ts
@@ -7,10 +7,11 @@ import {
   downloadFirstFile,
   dragAndDropFile,
   playwrightConfig,
+  requireShareLink,
   saveClipboardItem,
 } from "../../utils/dev/testUtils";
 
-const { password, timeout, shareLinks, fileLinks } = playwrightConfig;
+const { password, timeout, fileLinks } = playwrightConfig;
 
 export async function upload_workflow({ page }: PlaywrightProps) {
   const { folderRowSelector, folderRowTestID, fileCountID, uploadButton, dropZone, tableCellID, passwordInput } =
@@ -150,13 +151,13 @@ export async function download_workflow({ page, context }: PlaywrightProps) {
 
   // Regular window downloads
   let otherPage = await context.newPage();
-  await otherPage.goto(shareLinks["folder-no-password"]!);
+  await otherPage.goto(requireShareLink("folder-no-password"));
   await otherPage.waitForLoadState("networkidle");
   await downloadFirstFile(otherPage);
   await otherPage.close();
 
   otherPage = await context.newPage();
-  await otherPage.goto(shareLinks["folder-with-password"]!);
+  await otherPage.goto(requireShareLink("folder-with-password"));
   await otherPage.waitForLoadState("networkidle");
   await otherPage.getByTestId(passwordInputID).fill(password);
   await otherPage.getByTestId(submitButtonID).click();
@@ -176,14 +177,14 @@ export async function download_workflow({ page, context }: PlaywrightProps) {
 
     // Download share link (folder) without password
     otherPage = await incognitoContext.newPage();
-    await otherPage.goto(shareLinks["folder-no-password"]!);
+    await otherPage.goto(requireShareLink("folder-no-password"));
     await otherPage.waitForLoadState("networkidle");
     await downloadFirstFile(otherPage);
     await otherPage.close();
 
     // Download share link (folder) with password
     otherPage = await incognitoContext.newPage();
-    await otherPage.goto(shareLinks["folder-with-password"]!);
+    await otherPage.goto(requireShareLink("folder-with-password"));
     await otherPage.waitForLoadState("networkidle");
     await otherPage.getByTestId(passwordInputID).fill(password);
     await otherPage.getByTestId(submitButtonID).click();
@@ -193,14 +194,14 @@ export async function download_workflow({ page, context }: PlaywrightProps) {
 
     // Download individual file without password
     otherPage = await incognitoContext.newPage();
-    await otherPage.goto(shareLinks["file-no-password"]!);
+    await otherPage.goto(requireShareLink("file-no-password"));
     await otherPage.waitForLoadState("networkidle");
     await downloadFirstFile(otherPage);
     await otherPage.close();
 
     // Download individual file with password
     otherPage = await incognitoContext.newPage();
-    await otherPage.goto(shareLinks["file-with-password"]!);
+    await otherPage.goto(requireShareLink("file-with-password"));
     await otherPage.waitForLoadState("networkidle");
     await otherPage.getByTestId(passwordInputID).fill(password);
     await otherPage.getByTestId(submitButtonID).click();
@@ -239,12 +240,12 @@ export async function delete_file({ page }: PlaywrightProps) {
 
   // Check that the share links are no longer accessible
   // Folder no password link
-  await page.goto(shareLinks["folder-no-password"]!);
+  await page.goto(requireShareLink("folder-no-password"));
   await page.waitForLoadState("networkidle");
   expect(await page.getByTestId("not_found").textContent()).toContain("This link is no longer active");
 
   // Folder with password link
-  await page.goto(shareLinks["folder-with-password"]!);
+  await page.goto(requireShareLink("folder-with-password"));
   await page.waitForLoadState("networkidle");
   await page.getByTestId(passwordInputID).fill(password);
   await page.getByTestId(submitButtonID).click();

--- a/packages/send/e2e/tests/desktop/dev/send.spec.ts
+++ b/packages/send/e2e/tests/desktop/dev/send.spec.ts
@@ -25,7 +25,7 @@ import {
 } from "../../../pages/dev/myFiles"
 
 import { oidc_login } from "../../../pages/dev/oidc"
-import { setup_browser } from "../../../utils/dev/testUtils"
+import { resetShareLinks, setup_browser } from "../../../utils/dev/testUtils"
 
 config.config({ path: path.resolve(__dirname, "./.env") });
 
@@ -106,6 +106,12 @@ test.describe("File workflows", {
 }, () => {
   let page: Page;
   let context: BrowserContext;
+
+  // Start from a clean share-link map so a prior (possibly failed) run can't
+  // leak stale/null links into the download + delete steps below (#930).
+  test.beforeAll(() => {
+    resetShareLinks();
+  });
 
   test.beforeEach(async () => {
     ({ page, context } = await setup_browser());

--- a/packages/send/e2e/tests/desktop/dev/send.spec.ts
+++ b/packages/send/e2e/tests/desktop/dev/send.spec.ts
@@ -25,7 +25,15 @@ import {
 } from "../../../pages/dev/myFiles"
 
 import { oidc_login } from "../../../pages/dev/oidc"
+import {
+  emptyState,
+  emptystatePath,
+  storageStatePath,
+} from "../../../utils/dev/paths"
 import { resetShareLinks, setup_browser } from "../../../utils/dev/testUtils"
+
+// Re-export for backwards compatibility with anything importing these from the spec.
+export { emptystatePath, storageStatePath }
 
 config.config({ path: path.resolve(__dirname, "./.env") });
 
@@ -37,20 +45,6 @@ export type PlaywrightProps = {
 export const credentials = {
   TBPRO_USERNAME: process.env.TBPRO_USERNAME,
   TBPRO_PASSWORD: process.env.TBPRO_PASSWORD,
-};
-
-export const storageStatePath = path.resolve(
-  __dirname,
-  "../../../data/lockboxstate.json"
-);
-
-export const emptystatePath = path.resolve(
-  __dirname,
-    "../../../data/emptystate.json"
-);
-const emptyState = {
-  cookies: [],
-  origins: [],
 };
 
 // Cleanup storage state after all tests

--- a/packages/send/e2e/tests/desktop/dev/sharelinks-guard.spec.ts
+++ b/packages/send/e2e/tests/desktop/dev/sharelinks-guard.spec.ts
@@ -1,0 +1,46 @@
+// Unit-level regression tests for the share-link state guards added for #930.
+// These exercise pure helpers (no browser/stack required) so they run fast in CI
+// alongside the dev-desktop suite and document the intended guard behaviour.
+
+import { expect, test } from "@playwright/test";
+
+import { PLAYWRIGHT_TAG_DEV_DESKTOP } from "../../../const/const";
+import {
+  playwrightConfig,
+  requireShareLink,
+  resetShareLinks,
+} from "../../../utils/dev/testUtils";
+
+test.describe("share-link guards (#930)", { tag: [PLAYWRIGHT_TAG_DEV_DESKTOP] }, () => {
+  test("resetShareLinks clears every entry back to null", () => {
+    // Simulate a prior run that populated some links.
+    playwrightConfig.shareLinks["file-no-password"] = "https://example/share/abc";
+    playwrightConfig.shareLinks["folder-with-password"] = "https://example/share/def";
+
+    resetShareLinks();
+
+    for (const value of Object.values(playwrightConfig.shareLinks)) {
+      expect(value).toBeNull();
+    }
+  });
+
+  test("requireShareLink throws an actionable error when a link is missing", () => {
+    resetShareLinks();
+
+    expect(() => requireShareLink("folder-no-password")).toThrow(
+      /Missing share link for "folder-no-password"/
+    );
+    // Must NOT let a null reach page.goto (the cryptic "expected string, got object").
+    expect(() => requireShareLink("folder-no-password")).not.toThrow(
+      /expected string/
+    );
+  });
+
+  test("requireShareLink returns the populated link", () => {
+    resetShareLinks();
+    const link = "https://example/share/xyz";
+    playwrightConfig.shareLinks["file-with-password"] = link;
+
+    expect(requireShareLink("file-with-password")).toBe(link);
+  });
+});

--- a/packages/send/e2e/utils/dev/paths.ts
+++ b/packages/send/e2e/utils/dev/paths.ts
@@ -1,0 +1,19 @@
+// Storage-state file paths shared between the dev spec and test utils.
+// Extracted here to break a circular import (send.spec <-> testUtils) that made
+// the helpers unloadable outside the spec's own load order. See issue #930.
+import path from "path";
+
+export const storageStatePath = path.resolve(
+  __dirname,
+  "../../data/lockboxstate.json"
+);
+
+export const emptystatePath = path.resolve(
+  __dirname,
+  "../../data/emptystate.json"
+);
+
+export const emptyState = {
+  cookies: [],
+  origins: [],
+};

--- a/packages/send/e2e/utils/dev/testUtils.ts
+++ b/packages/send/e2e/utils/dev/testUtils.ts
@@ -29,6 +29,33 @@ export const playwrightConfig = {
   fileLinks: [] as string[],
 };
 
+/**
+ * Reset the module-level `shareLinks` singleton back to its empty baseline.
+ * Call this at suite start so a failed/aborted run can't leak stale (or null)
+ * links into a later run and produce cryptic, misattributed failures (#930).
+ */
+export function resetShareLinks() {
+  for (const key of Object.keys(playwrightConfig.shareLinks)) {
+    playwrightConfig.shareLinks[key] = null;
+  }
+}
+
+/**
+ * Read a share link that an earlier workflow step was supposed to populate.
+ * Throws an actionable error instead of letting a `null` reach `page.goto()`,
+ * where it surfaces as the opaque `goto: url: expected string, got object`.
+ */
+export function requireShareLink(key: string): string {
+  const link = playwrightConfig.shareLinks[key];
+  if (!link) {
+    throw new Error(
+      `Missing share link for "${key}" — an upstream test step did not populate it. ` +
+        `This usually means an earlier workflow (share/upload) failed; check that failure first.`
+    );
+  }
+  return link;
+}
+
 export async function downloadFirstFile(page: Page) {
   const { downloadButton, confirmDownload } = fileLocators(page);
   await downloadButton.click();

--- a/packages/send/e2e/utils/dev/testUtils.ts
+++ b/packages/send/e2e/utils/dev/testUtils.ts
@@ -9,7 +9,7 @@ import {
 import { readFileSync } from "fs";
 
 import { fileLocators } from "../../pages/dev/locators";
-import { emptystatePath, storageStatePath } from "../../tests/desktop/dev/send.spec";
+import { emptystatePath, storageStatePath } from "./paths";
 import path from "path";
 
 const sharelinks = {

--- a/packages/send/frontend/src/lib/init.ts
+++ b/packages/send/frontend/src/lib/init.ts
@@ -1,7 +1,11 @@
 import { INIT_ERRORS } from '@send-frontend/apps/send/const';
 import { FolderStore } from '@send-frontend/apps/send/stores/folder-store.types';
-import { Keychain } from '@send-frontend/lib/keychain';
+import {
+  Keychain,
+  restoreKeysUsingLocalStorage,
+} from '@send-frontend/lib/keychain';
 import { useFolderStore } from '@send-frontend/stores';
+import useApiStore from '@send-frontend/stores/api-store';
 import { UserStoreType as UserStore } from '@send-frontend/stores/user-store';
 
 /**
@@ -11,7 +15,7 @@ import { UserStoreType as UserStore } from '@send-frontend/stores/user-store';
  * @param {FolderStore} folderStore - Pinia store for managing folders.
  * @return {Promise<INIT_ERRORS>} - Returns Promise of 0 (success) or an error code typed by INIT_ERRORS.
  */
-async function init(
+async function _init(
   userStore: UserStore,
   keychain: Keychain,
   folderStore: FolderStore | ReturnType<typeof useFolderStore>
@@ -25,6 +29,18 @@ async function init(
 
   if (!hasKeychain) {
     return INIT_ERRORS.NO_KEYCHAIN;
+  }
+
+  // Ensure container keys are restored from the server backup before deciding a
+  // default folder is "orphaned". keychain.load() above only reads local storage;
+  // a valid folder's key may live only in the server backup and would otherwise
+  // appear missing here, causing us to destroy a perfectly good container.
+  // This is idempotent and no-ops when no passphrase is available.
+  try {
+    const { api } = useApiStore();
+    await restoreKeysUsingLocalStorage(keychain, api);
+  } catch (error) {
+    console.warn('init(): could not restore keys before folder check', error);
   }
 
   await folderStore.sync();
@@ -47,6 +63,25 @@ async function init(
   }
 
   return INIT_ERRORS.NONE;
+}
+
+// Single-flight guard: concurrent callers (e.g. the login flow and dbUserSetup
+// firing during the same rapid navigation) share one run instead of each
+// independently deciding to delete + recreate the default folder. See issue #930.
+let inFlight: Promise<INIT_ERRORS> | null = null;
+
+function init(
+  userStore: UserStore,
+  keychain: Keychain,
+  folderStore: FolderStore | ReturnType<typeof useFolderStore>
+): Promise<INIT_ERRORS> {
+  if (inFlight) {
+    return inFlight;
+  }
+  inFlight = _init(userStore, keychain, folderStore).finally(() => {
+    inFlight = null;
+  });
+  return inFlight;
 }
 
 export default init;

--- a/packages/send/frontend/src/test/lib/init.test.ts
+++ b/packages/send/frontend/src/test/lib/init.test.ts
@@ -1,6 +1,18 @@
 import { INIT_ERRORS } from '@send-frontend/apps/send/const';
 import init from '@send-frontend/lib/init';
+import { restoreKeysUsingLocalStorage } from '@send-frontend/lib/keychain';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// init() pulls the api connection from the store and attempts a key restore
+// before deciding a default folder is orphaned. Mock both so the tests can
+// control whether the restore populates the keychain.
+vi.mock('@send-frontend/stores/api-store', () => ({
+  default: () => ({ api: {} }),
+}));
+
+vi.mock('@send-frontend/lib/keychain', () => ({
+  restoreKeysUsingLocalStorage: vi.fn(),
+}));
 
 // ---------------------------------------------------------------------------
 // Helper factories — produce minimal duck-typed stand-ins for each dependency
@@ -62,6 +74,7 @@ describe('init()', () => {
     userStore = makeUserStore();
     keychain = makeKeychain();
     folderStore = makeFolderStore();
+    vi.mocked(restoreKeysUsingLocalStorage).mockReset();
   });
 
   // --- Early-exit error paths (pre-existing behaviour — regression tests) ---
@@ -205,5 +218,46 @@ describe('init()', () => {
     expect(result).toBe(INIT_ERRORS.COULD_NOT_CREATE_DEFAULT_FOLDER);
 
     vi.restoreAllMocks();
+  });
+
+  // --- Regression for #930: do not destroy a valid container ---
+
+  it('restores keys before the orphan check and does NOT delete when the key arrives via restore', async () => {
+    const folderId = 'folder-from-backup';
+    const keysMap: Record<string, string> = {}; // key not in local storage yet
+    folderStore = makeFolderStore({ defaultFolder: { id: folderId } });
+    keychain = makeKeychain(keysMap);
+
+    // The server-backup restore populates the previously-missing key.
+    vi.mocked(restoreKeysUsingLocalStorage).mockImplementation(async () => {
+      keysMap[folderId] = 'restored-key';
+    });
+
+    const result = await init(
+      userStore as any,
+      keychain as any,
+      folderStore as any
+    );
+
+    expect(restoreKeysUsingLocalStorage).toHaveBeenCalledOnce();
+    // The valid container must survive: no destructive delete + recreate.
+    expect(folderStore.deleteFolder).not.toHaveBeenCalled();
+    expect(folderStore.createFolder).not.toHaveBeenCalled();
+    expect(result).toBe(INIT_ERRORS.NONE);
+  });
+
+  it('is single-flight: concurrent calls share one run (no double delete/create)', async () => {
+    folderStore = makeFolderStore({ defaultFolder: null });
+
+    const [r1, r2] = await Promise.all([
+      init(userStore as any, keychain as any, folderStore as any),
+      init(userStore as any, keychain as any, folderStore as any),
+    ]);
+
+    // Both callers resolve, but the work runs exactly once.
+    expect(folderStore.sync).toHaveBeenCalledOnce();
+    expect(folderStore.createFolder).toHaveBeenCalledOnce();
+    expect(r1).toBe(INIT_ERRORS.NONE);
+    expect(r2).toBe(INIT_ERRORS.NONE);
   });
 });


### PR DESCRIPTION
## What changed?

Fixes the flaky Send E2E suites traced in #930 to a frontend `init()` race that **deletes and recreates the user's valid default folder**, briefly references the deleted container (`403` / `No Group found`), and cascades into `folder-row` timeouts.

- **Frontend (root cause) — `packages/send/frontend/src/lib/init.ts`**
  - `init()` is now **single-flight**: concurrent callers (`background.ts`, `useSendConfig.ts`, `helpers.ts`) share one run instead of each independently deciding to delete + recreate.
  - Container keys are **restored from the server backup before** the "is this folder orphaned?" check, so a valid default folder whose key isn't loaded yet is no longer destroyed. Preserves the genuine orphan-cleanup intent from #811.
  - New regression tests in `init.test.ts` (single-flight; no-delete-when-key-restorable).
- **Backend (hardening) — `packages/send/backend/src/models/containers.ts`**
  - Container + group + membership creation wrapped in `prisma.$transaction`, errors caught per step (no `fromPrismaV2`), closing a partial-create window.
- **E2E (diagnosability) — `packages/send/e2e/...`**
  - `resetShareLinks()` per suite + `requireShareLink()` that throws an actionable error instead of leaking `null` into `page.goto` (the cryptic `expected string, got object`).
  - Broke a `send.spec ↔ testUtils` circular import by extracting path constants to `utils/dev/paths.ts`; added a stack-free guard spec.
- **Docs — `packages/send/docs/`**: test plan, per-branch results, main-vs-fix comparison, and an agent E2E runbook.

**AI disclosure:** This PR was developed with an AI agent (Claude) under human direction. The agent wrote the code, tests, and docs; the author reviewed and directed the approach, scope, and verification at each step. This description was AI-drafted and human-reviewed.

## Why?

The E2E suites passed on rerun but intermittently failed because `init()` could delete a perfectly valid default container when its key wasn't loaded yet, or run twice concurrently and thrash create/delete. Downstream, a single failure was amplified into 5–8 cryptic failures by an unreset `shareLinks` singleton. See #930 for the full trace.

## Limitations and Notes

- `background.ts` runs in a separate JS context, so the single-flight guard synchronizes the **app-context** calls (where the dev-E2E race lives) — sufficient for the observed failure.
- The backend `$transaction` is hardening, **not** the flake fix: the observed `403` was a reference to an *already-deleted* container, not a partial create.
- Pre-existing, unrelated: the `register_and_login` / `reset_keys` E2E tests assume a local register flow but the stack authenticates via OIDC — they fail independently of this change (follow-up to port them to the OIDC path).

## Applicable Issues

Closes #930

## Verification — proof of impact (main vs this branch)

Both branches are green on **their own** suites (main is internally consistent). The fix's impact is shown by running the **new** regression tests against each branch's `init.ts`:

| | `main` | this branch |
|---|---|---|
| Branch regression tests vs that branch's `init.ts` | ❌ **2 fail** | ✅ **2 pass** |
| → "does NOT delete valid folder when key restorable" | ❌ deletes it | ✅ preserved |
| → "single-flight: concurrent init shares one run" | ❌ runs twice | ✅ one run |

Deterministic cross-check — branch regression tests run against **main's** `init.ts`:
```
× restores keys before the orphan check and does NOT delete when the key arrives via restore
    AssertionError: expected "vi.fn()" to be called once, but got 0 times   // restoreKeysUsingLocalStorage
× is single-flight: concurrent calls share one run (no double delete/create)
    AssertionError: expected "vi.fn()" to be called once, but got 2 times   // folderStore.sync
```
Same tests on this branch: **both pass**.

Test-count diff (no regressions — additive only):

| Suite | `main` | this branch |
|-------|-------:|------------:|
| Frontend unit (full) | 227 + 2 skip | 229 + 2 skip |
| `init.test.ts` | 8 | 10 |
| Backend unit/integration | 251 | 251 |
| E2E share-link guard spec | — | 3 |
| Live OIDC E2E folder-view probe | — | 5/5 |

Live E2E (OIDC login + key recovery, this branch): folder view loads, **default folder preserved** (not deleted+recreated), **no `DELETE → 403` thrash**, backend logs show **0** `"No Group found"` across all runs. Full details in [`packages/send/docs/Comparison-main-vs-fix.md`](packages/send/docs/Comparison-main-vs-fix.md).

> Note: a single clean login does not reproduce the destructive delete on either branch — the #930 bug is an intermittent race, which is why the suite was *flaky* rather than consistently red. The deterministic discriminator is the unit cross-check above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)