### PR TITLE
fix(addon): stop closing Send tabs when access token has expired

### DIFF
--- a/packages/addon/src/menu.ts
+++ b/packages/addon/src/menu.ts
@@ -134,57 +134,37 @@ export async function menuLogout() {
   });
 }
 
-async function closeAllTbProTabs() {
-  const openWindows = await browser.windows.getAll({ populate: true });
-
-  // Close all the tabs that are still open to the BASE_URL, as they may be in a bad state due to the expired token
-  for (const window of openWindows) {
-    for (const tab of window.tabs) {
-      if (tab.url?.includes(`${BASE_URL}`)) {
-        try {
-          await browser.tabs.remove(tab.id!);
-          console.log(`Closed expired session tab with id ${tab.id}`);
-        } catch {
-          console.warn(`Could not close tab with id ${tab.id}`);
-        }
-      }
-    }
-  }
-}
-
-/* 
+/*
   Checks if the add-on is logged in, this is separate from the web context.
-  It's useful for the web context to figure out if the add-on is logged in or not, and also for the add-on to check if the token is expired and log out if necessary.
+  It's a read-only probe: it's called by the Send route guard (via GET_LOGIN_STATE)
+  and by a 60s timer, so it MUST NOT have destructive side effects (closing tabs,
+  wiping storage, forcing the menu to log out).
+
+  Note on `expires_at`: that field is the short-lived OIDC *access token* expiry. An
+  expired access token does NOT mean the session is over — the Send web app refreshes
+  it transparently via userManager.signinSilent() using the refresh_token (see
+  auth-store getAccessToken/checkAuthStatus). So login state is driven by the presence
+  of a refresh_token, not by access-token expiry. Genuine logout flows through the
+  SIGN_OUT message path, which calls menuLogout().
  */
 export async function getLoginState() {
   try {
     // Get the auth token from browser storage (this is a copy of the auth token stored in the web context, used to determine login state in the add-on context)
     const authStorageData = await browser.storage.local.get(STORAGE_KEY_AUTH);
-    console.log(authStorageData);
-    if (authStorageData[STORAGE_KEY_AUTH]) {
-      // Check token expiration
-      const expiration = authStorageData[STORAGE_KEY_AUTH]?.expires_at * 1000; // Convert to milliseconds
-      const now = Date.now();
-      console.log('Token expires in (s):', (expiration - now) / 1000);
-      // If the token is expired, treat as logged out
-      if (expiration && now >= expiration) {
-        console.warn('Auth token is expired. Treating as logged out.');
-        await closeAllTbProTabs();
-
-        await browser.storage.local.remove(STORAGE_KEY_AUTH);
-        await menuLogout();
-        return { isLoggedIn: false, username: null };
-      }
-
-      const username =
-        authStorageData[STORAGE_KEY_AUTH]?.profile?.preferred_username ||
-        authStorageData[STORAGE_KEY_AUTH]?.profile?.email;
-
-      if (username) {
-        await menuLoggedIn({ username });
-        return { isLoggedIn: true, username };
-      }
+    const auth = authStorageData[STORAGE_KEY_AUTH];
+    if (!auth) {
+      return { isLoggedIn: false, username: null };
     }
+
+    const username = auth?.profile?.preferred_username || auth?.profile?.email;
+
+    // A stored session with a refresh_token is logged in, even if the access
+    // token's expires_at has lapsed — the web app will silently refresh it.
+    if (auth.refresh_token && username) {
+      await menuLoggedIn({ username });
+      return { isLoggedIn: true, username };
+    }
+
     return { isLoggedIn: false, username: null };
   } catch (error) {
     console.error('Error retrieving auth state from storage:', error);

--- a/packages/addon/src/test/menu.test.ts
+++ b/packages/addon/src/test/menu.test.ts
@@ -1,0 +1,110 @@
+import { STORAGE_KEY_AUTH } from '@send-frontend/lib/const';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getLoginState } from '../menu';
+
+/**
+ * Regression guard: getLoginState() is a read-only probe (called by the Send
+ * route guard via GET_LOGIN_STATE and by a 60s timer). It must never close tabs
+ * or wipe storage as a side effect. In particular, an *expired access token*
+ * (short-lived `expires_at`) is NOT logged out — the web app refreshes it
+ * silently with the refresh_token — so it must keep returning isLoggedIn: true
+ * and leave open send.tb.pro tabs alone. Previously the expiry branch called
+ * closeAllTbProTabs(), which closed the Send dashboard tab opened from the
+ * accounts dashboard.
+ */
+
+const USERNAME = 'user@example.com';
+
+function setupBrowserMock(authValue: unknown) {
+  vi.stubGlobal('browser', {
+    storage: {
+      local: {
+        get: vi.fn().mockResolvedValue(
+          authValue === undefined ? {} : { [STORAGE_KEY_AUTH]: authValue }
+        ),
+        remove: vi.fn().mockResolvedValue(undefined),
+        clear: vi.fn().mockResolvedValue(undefined),
+      },
+    },
+    tabs: {
+      remove: vi.fn().mockResolvedValue(undefined),
+      create: vi.fn().mockResolvedValue({ id: 1 }),
+    },
+    windows: {
+      getAll: vi.fn().mockResolvedValue([]),
+    },
+    TBProMenu: {
+      update: vi.fn().mockResolvedValue(undefined),
+      create: vi.fn().mockResolvedValue(undefined),
+      clear: vi.fn().mockResolvedValue(undefined),
+    },
+    i18n: { getMessage: vi.fn((key: string) => key) },
+  });
+}
+
+// `expires_at` is a Unix timestamp in seconds (OIDC access-token expiry).
+const PAST = Math.floor(Date.now() / 1000) - 3600;
+const FUTURE = Math.floor(Date.now() / 1000) + 3600;
+
+const authWith = (overrides: Record<string, unknown> = {}) => ({
+  refresh_token: 'refresh-abc',
+  expires_at: FUTURE,
+  profile: { preferred_username: USERNAME },
+  ...overrides,
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('getLoginState', () => {
+  it('reports logged out and closes no tabs when no auth is stored', async () => {
+    setupBrowserMock(undefined);
+
+    const state = await getLoginState();
+
+    expect(state).toEqual({ isLoggedIn: false, username: null });
+    expect(browser.tabs.remove).not.toHaveBeenCalled();
+  });
+
+  it('stays logged in WITHOUT closing tabs when the access token has expired', async () => {
+    setupBrowserMock(authWith({ expires_at: PAST }));
+
+    const state = await getLoginState();
+
+    expect(state).toEqual({ isLoggedIn: true, username: USERNAME });
+    // The core regression: an expired access token must not tear down Send tabs.
+    expect(browser.tabs.remove).not.toHaveBeenCalled();
+    expect(browser.storage.local.remove).not.toHaveBeenCalled();
+  });
+
+  it('reports logged in for a stored session with a valid token', async () => {
+    setupBrowserMock(authWith());
+
+    const state = await getLoginState();
+
+    expect(state).toEqual({ isLoggedIn: true, username: USERNAME });
+    expect(browser.tabs.remove).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the profile email when preferred_username is absent', async () => {
+    setupBrowserMock(
+      authWith({ profile: { email: USERNAME }, expires_at: PAST })
+    );
+
+    const state = await getLoginState();
+
+    expect(state).toEqual({ isLoggedIn: true, username: USERNAME });
+  });
+
+  it('reports logged out when the stored session has no refresh_token', async () => {
+    setupBrowserMock(authWith({ refresh_token: undefined }));
+
+    const state = await getLoginState();
+
+    expect(state).toEqual({ isLoggedIn: false, username: null });
+    expect(browser.tabs.remove).not.toHaveBeenCalled();
+  });
+});

--- a/packages/send/frontend/src/apps/send/stores/folder-store.ts
+++ b/packages/send/frontend/src/apps/send/stores/folder-store.ts
@@ -77,7 +77,7 @@ export interface FolderStore {
 
 const useFolderStore = defineStore('folderManager', () => {
   const { api } = useApiStore();
-  const { user } = useUserStore();
+  const { user, populateFromBackend } = useUserStore();
   const { progress } = useStatusStore();
   const { metrics } = useMetricsStore();
   const { keychain } = useKeychainStore();
@@ -264,6 +264,23 @@ const useFolderStore = defineStore('folderManager', () => {
     api: ApiConnection
   ): Promise<Item[]> {
     progress.error = '';
+
+    // Guard against uploading with an unpopulated user. The create-entry POST
+    // (`POST /api/uploads`) sends `ownerId: user.id`; an undefined id is silently
+    // dropped by JSON.stringify, so the backend rejects every attempt with a 400
+    // ("Required" on ownerId) and the upload retry loop hammers it — which also
+    // drives a storm of token/userinfo refreshes. Re-hydrate from the backend
+    // session first, and fail with a clear message if it still can't provide one.
+    if (!user.id) {
+      console.warn('uploadItem: user.id missing; re-populating from backend');
+      await populateFromBackend();
+    }
+    if (!user.id) {
+      progress.error = 'You are not fully signed in. Please sign in again.';
+      throw new Error(
+        'Cannot upload: user session is missing a user id (ownerId would be empty).'
+      );
+    }
 
     const canUpload = await checkBlobSize(fileBlob);
 

--- a/packages/send/frontend/src/stores/auth-store.ts
+++ b/packages/send/frontend/src/stores/auth-store.ts
@@ -24,16 +24,40 @@ const settings: UserManagerSettings = {
   post_logout_redirect_uri: `${import.meta.env?.VITE_SEND_CLIENT_URL}/logout`,
   response_type: 'code',
   scope: 'openid profile email offline_access',
-  automaticSilentRenew: true,
+  // Refresh on demand only (see refreshAccessToken). The library's background
+  // auto-renew adds uncontrolled concurrent refreshes and falls back to an
+  // iframe flow that cannot work inside Thunderbird, both of which surface as
+  // spurious logouts.
+  automaticSilentRenew: false,
   filterProtocolClaims: true,
-  loadUserInfo: true,
+  // Profile claims (preferred_username, email, name, given_name) already come
+  // from the id_token with the profile+email scopes. Skipping the userinfo
+  // call removes a post-refresh network round-trip that can fail inside
+  // Thunderbird and reject an otherwise-successful token refresh.
+  loadUserInfo: false,
 };
 
 const userManager = new UserManager(settings);
 
+/**
+ * OIDC error codes that mean the session is genuinely over — the refresh token
+ * was revoked or has expired. Any other failure (network, timeout, userinfo)
+ * is transient and must NOT drop the user out of a still-valid session.
+ */
+const GENUINE_AUTH_FAILURE_CODES = [
+  'invalid_grant',
+  'login_required',
+  'session_expired',
+];
+
+function isGenuineAuthFailure(error: unknown): boolean {
+  const code = (error as { error?: string } | null)?.error;
+  return typeof code === 'string' && GENUINE_AUTH_FAILURE_CODES.includes(code);
+}
+
 export const useAuthStore = defineStore('auth', () => {
   const { api } = useApiStore();
-  const { isExtension } = useConfigStore();
+  const { isExtension, isThunderbirdHost } = useConfigStore();
 
   const isLoggedIn = ref(false);
   const currentUser = ref<User | null>(null);
@@ -43,6 +67,76 @@ export const useAuthStore = defineStore('auth', () => {
   });
 
   // ------- OIDC Authentication ------- //
+
+  // Shared in-flight refresh promise. Concurrent callers (getAccessToken before
+  // an API call, checkAuthStatus, the 60s add-on menu timer) reuse the same
+  // signinSilent() rather than firing overlapping refreshes — with refresh-token
+  // rotation, every extra concurrent refresh races the others and loses with
+  // invalid_grant, which reads as a spurious logout.
+  let inFlightRefresh: Promise<User | null> | null = null;
+
+  /**
+   * Notify the add-on background that the session is over so its menu reverts
+   * to logged-out. Only meaningful inside Thunderbird, where the token-bridge
+   * content script forwards window messages to background.ts — the same path
+   * UserMenu.vue uses on explicit logout.
+   */
+  function notifyAddonSignedOut() {
+    if (!isThunderbirdHost) return;
+    try {
+      window.postMessage({ type: SIGN_OUT }, window.location.origin);
+    } catch (error) {
+      console.error('Failed to notify add-on of sign-out:', error);
+    }
+  }
+
+  /**
+   * Refresh the access token via the refresh_token, deduping concurrent callers.
+   *
+   * Returns the refreshed User on success. On a genuine auth failure (refresh
+   * token revoked/expired) it clears local login state, notifies the add-on,
+   * and returns null. On a transient failure (network/timeout) it leaves the
+   * session intact and returns null so a later call can retry — we do not log
+   * the user out over a blip.
+   */
+  async function refreshAccessToken(): Promise<User | null> {
+    if (inFlightRefresh) return inFlightRefresh;
+
+    inFlightRefresh = (async () => {
+      try {
+        const user = await userManager.signinSilent();
+        currentUser.value = user;
+        // Persist the freshly-rotated token so the extension popup's next cold
+        // start reads a current token instead of a stale one.
+        if (isExtension && user) {
+          await browser.storage.local.set({ [STORAGE_KEY_AUTH]: user });
+        }
+        return user;
+      } catch (error) {
+        if (isGenuineAuthFailure(error)) {
+          console.warn(
+            `Silent token refresh failed — session ended (${
+              (error as { error?: string }).error
+            }). Signing out.`
+          );
+          isLoggedIn.value = false;
+          currentUser.value = null;
+          notifyAddonSignedOut();
+        } else {
+          // Transient failure: keep the session and let a later call retry.
+          console.warn(
+            'Silent token refresh hit a transient error; keeping session:',
+            error
+          );
+        }
+        return null;
+      } finally {
+        inFlightRefresh = null;
+      }
+    })();
+
+    return inFlightRefresh;
+  }
 
   async function getOIDCUser() {
     try {
@@ -206,23 +300,11 @@ export const useAuthStore = defineStore('auth', () => {
       // If the stored access token has expired (common when the extension is
       // reopened after being idle for longer than the token lifetime, typically
       // ~5 minutes), attempt a silent refresh using the refresh_token before
-      // giving up.  automaticSilentRenew only fires while the page is open, so
-      // we cannot rely on it for cold starts.
+      // giving up. refreshAccessToken() handles state/notification on genuine
+      // failure and preserves the session on transient errors.
       if (user?.expired) {
-        try {
-          user = await userManager.signinSilent();
-          // Sync the fresh token back to extension storage so the next cold
-          // start doesn't need another round-trip to the token endpoint.
-          if (isExtension) {
-            await browser.storage.local.set({ [STORAGE_KEY_AUTH]: user });
-          }
-        } catch (refreshError) {
-          console.warn(
-            'Silent token refresh failed during checkAuthStatus:',
-            refreshError
-          );
-          isLoggedIn.value = false;
-          currentUser.value = null;
+        user = await refreshAccessToken();
+        if (!user) {
           return null;
         }
       }
@@ -265,11 +347,7 @@ export const useAuthStore = defineStore('auth', () => {
       if (user.expired) {
         // Access token has expired — use the refresh_token to obtain a new one
         // rather than returning a stale value that will be rejected by every API.
-        user = await userManager.signinSilent();
-        currentUser.value = user;
-        if (isExtension) {
-          await browser.storage.local.set({ [STORAGE_KEY_AUTH]: user });
-        }
+        user = await refreshAccessToken();
       }
       return user?.access_token || null;
     } catch (error) {
@@ -302,20 +380,13 @@ export const useAuthStore = defineStore('auth', () => {
   }
 
   /**
-   * Silent refresh of the access token
+   * Silent refresh of the access token. Delegates to the deduped
+   * refreshAccessToken(), which owns state/notification on genuine failure and
+   * preserves the session on transient errors.
    */
   async function refreshToken() {
-    try {
-      const user = await userManager.signinSilent();
-      currentUser.value = user;
-      return user.access_token;
-    } catch (error) {
-      console.error('Token refresh failed:', error);
-      // If silent refresh fails, user needs to re-authenticate
-      isLoggedIn.value = false;
-      currentUser.value = null;
-      return null;
-    }
+    const user = await refreshAccessToken();
+    return user?.access_token ?? null;
   }
 
   async function loadUser() {

--- a/packages/send/frontend/src/test/stores/auth-store.test.ts
+++ b/packages/send/frontend/src/test/stores/auth-store.test.ts
@@ -1,0 +1,123 @@
+import { useAuthStore } from '@send-frontend/stores/auth-store';
+import { UserManager } from 'oidc-client-ts';
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Force the config store's `isThunderbirdHost` (derived from the user agent) on
+ * or off. Must be called BEFORE useAuthStore(), because the auth store reads the
+ * value once at setup time.
+ */
+function setThunderbirdHost(isThunderbird: boolean) {
+  Object.defineProperty(navigator, 'userAgent', {
+    value: isThunderbird
+      ? 'Mozilla/5.0 Thunderbird/128.0'
+      : 'Mozilla/5.0 Firefox/128.0',
+    configurable: true,
+  });
+}
+
+describe('auth-store token refresh', () => {
+  let signinSilent: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    signinSilent = vi.spyOn(UserManager.prototype, 'signinSilent');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('dedupes concurrent refreshes into a single signinSilent call', async () => {
+    setThunderbirdHost(false);
+    // Resolve only after both callers have started, so both observe the same
+    // in-flight promise.
+    let resolveSignin: (value: unknown) => void;
+    signinSilent.mockReturnValue(
+      new Promise((resolve) => {
+        resolveSignin = resolve;
+      }) as never
+    );
+
+    const auth = useAuthStore();
+    const first = auth.refreshToken();
+    const second = auth.refreshToken();
+
+    resolveSignin!({ access_token: 'fresh-token', expired: false });
+    const [a, b] = await Promise.all([first, second]);
+
+    expect(signinSilent).toHaveBeenCalledTimes(1);
+    expect(a).toBe('fresh-token');
+    expect(b).toBe('fresh-token');
+  });
+
+  it('runs a fresh signinSilent again after the in-flight one settles', async () => {
+    setThunderbirdHost(false);
+    signinSilent.mockResolvedValue({
+      access_token: 'token-1',
+      expired: false,
+    } as never);
+
+    const auth = useAuthStore();
+    await auth.refreshToken();
+    await auth.refreshToken();
+
+    expect(signinSilent).toHaveBeenCalledTimes(2);
+  });
+
+  it('signs out and notifies the add-on on a genuine invalid_grant failure', async () => {
+    setThunderbirdHost(true);
+    const postMessage = vi
+      .spyOn(window, 'postMessage')
+      .mockImplementation(() => {});
+    signinSilent.mockRejectedValue({ error: 'invalid_grant' } as never);
+
+    const auth = useAuthStore();
+    auth.isLoggedIn = true;
+
+    const token = await auth.refreshToken();
+
+    expect(token).toBeNull();
+    expect(auth.isLoggedIn).toBe(false);
+    expect(auth.currentUser).toBeNull();
+    expect(postMessage).toHaveBeenCalledWith(
+      { type: 'SIGN_OUT' },
+      window.location.origin
+    );
+  });
+
+  it('preserves the session and does not notify on a transient failure', async () => {
+    setThunderbirdHost(true);
+    const postMessage = vi
+      .spyOn(window, 'postMessage')
+      .mockImplementation(() => {});
+    signinSilent.mockRejectedValue(new Error('network down') as never);
+
+    const auth = useAuthStore();
+    auth.isLoggedIn = true;
+
+    const token = await auth.refreshToken();
+
+    expect(token).toBeNull();
+    // A network blip must not log the user out.
+    expect(auth.isLoggedIn).toBe(true);
+    expect(postMessage).not.toHaveBeenCalled();
+  });
+
+  it('does not post SIGN_OUT when not running inside Thunderbird', async () => {
+    setThunderbirdHost(false);
+    const postMessage = vi
+      .spyOn(window, 'postMessage')
+      .mockImplementation(() => {});
+    signinSilent.mockRejectedValue({ error: 'invalid_grant' } as never);
+
+    const auth = useAuthStore();
+    auth.isLoggedIn = true;
+
+    await auth.refreshToken();
+
+    expect(auth.isLoggedIn).toBe(false);
+    expect(postMessage).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What changed?

This branch fixes three related add-on session/upload bugs.

**1. Add-on menu no longer closes Send tabs on access-token expiry (#948).**
Made the add-on's `getLoginState()` (`packages/addon/src/menu.ts`) a **read-only probe**. It now reports logged-in based on a stored session that has a `refresh_token`, regardless of the OIDC access-token `expires_at`, and no longer performs destructive side effects. The previously coupled `closeAllTbProTabs()` / `storage.remove` / `menuLogout()` calls were removed from the probe, and the now-unused `closeAllTbProTabs()` helper was deleted. Added `packages/addon/src/test/menu.test.ts`.

**2. OIDC silent-refresh churn / spurious logouts (#951).**
Reworked `packages/send/frontend/src/stores/auth-store.ts`:
- `automaticSilentRenew: false` and `loadUserInfo: false` — removes uncontrolled background renews and a fragile post-refresh `userinfo` round-trip that can fail inside Thunderbird and reject an otherwise-successful refresh (profile claims already come from the id_token).
- A shared in-flight `refreshAccessToken()` promise dedupes concurrent refreshes, so refresh-token rotation no longer races callers into `invalid_grant`.
- Distinguishes genuine auth failures (`invalid_grant`, `login_required`, `session_expired`) — which clear login state and notify the add-on via `SIGN_OUT` — from transient failures, which preserve the session for a later retry. This implements the `SIGN_OUT`-on-silent-refresh-failure follow-up noted in the original scope of this PR. Added `packages/send/frontend/src/test/stores/auth-store.test.ts`.

**3. File upload fails with an empty `ownerId` → 400 storm (#950).**
Added a self-healing guard in `uploadItem` (`packages/send/frontend/src/apps/send/stores/folder-store.ts`): before uploading, if `user.id` is empty it calls `populateFromBackend()`, and if the id is still empty it aborts with a clear error instead of sending an `ownerId`-less body that the backend rejects with `400` and the retry loop hammers. Because the `Uploader` holds the same shared reactive `user` object, re-populating also fixes `this.user.id` inside `doUpload`.

**AI disclosure:** These changes were implemented by Claude (agent-written) under close human direction. The maintainer reproduced each bug manually in Thunderbird, drove the investigation (including capturing the network traffic and the exact 400 response body), reviewed the root-cause analysis, and approved the plans and final diffs.

## Why?

Inside Thunderbird, clicking a `send.tb.pro` link from `accounts.tb.pro/dashboard` closed the newly-opened Send tab once the add-on's stored access token had passed its short-lived `expires_at`, because `getLoginState()` treated an expired access token as logged-out. `expires_at` is the access-token expiry, not the session lifetime — the Send web app refreshes transparently via `signinSilent()` (#948).

That refresh path was itself fragile: `automaticSilentRenew` plus on-demand `signinSilent()` with no deduplication produced concurrent refreshes that race under refresh-token rotation, and `loadUserInfo` added a `userinfo` round-trip that can fail in Thunderbird. The result was a storm of `token`/`userinfo` requests and spurious logouts (#951).

One downstream effect of that churn: `GET users/me` could fail at load, leaving the reactive user store unpopulated. An upload would then send `ownerId: undefined`; `JSON.stringify` drops the key, the backend's Zod schema rejects it with `400 "ownerId Required"`, and the upload retry loop re-fires the whole block repeatedly — the visible `signed → PUT(200) → uploads(400)` storm (#950).

## Limitations and Notes

- The add-on background has no `userManager`, so it cannot refresh tokens itself — refresh remains owned by the web app, which the menu change defers to.
- #948 is distinct from #945 (the `ProfileView` self-close), which is working correctly.
- The upload guard fixes the symptom (never send an empty `ownerId`) from one side; the auth-store rework fixes the churn that can leave `user.id` unpopulated from the other side.

## Applicable Issues

Closes #948
Closes #950
Closes #951

## Screenshots

N/A — behavioral fixes, no UI change. The #950 network-tab repro (repeating `token`/`userinfo`/`signed`/`uploads` 400 cycles) is described in that issue.
