### PR TITLE
fix(send): stop Send dashboard self-closing when opened from accounts dashboard

### DIFF
--- a/packages/send/frontend/src/apps/send/components/ProfileView.test.ts
+++ b/packages/send/frontend/src/apps/send/components/ProfileView.test.ts
@@ -1,0 +1,104 @@
+import { mount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import ProfileView from './ProfileView.vue';
+
+const { isThunderbirdHost, environmentType, push } = vi.hoisted(() => {
+  return { isThunderbirdHost: vi.fn(), environmentType: vi.fn(), push: vi.fn() };
+});
+
+// Run debounced callbacks synchronously so we can assert without timers.
+vi.mock('@vueuse/core', () => ({
+  useDebounceFn: (fn: (...args: unknown[]) => unknown) => fn,
+}));
+
+vi.mock('@send-frontend/stores', () => ({
+  useConfigStore: () => ({
+    get isThunderbirdHost() {
+      return isThunderbirdHost();
+    },
+  }),
+}));
+
+vi.mock('@send-frontend/composables/useIsExtension', () => ({
+  useIsExtension: () => ({
+    environmentType: { value: environmentType() },
+  }),
+}));
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push }),
+}));
+
+const stubs = {
+  UserDashboard: true,
+  LoadingComponent: true,
+};
+
+function setSearch(search: string) {
+  Object.defineProperty(window, 'location', {
+    value: { search },
+    writable: true,
+  });
+}
+
+describe('ProfileView.vue', () => {
+  beforeEach(() => {
+    window.close = vi.fn();
+    setSearch('');
+    isThunderbirdHost.mockReturnValue(false);
+    environmentType.mockReturnValue('WEB APP OUTSIDE THUNDERBIRD');
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows the dashboard for the web app outside Thunderbird', () => {
+    environmentType.mockReturnValue('WEB APP OUTSIDE THUNDERBIRD');
+    isThunderbirdHost.mockReturnValue(false);
+
+    const wrapper = mount(ProfileView, { global: { stubs } });
+
+    expect(wrapper.findComponent({ name: 'UserDashboard' }).exists()).toBe(true);
+    expect(window.close).not.toHaveBeenCalled();
+  });
+
+  it('shows the dashboard when ?showDashboard=true is present inside Thunderbird', () => {
+    environmentType.mockReturnValue('WEB APP INSIDE THUNDERBIRD');
+    isThunderbirdHost.mockReturnValue(true);
+    setSearch('?showDashboard=true');
+
+    const wrapper = mount(ProfileView, { global: { stubs } });
+
+    expect(wrapper.findComponent({ name: 'UserDashboard' }).exists()).toBe(true);
+    expect(window.close).not.toHaveBeenCalled();
+  });
+
+  it('shows the dashboard for a genuine web-app tab inside Thunderbird (e.g. opened from accounts dashboard)', () => {
+    // Regression test for bugzilla #2051092: the accounts.tb.pro Send link
+    // navigates here without ?showDashboard=true and the page used to
+    // self-close instead of rendering the dashboard.
+    environmentType.mockReturnValue('WEB APP INSIDE THUNDERBIRD');
+    isThunderbirdHost.mockReturnValue(true);
+    setSearch('');
+
+    const wrapper = mount(ProfileView, { global: { stubs } });
+
+    expect(wrapper.findComponent({ name: 'UserDashboard' }).exists()).toBe(true);
+    expect(window.close).not.toHaveBeenCalled();
+  });
+
+  it('auto-closes the post-login extension popup (isExtension=true)', () => {
+    environmentType.mockReturnValue('WEB APP INSIDE THUNDERBIRD');
+    isThunderbirdHost.mockReturnValue(true);
+    setSearch('?isExtension=true');
+
+    const wrapper = mount(ProfileView, { global: { stubs } });
+
+    expect(wrapper.findComponent({ name: 'UserDashboard' }).exists()).toBe(
+      false
+    );
+    expect(window.close).toHaveBeenCalled();
+    expect(push).toHaveBeenCalledWith('/close');
+  });
+});

--- a/packages/send/frontend/src/apps/send/components/ProfileView.vue
+++ b/packages/send/frontend/src/apps/send/components/ProfileView.vue
@@ -11,11 +11,24 @@ const { isThunderbirdHost } = useConfigStore();
 const { environmentType } = useIsExtension();
 const router = useRouter();
 
