### PR TITLE
fix(addon): make font url() rewrite quote-aware to prevent parsable-css crash

### DIFF
--- a/packages/addon/scripts/build.sh
+++ b/packages/addon/scripts/build.sh
@@ -67,7 +67,21 @@ echo "=============== rewrite font urls =============================="
 ### check crashes (Bug 2036665). The CSS lives in dist/assets/ and the fonts in
 ### dist/fonts/, so rewrite the absolute url(/fonts/...) to a relative
 ### url(../fonts/...) that resolves inside the add-on's own directory.
-find dist/assets -name '*.css' -exec perl -pi -e 's{url\(/fonts/}{url(../fonts/}g' {} +
+###
+### The url() value may be quoted or bare: production (minified) builds emit
+### url(/fonts/...) while dev/unminified builds preserve the source quotes,
+### url('/fonts/...'). Capture the optional quote ((["\x27]?), \x27 = ') and
+### re-emit it so both forms are rewritten — a quote-blind regex silently
+### leaves dev builds absolute and re-introduces the crash above.
+find dist/assets -name '*.css' -exec perl -pi -e 's{url\((["\x27]?)/fonts/}{url($1../fonts/}g' {} +
+
+### Fail the build if any absolute /fonts/ url() survived the rewrite, so a
+### broken bundle can never silently ship and crash browser_parsable_css.js.
+if grep -REq "url\((['\"]?)/fonts/" dist/assets/*.css; then
+    echo "ERROR: absolute /fonts/ url() survived rewrite — would crash browser_parsable_css.js" >&2
+    grep -REn "url\((['\"]?)/fonts/" dist/assets/*.css >&2
+    exit 1
+fi
 
 echo "================================================================"
 echo "=============== sanitize parsable css =========================="


### PR DESCRIPTION
## What changed?

Made the webfont `url()` rewrite in `packages/addon/scripts/build.sh` quote-aware, and added a build-time guard.

- The rewrite that converts absolute `url(/fonts/...)` to relative `url(../fonts/...)` previously used `s{url\(/fonts/}{url(../fonts/}g`, which only matched the **unquoted** form. It now captures an optional quote (`(["\x27]?)`) and re-emits it, so `url(/fonts/`, `url('/fonts/`, and `url("/fonts/` are all rewritten.
- Added a guard that greps the bundled CSS after the rewrite and **fails the build** (printing the offending lines) if any absolute `/fonts/` `url()` survived, so a broken bundle can never silently ship again.

I verified the new regex against the actual deployed CSS: all 36 `url('/fonts/...')` references convert to `url('../fonts/...')`, and the guard passes on the rewritten output (and fails on the pre-fix input).

_AI disclosure: this change was diagnosed and written by Claude (agent), reviewed and directed by the author. The author identified the failing try run; the agent traced the root cause from the CI log, wrote the one-line regex fix and guard, and verified the rewrite against the deployed CSS._

## Why?

A try push crashed in Thunderbird's static `browser_parsable_css.js` check:

```
TEST-UNEXPECTED-CRASH | comm/mail/base/test/browser/static/browser_parsable_css.js
PROCESS-CRASH | Missing chrome or resource URLs:
  resource://builtin-addons/fonts/Inter/Inter-Regular.woff2 [@ mozilla::net::CheckForBrokenChromeURL]
```

The bundled CSS shipped absolute `url('/fonts/...')` font references. Loaded as a built-in add-on, an absolute `/fonts/...` URL resolves against the `resource://` protocol root (`resource://builtin-addons/fonts/...`) rather than the add-on's own directory, so the font is missing and the static check fatally crashes (Bug 2036665).

`build.sh` already had a rewrite step meant to prevent exactly this, but its regex only matched unquoted `url(/fonts/`. Production (minified) builds strip quotes so the bug stayed hidden; the dev/unminified build that was deployed preserved the source single quotes (`url('/fonts/...')`), so the rewrite was a no-op and the absolute paths shipped — crashing CI.

Failing run: https://treeherder.mozilla.org/jobs?repo=try-comm-central&revision=51fc152ffe02dc4a5ec85cedbb188463172bb7f2&selectedTaskRun=dHZ5CqI4QRSnRU3g-hftrg.0

## Limitations and Notes

- The font files themselves were always packaged correctly; only the CSS URL form was wrong.
- Follow-up (process, not code): the deployed `.xpi` was a dev/unminified build, which is what exposed the gap. Standardizing the deploy/release path on the production `pnpm build` would add defense in depth, though this fix makes the rewrite correct for both modes.
- Still needs a fresh `.xpi` rebuild + re-deploy into the comm tree and a new try push to confirm the suite goes green.

## Applicable Issues

Closes #941

## Screenshots

N/A — build-script change.