+// The post-login extension popup arrives at /send/profile?isExtension=true and
+// relies on the auto-close below to dismiss itself. A genuine user tab (e.g.
+// opened from the accounts.tb.pro dashboard) does not carry this flag.
+const isExtensionLoginPopup = computed(
+  () =>
+    new URLSearchParams(window.location.search).get('isExtension') === 'true'
+);
+
 const shouldShowDashboard = computed(() => {
   if (environmentType.value === 'WEB APP OUTSIDE THUNDERBIRD') return true;
 
   const urlParams = new URLSearchParams(window.location.search);
-  return urlParams.get('showDashboard') === 'true';
+  if (urlParams.get('showDashboard') === 'true') return true;
+
+  // A real web-app tab inside Thunderbird should render the dashboard rather
+  // than self-close. Only the post-login extension popup (isExtension=true)
+  // should fall through to the auto-close path.
+  return !isExtensionLoginPopup.value;
 });
 
 const close = useDebounceFn(() => {

--- a/packages/send/frontend/src/composables/useSendConfig.ts
+++ b/packages/send/frontend/src/composables/useSendConfig.ts
@@ -157,7 +157,16 @@ export function useSendConfig() {
     isLoggedIn: boolean;
     username: string | null;
   }> => {
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
+      // Guards against the token-bridge content script being absent or
+      // unresponsive (e.g. the page is open outside of Thunderbird, or the
+      // add-on isn't installed). Without this the promise — and any router
+      // guard awaiting it — would hang forever.
+      const timeout = setTimeout(() => {
+        cleanup();
+        reject(new Error('Timed out waiting for addon login state'));
+      }, 5000);
+
       const messageHandler = (event: MessageEvent) => {
         if (event.data?.type === LOGIN_STATE_RESPONSE) {
           cleanup();
@@ -169,6 +178,7 @@ export function useSendConfig() {
       };
 
       const cleanup = () => {
+        clearTimeout(timeout);
         window.removeEventListener('message', messageHandler);
       };
 


### PR DESCRIPTION
## What changed?

Fixes the Send dashboard self-closing when opened from the Thundermail (accounts.tb.pro) account dashboard inside Thunderbird.

- **`ProfileView.vue`** — the dashboard route auto-closed itself whenever it loaded inside Thunderbird without `?showDashboard=true`. The accounts.tb.pro Send link doesn't append that flag, so the page briefly rendered then ran `window.close()` + a `/close` redirect, appearing to "fail to load". The condition is inverted: a genuine web-app tab inside Thunderbird now renders the dashboard, and only the post-login extension popup (which always carries `?isExtension=true` and *relies* on the auto-close) falls through to closing. The "outside Thunderbird" and explicit `showDashboard=true` cases are unchanged.
- **`useSendConfig.ts`** — `queryAddonLoginState` documented a 5-second timeout it never implemented; its promise could hang forever and block the `/send/profile` router guard when the token-bridge doesn't respond. Implemented the missing `setTimeout`/`clearTimeout` so it rejects after 5s and the guard's existing `catch` lets navigation continue.
- **`ProfileView.test.ts`** (new) — covers outside-TB shows dashboard, `showDashboard=true` shows, the regression case (web tab inside TB with no flags → shows, no `window.close()`), and the `isExtension=true` popup still auto-closing.

**AI disclosure:** This change was written by Claude (Opus 4.8) acting as a coding agent, driven and reviewed interactively by the author. The author identified the root cause (the missing `showDashboard` flag triggering the self-close); the agent implemented the fix, tests, and this description. All code was reviewed by the author before submission.

## Why?

Mirrors Bugzilla [bug 2051092](https://bugzilla.mozilla.org/show_bug.cgi?id=2051092): clicking the Send icon in the Thundermail account dashboard showed the Send dashboard briefly, then the page failed to load and redirected back to the accounts dashboard. Root cause was the in-app self-close path firing for a legitimate user-facing tab.

## Limitations and Notes

- A complementary fix could live in the accounts.tb.pro repo (append `?showDashboard=true` to the Send link, or point it at `/send`). This change makes the Send app robust regardless of how it's entered, and is compatible with that source-side change if it also lands.
- The `queryAddonLoginState` timeout is a latent-robustness fix, not the cause of this specific report (the reporter has the add-on installed and the bridge responding); it's folded in because it sits on the same `/send/profile` guard path.

## Applicable Issues

Closes #944

## Screenshots

N/A — behavior fix; no visual changes beyond the dashboard now remaining visible instead of closing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
