### PR TITLE
feat(telemetry): honor Thunderbird telemetry opt-out for Sentry & PostHog

### DIFF
--- a/packages/addon/public/api/Telemetry/implementation.js
+++ b/packages/addon/public/api/Telemetry/implementation.js
@@ -1,0 +1,69 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+/**
+ * Telemetry Experiment API
+ *
+ * Exposes Thunderbird's telemetry opt-out preference
+ * (datareporting.healthreport.uploadEnabled) to the WebExtension so the add-on
+ * can gate Sentry and PostHog on it. Reads fail closed: if the preference
+ * cannot be read, telemetry is treated as disabled (opted out).
+ */
+
+(function (exports) {
+  const TELEMETRY_PREF = 'datareporting.healthreport.uploadEnabled';
+
+  /**
+   * Reads the telemetry upload preference, defaulting to false (opted out) on
+   * any error so we never send telemetry when the pref state is unknown.
+   */
+  function readUploadEnabled() {
+    try {
+      return Services.prefs.getBoolPref(TELEMETRY_PREF, false);
+    } catch (e) {
+      console.error('[Telemetry] Failed to read telemetry preference:', e);
+      return false;
+    }
+  }
+
+  class Telemetry extends ExtensionCommon.ExtensionAPI {
+    getAPI(context) {
+      return {
+        Telemetry: {
+          async getUploadEnabled() {
+            return readUploadEnabled();
+          },
+
+          onChanged: new ExtensionCommon.EventManager({
+            context,
+            name: 'Telemetry.onChanged',
+            register(fire) {
+              const observer = {
+                QueryInterface: ChromeUtils.generateQI(['nsIObserver']),
+                observe(_subject, _topic, data) {
+                  // When observing a single branch, `data` is the full name of
+                  // the pref that changed.
+                  if (data === TELEMETRY_PREF) {
+                    fire.async(readUploadEnabled());
+                  }
+                },
+              };
+
+              Services.prefs.addObserver(TELEMETRY_PREF, observer);
+
+              // Return cleanup function — called when the listener is removed.
+              return () => {
+                Services.prefs.removeObserver(TELEMETRY_PREF, observer);
+              };
+            },
+          }).api(),
+        },
+      };
+    }
+  }
+
+  exports.Telemetry = Telemetry;
+})(this);

--- a/packages/addon/public/api/Telemetry/implementation.js
+++ b/packages/addon/public/api/Telemetry/implementation.js
@@ -7,24 +7,35 @@
 /**
  * Telemetry Experiment API
  *
- * Exposes Thunderbird's telemetry opt-out preference
- * (datareporting.healthreport.uploadEnabled) to the WebExtension so the add-on
- * can gate Sentry and PostHog on it. Reads fail closed: if the preference
- * cannot be read, telemetry is treated as disabled (opted out).
+ * Exposes whether Thunderbird telemetry is enabled to the WebExtension so the
+ * add-on can gate Sentry and PostHog on it. Telemetry is considered enabled
+ * only when BOTH of Thunderbird's data-reporting prefs are on:
+ *   - datareporting.policy.dataSubmissionEnabled (master switch)
+ *   - datareporting.healthreport.uploadEnabled   (upload opt-in)
+ * Reads fail closed: if either pref cannot be read, telemetry is treated as
+ * disabled (opted out).
  */
 
 (function (exports) {
-  const TELEMETRY_PREF = 'datareporting.healthreport.uploadEnabled';
+  // Both prefs must be true for telemetry to be enabled. dataSubmissionEnabled
+  // is the master data-reporting switch; uploadEnabled is the user's opt-in.
+  const TELEMETRY_PREFS = [
+    'datareporting.policy.dataSubmissionEnabled',
+    'datareporting.healthreport.uploadEnabled',
+  ];
 
   /**
-   * Reads the telemetry upload preference, defaulting to false (opted out) on
-   * any error so we never send telemetry when the pref state is unknown.
+   * Returns true only when the user has telemetry enabled. Defaults to false
+   * (opted out) on any error so we never send telemetry when the pref state is
+   * unknown.
    */
-  function readUploadEnabled() {
+  function readTelemetryEnabled() {
     try {
-      return Services.prefs.getBoolPref(TELEMETRY_PREF, false);
+      return TELEMETRY_PREFS.every((pref) =>
+        Services.prefs.getBoolPref(pref, false)
+      );
     } catch (e) {
-      console.error('[Telemetry] Failed to read telemetry preference:', e);
+      console.error('[Telemetry] Failed to read telemetry preferences:', e);
       return false;
     }
   }
@@ -32,31 +43,41 @@
   class Telemetry extends ExtensionCommon.ExtensionAPI {
     getAPI(context) {
       return {
-        Telemetry: {
-          async getUploadEnabled() {
-            return readUploadEnabled();
+        thundermailTelemetry: {
+          async isTelemetryEnabled() {
+            return readTelemetryEnabled();
           },
 
+          // NOTE: Under MV2 (this add-on's manifest) the background is
+          // persistent, so ExtensionCommon.EventManager is sufficient here. An
+          // eventual MV3 / event-page migration would instead need the
+          // primed/persistent-listener pattern so pref changes can wake a
+          // suspended background — revisit this then.
           onChanged: new ExtensionCommon.EventManager({
             context,
-            name: 'Telemetry.onChanged',
+            name: 'thundermailTelemetry.onChanged',
             register(fire) {
               const observer = {
                 QueryInterface: ChromeUtils.generateQI(['nsIObserver']),
                 observe(_subject, _topic, data) {
-                  // When observing a single branch, `data` is the full name of
-                  // the pref that changed.
-                  if (data === TELEMETRY_PREF) {
-                    fire.async(readUploadEnabled());
+                  // When observing these branches, `data` is the full name of
+                  // the pref that changed. Either pref flipping can change the
+                  // effective telemetry state.
+                  if (TELEMETRY_PREFS.includes(data)) {
+                    fire.async(readTelemetryEnabled());
                   }
                 },
               };
 
-              Services.prefs.addObserver(TELEMETRY_PREF, observer);
+              for (const pref of TELEMETRY_PREFS) {
+                Services.prefs.addObserver(pref, observer);
+              }
 
               // Return cleanup function — called when the listener is removed.
               return () => {
-                Services.prefs.removeObserver(TELEMETRY_PREF, observer);
+                for (const pref of TELEMETRY_PREFS) {
+                  Services.prefs.removeObserver(pref, observer);
+                }
               };
             },
           }).api(),

--- a/packages/addon/public/api/Telemetry/schema.json
+++ b/packages/addon/public/api/Telemetry/schema.json
@@ -1,16 +1,16 @@
 [
   {
-    "namespace": "Telemetry",
+    "namespace": "thundermailTelemetry",
     "functions": [
       {
-        "name": "getUploadEnabled",
+        "name": "isTelemetryEnabled",
         "type": "function",
-        "description": "Returns the current value of the Thunderbird telemetry upload preference (datareporting.healthreport.uploadEnabled). Defaults to false (opted out) if the preference cannot be read.",
+        "description": "Returns whether Thunderbird telemetry is currently enabled in the client. Telemetry is enabled only when both datareporting.policy.dataSubmissionEnabled and datareporting.healthreport.uploadEnabled are true. Defaults to false (opted out) if the state cannot be read.",
         "async": true,
         "parameters": [],
         "returns": {
           "type": "boolean",
-          "description": "True if the user has telemetry upload enabled; false if the user has opted out or the preference cannot be read."
+          "description": "True if telemetry is enabled; false if the user has opted out or the state cannot be read."
         }
       }
     ],
@@ -18,12 +18,12 @@
       {
         "name": "onChanged",
         "type": "function",
-        "description": "Fires when the Thunderbird telemetry upload preference (datareporting.healthreport.uploadEnabled) changes, with the new value.",
+        "description": "Fires when the effective Thunderbird telemetry state changes (i.e. either data-reporting pref changes), with the new value.",
         "parameters": [
           {
-            "name": "uploadEnabled",
+            "name": "enabled",
             "type": "boolean",
-            "description": "The new value of datareporting.healthreport.uploadEnabled."
+            "description": "The new effective telemetry state (true if enabled)."
           }
         ]
       }

--- a/packages/addon/public/api/Telemetry/schema.json
+++ b/packages/addon/public/api/Telemetry/schema.json
@@ -1,0 +1,32 @@
+[
+  {
+    "namespace": "Telemetry",
+    "functions": [
+      {
+        "name": "getUploadEnabled",
+        "type": "function",
+        "description": "Returns the current value of the Thunderbird telemetry upload preference (datareporting.healthreport.uploadEnabled). Defaults to false (opted out) if the preference cannot be read.",
+        "async": true,
+        "parameters": [],
+        "returns": {
+          "type": "boolean",
+          "description": "True if the user has telemetry upload enabled; false if the user has opted out or the preference cannot be read."
+        }
+      }
+    ],
+    "events": [
+      {
+        "name": "onChanged",
+        "type": "function",
+        "description": "Fires when the Thunderbird telemetry upload preference (datareporting.healthreport.uploadEnabled) changes, with the new value.",
+        "parameters": [
+          {
+            "name": "uploadEnabled",
+            "type": "boolean",
+            "description": "The new value of datareporting.healthreport.uploadEnabled."
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/addon/public/manifest.json
+++ b/packages/addon/public/manifest.json
@@ -124,6 +124,20 @@
           "startup"
         ]
       }
+    },
+    "Telemetry": {
+      "schema": "api/Telemetry/schema.json",
+      "parent": {
+        "scopes": [
+          "addon_parent"
+        ],
+        "paths": [
+          [
+            "Telemetry"
+          ]
+        ],
+        "script": "api/Telemetry/implementation.js"
+      }
     }
   },
   "content_scripts": [

--- a/packages/addon/public/manifest.json
+++ b/packages/addon/public/manifest.json
@@ -136,7 +136,10 @@
             "Telemetry"
           ]
         ],
-        "script": "api/Telemetry/implementation.js"
+        "script": "api/Telemetry/implementation.js",
+        "events": [
+          "startup"
+        ]
       }
     }
   },

--- a/packages/addon/public/manifest.json
+++ b/packages/addon/public/manifest.json
@@ -125,7 +125,7 @@
         ]
       }
     },
-    "Telemetry": {
+    "thundermailTelemetry": {
       "schema": "api/Telemetry/schema.json",
       "parent": {
         "scopes": [
@@ -133,7 +133,7 @@
         ],
         "paths": [
           [
-            "Telemetry"
+            "thundermailTelemetry"
           ]
         ],
         "script": "api/Telemetry/implementation.js"

--- a/packages/addon/public/manifest.json
+++ b/packages/addon/public/manifest.json
@@ -136,10 +136,7 @@
             "Telemetry"
           ]
         ],
-        "script": "api/Telemetry/implementation.js",
-        "events": [
-          "startup"
-        ]
+        "script": "api/Telemetry/implementation.js"
       }
     }
   },

--- a/packages/addon/public/token-bridge.js
+++ b/packages/addon/public/token-bridge.js
@@ -19,7 +19,7 @@ const OPEN_MANAGEMENT_PAGE = 'OPEN_MANAGEMENT_PAGE';
 const GET_PENDING_ADDON_TOKEN = 'TB/GET_PENDING_ADDON_TOKEN';
 const PENDING_ADDON_TOKEN_RESPONSE = 'TB/PENDING_ADDON_TOKEN_RESPONSE';
 // Telemetry pref bridge (issue #952). The hosted Send dashboard cannot call the
-// browser.Telemetry experiment API, so it asks the background for the pref:
+// browser.thundermailTelemetry experiment API, so it asks the background for the pref:
 //   GET_TELEMETRY_STATE      : web page → bridge → background
 //   TELEMETRY_STATE_RESPONSE : background → bridge → web page
 //   TELEMETRY_STATE_CHANGED  : background → bridge → web page (runtime change)
@@ -146,10 +146,23 @@ window.addEventListener('message', (e) => {
   }
 
   // ----- Web to add-on: hosted dashboard asks for the telemetry pref -----
+  // The background returns the state as the sendMessage response (scoped to
+  // this tab), which we relay back to the page. It answers only for our own
+  // Send tabs, so a non-Send page gets no response and the page fails closed.
   if (e?.data?.type === GET_TELEMETRY_STATE) {
-    browser.runtime.sendMessage({
-      type: GET_TELEMETRY_STATE,
-    });
+    browser.runtime
+      .sendMessage({ type: GET_TELEMETRY_STATE })
+      .then((response) => {
+        if (response?.type === TELEMETRY_STATE_RESPONSE) {
+          window.postMessage(
+            { type: TELEMETRY_STATE_RESPONSE, enabled: response.enabled },
+            window.location.origin
+          );
+        }
+      })
+      .catch(() => {
+        // No handler / not our tab — the page-side timeout fails closed.
+      });
   }
 });
 
@@ -195,14 +208,14 @@ browser.runtime.onMessage.addListener((message) => {
     );
   }
 
-  // ----- Add-on to Web: telemetry pref value / runtime change (issue #952) -----
-  if (
-    message.type === TELEMETRY_STATE_RESPONSE ||
-    message.type === TELEMETRY_STATE_CHANGED
-  ) {
+  // ----- Add-on to Web: telemetry runtime change (issue #952) -----
+  // The GET_TELEMETRY_STATE reply is handled inline as the sendMessage
+  // response above; here we only forward unsolicited runtime changes the
+  // background broadcasts to our Send tabs.
+  if (message.type === TELEMETRY_STATE_CHANGED) {
     window.postMessage(
       {
-        type: message.type,
+        type: TELEMETRY_STATE_CHANGED,
         enabled: message.enabled,
       },
       window.location.origin

--- a/packages/addon/public/token-bridge.js
+++ b/packages/addon/public/token-bridge.js
@@ -18,6 +18,14 @@ const OPEN_MANAGEMENT_PAGE = 'OPEN_MANAGEMENT_PAGE';
 //   PENDING_ADDON_TOKEN_RESPONSE : background → bridge → web page ("here it is")
 const GET_PENDING_ADDON_TOKEN = 'TB/GET_PENDING_ADDON_TOKEN';
 const PENDING_ADDON_TOKEN_RESPONSE = 'TB/PENDING_ADDON_TOKEN_RESPONSE';
+// Telemetry pref bridge (issue #952). The hosted Send dashboard cannot call the
+// browser.Telemetry experiment API, so it asks the background for the pref:
+//   GET_TELEMETRY_STATE      : web page → bridge → background
+//   TELEMETRY_STATE_RESPONSE : background → bridge → web page
+//   TELEMETRY_STATE_CHANGED  : background → bridge → web page (runtime change)
+const GET_TELEMETRY_STATE = 'TB/GET_TELEMETRY_STATE';
+const TELEMETRY_STATE_RESPONSE = 'TB/TELEMETRY_STATE_RESPONSE';
+const TELEMETRY_STATE_CHANGED = 'TB/TELEMETRY_STATE_CHANGED';
 
 window.postMessage({ type: BRIDGE_READY }, window.location.origin);
 console.log(`[🌉 token-bridge] the token bridge has loaded.`);
@@ -136,6 +144,13 @@ window.addEventListener('message', (e) => {
       type: GET_PENDING_ADDON_TOKEN,
     });
   }
+
+  // ----- Web to add-on: hosted dashboard asks for the telemetry pref -----
+  if (e?.data?.type === GET_TELEMETRY_STATE) {
+    browser.runtime.sendMessage({
+      type: GET_TELEMETRY_STATE,
+    });
+  }
 });
 
 // Listen for responses from background script and forward to web app
@@ -175,6 +190,20 @@ browser.runtime.onMessage.addListener((message) => {
       {
         type: PENDING_ADDON_TOKEN_RESPONSE,
         tokenSet: message.tokenSet,
+      },
+      window.location.origin
+    );
+  }
+
+  // ----- Add-on to Web: telemetry pref value / runtime change (issue #952) -----
+  if (
+    message.type === TELEMETRY_STATE_RESPONSE ||
+    message.type === TELEMETRY_STATE_CHANGED
+  ) {
+    window.postMessage(
+      {
+        type: message.type,
+        enabled: message.enabled,
       },
       window.location.origin
     );

--- a/packages/addon/src/background.ts
+++ b/packages/addon/src/background.ts
@@ -797,6 +797,17 @@ function initAccountHubListener() {
 // watch it here and push changes through the token-bridge so telemetry can
 // start/stop at runtime without a reload.
 function initTelemetryListener() {
+  // The Telemetry experiment API may be unavailable in some builds/contexts.
+  // Degrade gracefully (runtime pref-change broadcast is simply disabled)
+  // instead of throwing and aborting the rest of background initialization.
+  if (!browser.Telemetry?.onChanged?.addListener) {
+    console.warn(
+      '[Telemetry] browser.Telemetry.onChanged unavailable; ' +
+        'runtime telemetry pref-change broadcast disabled.'
+    );
+    return;
+  }
+
   browser.Telemetry.onChanged.addListener(async (enabled) => {
     const tabs = await browser.tabs.query({});
     tabs.forEach((tab) => {

--- a/packages/addon/src/background.ts
+++ b/packages/addon/src/background.ts
@@ -18,6 +18,7 @@ import {
   FORCE_CLOSE_WINDOW,
   GET_LOGIN_STATE,
   GET_PENDING_ADDON_TOKEN,
+  GET_TELEMETRY_STATE,
   LOGIN_STATE_RESPONSE,
   OIDC_TOKEN,
   OIDC_USER,
@@ -31,6 +32,8 @@ import {
   SIGN_IN_COMPLETE,
   SIGN_OUT,
   STORAGE_KEY_AUTH,
+  TELEMETRY_STATE_CHANGED,
+  TELEMETRY_STATE_RESPONSE,
 } from '@send-frontend/lib/const';
 
 import init from '@send-frontend/lib/init';
@@ -447,6 +450,28 @@ browser.runtime.onMessage.addListener(async (message, sender) => {
       break;
     }
 
+    case GET_TELEMETRY_STATE: {
+      // The hosted Send dashboard (send.js) runs as a web page and cannot call
+      // the browser.Telemetry experiment API directly, so it requests the
+      // Thunderbird telemetry pref here via the token-bridge (issue #952).
+      // getUploadEnabled() already fails closed to false on error.
+      let enabled = false;
+      try {
+        enabled = await browser.Telemetry.getUploadEnabled();
+      } catch (e) {
+        console.warn('[onMessage] Failed to read telemetry pref:', e);
+      }
+      if (sender?.tab?.id) {
+        browser.tabs
+          .sendMessage(sender.tab.id, {
+            type: TELEMETRY_STATE_RESPONSE,
+            enabled,
+          })
+          .catch(() => {});
+      }
+      break;
+    }
+
     // ----- Add-On to Web — Step 6: Read staged token and respond to tab -----
     // The /addon-auth page (running as a normal web tab) cannot call
     // browser.storage.local directly. It sends GET_PENDING_ADDON_TOKEN via
@@ -765,6 +790,30 @@ function initAccountHubListener() {
   });
 }
 
+// ==============================================
+// Broadcast Thunderbird telemetry pref changes to hosted Send pages (issue
+// #952). The dashboard (send.js) runs as a web page without the
+// browser.Telemetry experiment API, so it can't observe the pref itself. We
+// watch it here and push changes through the token-bridge so telemetry can
+// start/stop at runtime without a reload.
+function initTelemetryListener() {
+  browser.Telemetry.onChanged.addListener(async (enabled) => {
+    const tabs = await browser.tabs.query({});
+    tabs.forEach((tab) => {
+      if (tab.id) {
+        browser.tabs
+          .sendMessage(tab.id, {
+            type: TELEMETRY_STATE_CHANGED,
+            enabled,
+          })
+          .catch(() => {
+            // Ignore tabs that can't receive messages.
+          });
+      }
+    });
+  });
+}
+
 (async function main() {
   await checkAndUninstallIfDeprecated();
   initMenu();
@@ -790,6 +839,7 @@ function initAccountHubListener() {
   }
   initStorageWatcher();
   initAccountHubListener();
+  initTelemetryListener();
 })().catch((error) => {
   console.error('Error initializing background.js', error);
 });

--- a/packages/addon/src/background.ts
+++ b/packages/addon/src/background.ts
@@ -452,24 +452,26 @@ browser.runtime.onMessage.addListener(async (message, sender) => {
 
     case GET_TELEMETRY_STATE: {
       // The hosted Send dashboard (send.js) runs as a web page and cannot call
-      // the browser.Telemetry experiment API directly, so it requests the
-      // Thunderbird telemetry pref here via the token-bridge (issue #952).
-      // getUploadEnabled() already fails closed to false on error.
+      // the browser.thundermailTelemetry experiment API directly, so it
+      // requests the telemetry state here via the token-bridge (issue #952).
+      //
+      // The token-bridge content script is injected on <all_urls>, so only
+      // answer requests originating from our own Send tabs — don't hand the
+      // state to arbitrary web pages that happen to post the same message.
+      if (!sender?.tab?.url?.startsWith(BASE_URL)) {
+        break;
+      }
+      // isTelemetryEnabled() already fails closed to false on error. Return the
+      // value so the requesting content script gets it as the sendMessage
+      // response (no separate broadcast needed — the reply reaches only the
+      // caller's tab).
       let enabled = false;
       try {
-        enabled = await browser.Telemetry.getUploadEnabled();
+        enabled = await browser.thundermailTelemetry.isTelemetryEnabled();
       } catch (e) {
-        console.warn('[onMessage] Failed to read telemetry pref:', e);
+        console.warn('[onMessage] Failed to read telemetry state:', e);
       }
-      if (sender?.tab?.id) {
-        browser.tabs
-          .sendMessage(sender.tab.id, {
-            type: TELEMETRY_STATE_RESPONSE,
-            enabled,
-          })
-          .catch(() => {});
-      }
-      break;
+      return { type: TELEMETRY_STATE_RESPONSE, enabled };
     }
 
     // ----- Add-On to Web — Step 6: Read staged token and respond to tab -----
@@ -793,25 +795,28 @@ function initAccountHubListener() {
 // ==============================================
 // Broadcast Thunderbird telemetry pref changes to hosted Send pages (issue
 // #952). The dashboard (send.js) runs as a web page without the
-// browser.Telemetry experiment API, so it can't observe the pref itself. We
+// browser.thundermailTelemetry experiment API, so it can't observe the pref itself. We
 // watch it here and push changes through the token-bridge so telemetry can
 // start/stop at runtime without a reload.
 function initTelemetryListener() {
-  // The Telemetry experiment API may be unavailable in some builds/contexts.
-  // Degrade gracefully (runtime pref-change broadcast is simply disabled)
-  // instead of throwing and aborting the rest of background initialization.
-  if (!browser.Telemetry?.onChanged?.addListener) {
+  // The experiment API may be unavailable in some builds/contexts. Degrade
+  // gracefully (runtime pref-change broadcast is simply disabled) instead of
+  // throwing and aborting the rest of background initialization.
+  if (!browser.thundermailTelemetry?.onChanged?.addListener) {
     console.warn(
-      '[Telemetry] browser.Telemetry.onChanged unavailable; ' +
+      '[Telemetry] browser.thundermailTelemetry.onChanged unavailable; ' +
         'runtime telemetry pref-change broadcast disabled.'
     );
     return;
   }
 
-  browser.Telemetry.onChanged.addListener(async (enabled) => {
+  browser.thundermailTelemetry.onChanged.addListener(async (enabled) => {
+    // Only notify our own Send dashboard tabs — the token-bridge is injected on
+    // <all_urls>, so broadcasting to every tab would leak the change to
+    // unrelated web pages.
     const tabs = await browser.tabs.query({});
     tabs.forEach((tab) => {
-      if (tab.id) {
+      if (tab.id && tab.url?.startsWith(BASE_URL)) {
         browser.tabs
           .sendMessage(tab.id, {
             type: TELEMETRY_STATE_CHANGED,

--- a/packages/addon/src/env.d.ts
+++ b/packages/addon/src/env.d.ts
@@ -192,4 +192,28 @@ declare namespace browser {
      */
     function unregisterProvider(): Promise<ProviderRegistrationResult>;
   }
+
+  /**
+   * Experiment API exposing Thunderbird's telemetry opt-out preference
+   * (datareporting.healthreport.uploadEnabled) so the add-on can gate Sentry
+   * and PostHog on it. Reads fail closed (return false) when the pref cannot be
+   * read.
+   */
+  namespace Telemetry {
+    /**
+     * Returns the current value of the Thunderbird telemetry upload preference.
+     * Resolves to false (opted out) if the preference cannot be read.
+     */
+    function getUploadEnabled(): Promise<boolean>;
+
+    /** Fires when the telemetry upload preference changes, with the new value. */
+    const onChanged: {
+      addListener(
+        callback: (uploadEnabled: boolean) => Promise<void> | void
+      ): void;
+      removeListener(
+        callback: (uploadEnabled: boolean) => Promise<void> | void
+      ): void;
+    };
+  }
 }

--- a/packages/addon/src/env.d.ts
+++ b/packages/addon/src/env.d.ts
@@ -194,25 +194,26 @@ declare namespace browser {
   }
 
   /**
-   * Experiment API exposing Thunderbird's telemetry opt-out preference
-   * (datareporting.healthreport.uploadEnabled) so the add-on can gate Sentry
-   * and PostHog on it. Reads fail closed (return false) when the pref cannot be
-   * read.
+   * Experiment API exposing whether Thunderbird telemetry is enabled so the
+   * add-on can gate Sentry and PostHog on it. Telemetry is enabled only when
+   * both datareporting.policy.dataSubmissionEnabled and
+   * datareporting.healthreport.uploadEnabled are true. Reads fail closed
+   * (return false) when the state cannot be read.
    */
-  namespace Telemetry {
+  namespace thundermailTelemetry {
     /**
-     * Returns the current value of the Thunderbird telemetry upload preference.
-     * Resolves to false (opted out) if the preference cannot be read.
+     * Returns whether Thunderbird telemetry is currently enabled. Resolves to
+     * false (opted out) if the state cannot be read.
      */
-    function getUploadEnabled(): Promise<boolean>;
+    function isTelemetryEnabled(): Promise<boolean>;
 
-    /** Fires when the telemetry upload preference changes, with the new value. */
+    /** Fires when the effective telemetry state changes, with the new value. */
     const onChanged: {
       addListener(
-        callback: (uploadEnabled: boolean) => Promise<void> | void
+        callback: (enabled: boolean) => Promise<void> | void
       ): void;
       removeListener(
-        callback: (uploadEnabled: boolean) => Promise<void> | void
+        callback: (enabled: boolean) => Promise<void> | void
       ): void;
     };
   }

--- a/packages/send/docs/TelemetryOptOut.md
+++ b/packages/send/docs/TelemetryOptOut.md
@@ -1,206 +1,95 @@
 # Telemetry Opt-Out (Sentry & PostHog)
 
-Status: **Implemented (frontend) — pending manual in-Thunderbird verification**
 Tracking issue: [thunderbird/tbpro-add-on#892](https://github.com/thunderbird/tbpro-add-on/issues/892)
-Branch: `worktree-telemetry-optout-892`
 
-This note documents how the TB Pro add-on honors Thunderbird's telemetry
-opt-out setting for Sentry and PostHog, so follow-up work (backend, privacy
-policy, subprocessor disclosure) can build on it.
+How the TB Pro add-on honors Thunderbird's telemetry opt-out for Sentry and
+PostHog.
 
-## Objective
+## Behavior
 
-When the Thunderbird telemetry preference is disabled, the add-on must send
-**zero** events to Sentry or PostHog — no errors, traces, session replays,
-console capture, analytics, feature-flag (`/decide`) calls, `$pageview`, or
-`identify`. The gate must:
+When Thunderbird telemetry is disabled, the add-on sends **zero** events to
+Sentry or PostHog (no errors, traces, session replays, console capture,
+analytics, `/decide`, `$pageview`, or `identify`). The gate:
 
-- Read the Thunderbird pref `datareporting.healthreport.uploadEnabled` via the
-  existing experiment-API pattern (`Services.prefs`).
-- React to the pref changing at runtime (no reinstall/reload required).
-- **Fail closed**: send nothing if the pref cannot be read.
+- Considers telemetry enabled only when **both** Thunderbird prefs are on —
+  `datareporting.policy.dataSubmissionEnabled` (master switch) and
+  `datareporting.healthreport.uploadEnabled` (upload opt-in).
+- Reacts to those prefs changing at runtime (no reload required).
+- **Fails closed**: sends nothing if the state cannot be read.
 
-## Scope (decided on #892)
-
-- **Contexts:** Gate telemetry whenever running *inside Thunderbird*
-  (`navigator.userAgent` contains `Thunderbird`). The public website (outside
-  Thunderbird) keeps its existing telemetry behavior.
-- **Backend:** Out of scope here — the server cannot read a per-user TB pref.
-  Tracked as follow-up.
-- **Privacy:** This change ships the gate **and** hardens Sentry (drops session
-  replay, scrubs PII). Privacy-policy text and the subprocessor list are
-  separate documentation follow-ups.
+The public website (outside Thunderbird, detected via `navigator.userAgent`)
+keeps its existing telemetry behavior. Backend telemetry is out of scope — the
+server can't read a per-user TB pref (tracked as a #892 follow-up, alongside
+privacy-policy and subprocessor disclosure).
 
 ## How it works
 
-### Runtime contexts
+The Send frontend runs in two kinds of context inside Thunderbird:
 
-The Send Vue frontend (`packages/send/frontend`) builds three HTML entry points
-that run in different contexts:
+- **Add-on (moz-extension) pages** (`extension.js`, `management.js`) can call
+  experiment APIs directly, so they read the state from
+  `browser.thundermailTelemetry`.
+- **The hosted Send dashboard** (`send.js`) opens as a regular web tab and has
+  no experiment API, so it asks the background script over the existing
+  `token-bridge.js` content-script relay (issue #952).
 
-| Entry | Context | `browser.*` / experiment APIs |
-|---|---|---|
-| `index.extension.html` → `extension.js` | moz-extension page in the add-on | **Yes** (direct) |
-| `index.management.html` → `management.js` | moz-extension page in the add-on | **Yes** (direct) |
-| `index.html` → `send.js` | public website / web-app-inside-TB | No — uses the token-bridge inside TB (issue #952) |
+### Experiment API — `browser.thundermailTelemetry`
 
-Add-on (moz-extension) pages can call experiment APIs directly — proven by
-`extension-store.ts` already calling `browser.CloudFileAccounts.*`. So on those
-pages the frontend reads the pref straight from the API.
+`packages/addon/public/api/Telemetry/` (registered in `manifest.json`, typed in
+`packages/addon/src/env.d.ts`):
 
-The **hosted Send dashboard** (`send.js`) is opened inside Thunderbird as a
-regular web tab (`menuManageSend()` → `${BASE_URL}/send/profile`), so it has no
-experiment API. It obtains the pref from the background script over the existing
-`token-bridge.js` content-script relay (issue #952) — see "Telemetry pref
-bridge" below.
+- `isTelemetryEnabled(): Promise<boolean>` — true only when both data-reporting
+  prefs are on; fails closed to `false`.
+- `onChanged` — fires the new effective state when either pref changes.
 
-### 1. Experiment API — `browser.Telemetry`
+### Frontend consent gate
 
-`packages/addon/public/api/Telemetry/`
-- `getUploadEnabled(): Promise<boolean>` — `Services.prefs.getBoolPref('datareporting.healthreport.uploadEnabled', false)`, wrapped in try/catch returning `false` (fail closed).
-- `onChanged` — `ExtensionCommon.EventManager` registering a `Services.prefs.addObserver` on the pref; fires the new boolean; cleanup removes the observer.
+`packages/send/frontend/src/lib/telemetryConsent.ts`:
 
-Registered in `packages/addon/public/manifest.json` (`experiment_apis.Telemetry`,
-scope `addon_parent`); typed in `packages/addon/src/env.d.ts`
-(`declare namespace browser { namespace Telemetry { … } }`).
+- `isTelemetryAllowed()` — outside TB → `true`; on an add-on page → reads
+  `browser.thundermailTelemetry`; on the dashboard → asks over the token-bridge
+  with a 2s fail-closed timeout.
+- `onTelemetryChanged(cb)` — subscribes to runtime changes (direct API or
+  bridged messages); no-op on the public website.
 
-### 2. Frontend consent gate
+### Telemetry bridge (hosted dashboard — issue #952)
 
-`packages/send/frontend/src/lib/telemetryConsent.ts`
-- `isTelemetryAllowed(): Promise<boolean>` — outside TB → `true` (website
-  unchanged); inside TB → reads the pref via `browser.Telemetry`; inside TB but
-  API unavailable or throwing → `false` (fail closed).
-- `onTelemetryChanged(cb)` — subscribes to `browser.Telemetry.onChanged`;
-  returns an unsubscribe fn (no-op when the API is absent).
-
-`browser.Telemetry` is a custom experiment API unknown to
-`@types/firefox-webext-browser`, so the helper accesses it via `// @ts-ignore`
-(same as `extension-store.ts`).
-
-On the hosted dashboard (no direct API), `isTelemetryAllowed()` falls back to
-the token-bridge and `onTelemetryChanged()` subscribes to bridged pref-change
-messages — both fail closed / no-op when the bridge is absent.
-
-### 2a. Telemetry pref bridge (hosted dashboard — issue #952)
-
-The dashboard (`send.js`) can't call `browser.Telemetry`, so it asks the
-background script over the existing `token-bridge.js` content-script relay
-(the same pattern as `GET_LOGIN_STATE` / `LOGIN_STATE_RESPONSE`). Message types
-(defined in `packages/send/frontend/src/lib/const.ts`):
-
-- `GET_TELEMETRY_STATE` — web page → bridge → background ("what's the pref?")
-- `TELEMETRY_STATE_RESPONSE` — background → bridge → web page (`{ enabled }`)
-- `TELEMETRY_STATE_CHANGED` — background → bridge → web page (runtime change)
-
-Flow:
-- `packages/addon/src/background.ts` handles `GET_TELEMETRY_STATE` by calling
-  `browser.Telemetry.getUploadEnabled()` and replying `TELEMETRY_STATE_RESPONSE`
-  to the requesting tab; `initTelemetryListener()` registers
-  `browser.Telemetry.onChanged` and broadcasts `TELEMETRY_STATE_CHANGED` to all
-  tabs so telemetry starts/stops without a reload.
-- `packages/addon/public/token-bridge.js` relays these three types between
-  `window.postMessage` and `browser.runtime.sendMessage`.
-- `telemetryConsent.ts` posts `GET_TELEMETRY_STATE` and awaits the response with
-  a 2s timeout (fail closed), and listens for `TELEMETRY_STATE_CHANGED`.
+`background.ts` answers `GET_TELEMETRY_STATE` (only for our own Send tabs) with
+the state as the `sendMessage` response, and broadcasts `TELEMETRY_STATE_CHANGED`
+to Send tabs when the prefs change. `token-bridge.js` relays both between
+`window.postMessage` and `browser.runtime.sendMessage`. Message types live in
+`packages/send/frontend/src/lib/const.ts`.
 
 > Related: #953 tracks hardening the `token-bridge.js` relay (validate
-> `event.origin`/`event.source`); it touches the same file.
+> `event.origin`/`event.source`).
 
-### 3. Sentry gating + hardening
+### Sentry & PostHog
 
-`packages/send/frontend/src/lib/sentry.ts`
-- `initSentry(app)` only runs when consent is granted; idempotent via an
-  `initialized` flag + `Sentry.getClient()` check.
-- **Hardening:** session replay integration removed (biggest PII risk);
-  `sendDefaultPii: false`; `beforeSend` strips `event.user` and request
-  cookies/headers/query/data.
-- `closeSentry()` tears down the client on runtime opt-out (safe if not init).
-
-### 4. PostHog gating
-
-`packages/send/frontend/src/plugins/posthog.js`
-- `posthog.init()` is **deferred** until first opt-in (`setPosthogConsent(true)`),
-  so while opted out PostHog is never initialized and makes zero network
-  requests. `capture()`/`identify()` on the shared instance before init are
-  no-ops, so the many `useMetricsStore` callers remain safe.
-- `setPosthogConsent(enabled)` — opt-in (init + `opt_in_capturing`) / opt-out
-  (`opt_out_capturing` + `reset`) at runtime.
-- The default export still exposes `.rest` (the posthog singleton) — unchanged
-  for existing importers like `stores/metrics.ts`.
-
-### 5. Entry wiring
-
-`apps/send/{extension,send,management}.js` — each wraps bootstrap in an async
-IIFE (top-level `await` is avoided because Vite's default build target predates
-TLA support):
-
-```js
-const telemetryAllowed = await isTelemetryAllowed();
-if (telemetryAllowed) initSentry(app);
-app.use(router);
-setupApp(app, telemetryAllowed); // installs posthog plugin + setPosthogConsent
-mountApp(app, '#…');
-onTelemetryChanged((enabled) => {
-  setPosthogConsent(enabled);
-  enabled ? initSentry(app) : closeSentry();
-});
-```
-
-`setupApp(app, telemetryAllowed)` (in `apps/send/setup.js`) applies the initial
-PostHog consent.
-
-## Files touched
-
-- New: `packages/addon/public/api/Telemetry/{schema.json,implementation.js}`
-- New: `packages/send/frontend/src/lib/telemetryConsent.ts` (+ `.test.ts`)
-- Edit: `packages/addon/public/manifest.json`, `packages/addon/src/env.d.ts`
-- Edit: `packages/send/frontend/src/lib/sentry.ts`
-- Edit: `packages/send/frontend/src/plugins/posthog.js`
-- Edit: `packages/send/frontend/src/apps/send/{setup.js,extension.js,send.js,management.js}`
+- `sentry.ts` — `initSentry(app)` runs only with consent; session replay removed,
+  `sendDefaultPii: false`, `beforeSend` scrubs identity and request payloads.
+  `closeSentry()` tears down on runtime opt-out.
+- `posthog.js` — `init()` is deferred until first opt-in; `setPosthogConsent()`
+  opts in/out at runtime.
 
 ## Verification
 
-### Automated (done)
-- `npx tsc --noEmit` — clean
-- ESLint on touched files — clean
-- `vite build --config vite.config.extension.js` — succeeds
-- `vitest run` — full suite green; `telemetryConsent.test.ts` covers
-  website-allowed, pref-on, pref-off, API-missing (fail closed), and
-  read-throws (fail closed).
+### Automated
+`tsc --noEmit`, ESLint (touched files), and `vitest` (`telemetryConsent.test.ts`
+covers website-allowed, pref on/off, bridge on/off, and fail-closed) are green.
 
-> Note for agents running tests in a fresh worktree: copy the gitignored
-> `.env` and `.env.secret` into `packages/send/frontend/` first (and ensure
-> `node_modules` is available), or many unrelated tests fail on undefined env
-> vars.
+> Running tests in a fresh worktree: copy the gitignored `.env` and `.env.secret`
+> into `packages/send/frontend/` first (and ensure `node_modules` is available),
+> or unrelated tests fail on undefined env vars.
 
-### Manual (still required — cannot run headless)
+### Manual (required — cannot run headless)
 
-Temp-load the built add-on in Thunderbird Daily (see the repo's local debug
-workflow) and use DevTools → Network:
+Temp-load the add-on in Thunderbird Daily (see the repo's local debug workflow)
+and use DevTools → Network, for **both** the popup and the dashboard tab:
 
-1. **Pref ON** (`datareporting.healthreport.uploadEnabled = true` via
-   `about:config` or Settings → Privacy): exercise the Send UI → confirm
-   requests to Sentry (`*.ingest.sentry.io`) and PostHog
-   (`*.i.posthog.com` / configured host) occur.
-2. **Pref OFF:** reload the add-on page → confirm **zero** requests to those
-   hosts (no events, traces, replay, console capture, `/decide`, `$pageview`,
-   `identify`).
-3. **Runtime change:** with the page open, toggle the pref → telemetry stops
-   (opt-out) / resumes (opt-in) without reload (exercises `onChanged` +
-   `closeSentry()` / `posthog.opt_out_capturing()`).
-4. **Fail-closed:** simulate the experiment API being unavailable inside TB →
-   no telemetry.
-5. **Website unaffected:** load `index.html` outside TB → telemetry as before.
-
-## Follow-up work (separate issues)
-
-- **Backend opt-out** — server-side Sentry/PostHog cannot read a per-user TB
-  pref. Options: forward an opt-out signal from the frontend (e.g. a request
-  header) so backend PostHog `identify`/`capture` honors it, and decide on
-  backend Sentry. Backend telemetry init lives in `packages/send/backend/src/sentry.ts`
-  and `packages/send/backend/src/metrics/posthog.ts`.
-- **Privacy policy** — update to reflect Sentry + PostHog usage.
-- **Subprocessor list** — document/disclose Sentry and PostHog.
-- **Fallback** — if this could not have shipped by ~2026-07-17, the interim
-  measure was to disable Sentry outright (a single guard in `initSentry`). Not
-  needed once this lands.
+1. **Pref ON** (both prefs true): exercise the Send UI → requests to
+   `*.ingest.sentry.io` and PostHog occur.
+2. **Pref OFF:** reload → **zero** requests to those hosts.
+3. **Runtime toggle:** with the page open, flip a pref → telemetry stops/resumes
+   without reload.
+4. **Fail-closed:** API/bridge unavailable inside TB → no telemetry.
+5. **Website unaffected:** load outside TB → telemetry as before.

--- a/packages/send/docs/TelemetryOptOut.md
+++ b/packages/send/docs/TelemetryOptOut.md
@@ -1,0 +1,206 @@
+# Telemetry Opt-Out (Sentry & PostHog)
+
+Status: **Implemented (frontend) — pending manual in-Thunderbird verification**
+Tracking issue: [thunderbird/tbpro-add-on#892](https://github.com/thunderbird/tbpro-add-on/issues/892)
+Branch: `worktree-telemetry-optout-892`
+
+This note documents how the TB Pro add-on honors Thunderbird's telemetry
+opt-out setting for Sentry and PostHog, so follow-up work (backend, privacy
+policy, subprocessor disclosure) can build on it.
+
+## Objective
+
+When the Thunderbird telemetry preference is disabled, the add-on must send
+**zero** events to Sentry or PostHog — no errors, traces, session replays,
+console capture, analytics, feature-flag (`/decide`) calls, `$pageview`, or
+`identify`. The gate must:
+
+- Read the Thunderbird pref `datareporting.healthreport.uploadEnabled` via the
+  existing experiment-API pattern (`Services.prefs`).
+- React to the pref changing at runtime (no reinstall/reload required).
+- **Fail closed**: send nothing if the pref cannot be read.
+
+## Scope (decided on #892)
+
+- **Contexts:** Gate telemetry whenever running *inside Thunderbird*
+  (`navigator.userAgent` contains `Thunderbird`). The public website (outside
+  Thunderbird) keeps its existing telemetry behavior.
+- **Backend:** Out of scope here — the server cannot read a per-user TB pref.
+  Tracked as follow-up.
+- **Privacy:** This change ships the gate **and** hardens Sentry (drops session
+  replay, scrubs PII). Privacy-policy text and the subprocessor list are
+  separate documentation follow-ups.
+
+## How it works
+
+### Runtime contexts
+
+The Send Vue frontend (`packages/send/frontend`) builds three HTML entry points
+that run in different contexts:
+
+| Entry | Context | `browser.*` / experiment APIs |
+|---|---|---|
+| `index.extension.html` → `extension.js` | moz-extension page in the add-on | **Yes** (direct) |
+| `index.management.html` → `management.js` | moz-extension page in the add-on | **Yes** (direct) |
+| `index.html` → `send.js` | public website / web-app-inside-TB | No — uses the token-bridge inside TB (issue #952) |
+
+Add-on (moz-extension) pages can call experiment APIs directly — proven by
+`extension-store.ts` already calling `browser.CloudFileAccounts.*`. So on those
+pages the frontend reads the pref straight from the API.
+
+The **hosted Send dashboard** (`send.js`) is opened inside Thunderbird as a
+regular web tab (`menuManageSend()` → `${BASE_URL}/send/profile`), so it has no
+experiment API. It obtains the pref from the background script over the existing
+`token-bridge.js` content-script relay (issue #952) — see "Telemetry pref
+bridge" below.
+
+### 1. Experiment API — `browser.Telemetry`
+
+`packages/addon/public/api/Telemetry/`
+- `getUploadEnabled(): Promise<boolean>` — `Services.prefs.getBoolPref('datareporting.healthreport.uploadEnabled', false)`, wrapped in try/catch returning `false` (fail closed).
+- `onChanged` — `ExtensionCommon.EventManager` registering a `Services.prefs.addObserver` on the pref; fires the new boolean; cleanup removes the observer.
+
+Registered in `packages/addon/public/manifest.json` (`experiment_apis.Telemetry`,
+scope `addon_parent`); typed in `packages/addon/src/env.d.ts`
+(`declare namespace browser { namespace Telemetry { … } }`).
+
+### 2. Frontend consent gate
+
+`packages/send/frontend/src/lib/telemetryConsent.ts`
+- `isTelemetryAllowed(): Promise<boolean>` — outside TB → `true` (website
+  unchanged); inside TB → reads the pref via `browser.Telemetry`; inside TB but
+  API unavailable or throwing → `false` (fail closed).
+- `onTelemetryChanged(cb)` — subscribes to `browser.Telemetry.onChanged`;
+  returns an unsubscribe fn (no-op when the API is absent).
+
+`browser.Telemetry` is a custom experiment API unknown to
+`@types/firefox-webext-browser`, so the helper accesses it via `// @ts-ignore`
+(same as `extension-store.ts`).
+
+On the hosted dashboard (no direct API), `isTelemetryAllowed()` falls back to
+the token-bridge and `onTelemetryChanged()` subscribes to bridged pref-change
+messages — both fail closed / no-op when the bridge is absent.
+
+### 2a. Telemetry pref bridge (hosted dashboard — issue #952)
+
+The dashboard (`send.js`) can't call `browser.Telemetry`, so it asks the
+background script over the existing `token-bridge.js` content-script relay
+(the same pattern as `GET_LOGIN_STATE` / `LOGIN_STATE_RESPONSE`). Message types
+(defined in `packages/send/frontend/src/lib/const.ts`):
+
+- `GET_TELEMETRY_STATE` — web page → bridge → background ("what's the pref?")
+- `TELEMETRY_STATE_RESPONSE` — background → bridge → web page (`{ enabled }`)
+- `TELEMETRY_STATE_CHANGED` — background → bridge → web page (runtime change)
+
+Flow:
+- `packages/addon/src/background.ts` handles `GET_TELEMETRY_STATE` by calling
+  `browser.Telemetry.getUploadEnabled()` and replying `TELEMETRY_STATE_RESPONSE`
+  to the requesting tab; `initTelemetryListener()` registers
+  `browser.Telemetry.onChanged` and broadcasts `TELEMETRY_STATE_CHANGED` to all
+  tabs so telemetry starts/stops without a reload.
+- `packages/addon/public/token-bridge.js` relays these three types between
+  `window.postMessage` and `browser.runtime.sendMessage`.
+- `telemetryConsent.ts` posts `GET_TELEMETRY_STATE` and awaits the response with
+  a 2s timeout (fail closed), and listens for `TELEMETRY_STATE_CHANGED`.
+
+> Related: #953 tracks hardening the `token-bridge.js` relay (validate
+> `event.origin`/`event.source`); it touches the same file.
+
+### 3. Sentry gating + hardening
+
+`packages/send/frontend/src/lib/sentry.ts`
+- `initSentry(app)` only runs when consent is granted; idempotent via an
+  `initialized` flag + `Sentry.getClient()` check.
+- **Hardening:** session replay integration removed (biggest PII risk);
+  `sendDefaultPii: false`; `beforeSend` strips `event.user` and request
+  cookies/headers/query/data.
+- `closeSentry()` tears down the client on runtime opt-out (safe if not init).
+
+### 4. PostHog gating
+
+`packages/send/frontend/src/plugins/posthog.js`
+- `posthog.init()` is **deferred** until first opt-in (`setPosthogConsent(true)`),
+  so while opted out PostHog is never initialized and makes zero network
+  requests. `capture()`/`identify()` on the shared instance before init are
+  no-ops, so the many `useMetricsStore` callers remain safe.
+- `setPosthogConsent(enabled)` — opt-in (init + `opt_in_capturing`) / opt-out
+  (`opt_out_capturing` + `reset`) at runtime.
+- The default export still exposes `.rest` (the posthog singleton) — unchanged
+  for existing importers like `stores/metrics.ts`.
+
+### 5. Entry wiring
+
+`apps/send/{extension,send,management}.js` — each wraps bootstrap in an async
+IIFE (top-level `await` is avoided because Vite's default build target predates
+TLA support):
+
+```js
+const telemetryAllowed = await isTelemetryAllowed();
+if (telemetryAllowed) initSentry(app);
+app.use(router);
+setupApp(app, telemetryAllowed); // installs posthog plugin + setPosthogConsent
+mountApp(app, '#…');
+onTelemetryChanged((enabled) => {
+  setPosthogConsent(enabled);
+  enabled ? initSentry(app) : closeSentry();
+});
+```
+
+`setupApp(app, telemetryAllowed)` (in `apps/send/setup.js`) applies the initial
+PostHog consent.
+
+## Files touched
+
+- New: `packages/addon/public/api/Telemetry/{schema.json,implementation.js}`
+- New: `packages/send/frontend/src/lib/telemetryConsent.ts` (+ `.test.ts`)
+- Edit: `packages/addon/public/manifest.json`, `packages/addon/src/env.d.ts`
+- Edit: `packages/send/frontend/src/lib/sentry.ts`
+- Edit: `packages/send/frontend/src/plugins/posthog.js`
+- Edit: `packages/send/frontend/src/apps/send/{setup.js,extension.js,send.js,management.js}`
+
+## Verification
+
+### Automated (done)
+- `npx tsc --noEmit` — clean
+- ESLint on touched files — clean
+- `vite build --config vite.config.extension.js` — succeeds
+- `vitest run` — full suite green; `telemetryConsent.test.ts` covers
+  website-allowed, pref-on, pref-off, API-missing (fail closed), and
+  read-throws (fail closed).
+
+> Note for agents running tests in a fresh worktree: copy the gitignored
+> `.env` and `.env.secret` into `packages/send/frontend/` first (and ensure
+> `node_modules` is available), or many unrelated tests fail on undefined env
+> vars.
+
+### Manual (still required — cannot run headless)
+
+Temp-load the built add-on in Thunderbird Daily (see the repo's local debug
+workflow) and use DevTools → Network:
+
+1. **Pref ON** (`datareporting.healthreport.uploadEnabled = true` via
+   `about:config` or Settings → Privacy): exercise the Send UI → confirm
+   requests to Sentry (`*.ingest.sentry.io`) and PostHog
+   (`*.i.posthog.com` / configured host) occur.
+2. **Pref OFF:** reload the add-on page → confirm **zero** requests to those
+   hosts (no events, traces, replay, console capture, `/decide`, `$pageview`,
+   `identify`).
+3. **Runtime change:** with the page open, toggle the pref → telemetry stops
+   (opt-out) / resumes (opt-in) without reload (exercises `onChanged` +
+   `closeSentry()` / `posthog.opt_out_capturing()`).
+4. **Fail-closed:** simulate the experiment API being unavailable inside TB →
+   no telemetry.
+5. **Website unaffected:** load `index.html` outside TB → telemetry as before.
+
+## Follow-up work (separate issues)
+
+- **Backend opt-out** — server-side Sentry/PostHog cannot read a per-user TB
+  pref. Options: forward an opt-out signal from the frontend (e.g. a request
+  header) so backend PostHog `identify`/`capture` honors it, and decide on
+  backend Sentry. Backend telemetry init lives in `packages/send/backend/src/sentry.ts`
+  and `packages/send/backend/src/metrics/posthog.ts`.
+- **Privacy policy** — update to reflect Sentry + PostHog usage.
+- **Subprocessor list** — document/disclose Sentry and PostHog.
+- **Fallback** — if this could not have shipped by ~2026-07-17, the interim
+  measure was to disable Sentry outright (a single guard in `initSentry`). Not
+  needed once this lands.

--- a/packages/send/frontend/src/apps/send/extension.js
+++ b/packages/send/frontend/src/apps/send/extension.js
@@ -1,4 +1,9 @@
-import { initSentry } from '@send-frontend/lib/sentry';
+import { closeSentry, initSentry } from '@send-frontend/lib/sentry';
+import {
+  isTelemetryAllowed,
+  onTelemetryChanged,
+} from '@send-frontend/lib/telemetryConsent';
+import { setPosthogConsent } from '@send-frontend/plugins/posthog';
 import { createApp } from 'vue';
 import Extension from './ExtensionPage.vue';
 import router from './router';
@@ -6,7 +11,24 @@ import { mountApp, setupApp } from './setup';
 
 const app = createApp(Extension);
 
-initSentry(app);
-app.use(router);
-setupApp(app);
-mountApp(app, '#extension-page');
+// Resolve the Thunderbird telemetry opt-out before initializing any telemetry,
+// so nothing is sent when the user has opted out. See issue #892.
+(async () => {
+  const telemetryAllowed = await isTelemetryAllowed();
+  if (telemetryAllowed) {
+    initSentry(app);
+  }
+  app.use(router);
+  setupApp(app, telemetryAllowed);
+  mountApp(app, '#extension-page');
+
+  // React to runtime pref changes without requiring a reinstall/reload.
+  onTelemetryChanged((enabled) => {
+    setPosthogConsent(enabled);
+    if (enabled) {
+      initSentry(app);
+    } else {
+      closeSentry();
+    }
+  });
+})();

--- a/packages/send/frontend/src/apps/send/management.js
+++ b/packages/send/frontend/src/apps/send/management.js
@@ -1,4 +1,9 @@
-import { initSentry } from '@send-frontend/lib/sentry';
+import { closeSentry, initSentry } from '@send-frontend/lib/sentry';
+import {
+  isTelemetryAllowed,
+  onTelemetryChanged,
+} from '@send-frontend/lib/telemetryConsent';
+import { setPosthogConsent } from '@send-frontend/plugins/posthog';
 import { createApp } from 'vue';
 import ManagementPage from './ManagementPage.vue';
 import router from './router';
@@ -6,7 +11,24 @@ import { mountApp, setupApp } from './setup';
 
 const app = createApp(ManagementPage);
 
-initSentry(app);
-app.use(router);
-setupApp(app);
-mountApp(app, '#management-page');
+// Resolve the Thunderbird telemetry opt-out before initializing any telemetry,
+// so nothing is sent when the user has opted out. See issue #892.
+(async () => {
+  const telemetryAllowed = await isTelemetryAllowed();
+  if (telemetryAllowed) {
+    initSentry(app);
+  }
+  app.use(router);
+  setupApp(app, telemetryAllowed);
+  mountApp(app, '#management-page');
+
+  // React to runtime pref changes without requiring a reinstall/reload.
+  onTelemetryChanged((enabled) => {
+    setPosthogConsent(enabled);
+    if (enabled) {
+      initSentry(app);
+    } else {
+      closeSentry();
+    }
+  });
+})();

--- a/packages/send/frontend/src/apps/send/send.js
+++ b/packages/send/frontend/src/apps/send/send.js
@@ -1,4 +1,9 @@
-import { initSentry } from '@send-frontend/lib/sentry';
+import { closeSentry, initSentry } from '@send-frontend/lib/sentry';
+import {
+  isTelemetryAllowed,
+  onTelemetryChanged,
+} from '@send-frontend/lib/telemetryConsent';
+import { setPosthogConsent } from '@send-frontend/plugins/posthog';
 import { createApp } from 'vue';
 import Send from './SendPage.vue';
 import router from './router';
@@ -6,7 +11,25 @@ import { mountApp, setupApp } from './setup';
 
 const app = createApp(Send);
 
-initSentry(app);
-app.use(router);
-setupApp(app);
-mountApp(app, '#app');
+// Resolve the Thunderbird telemetry opt-out before initializing any telemetry,
+// so nothing is sent when the user has opted out. Outside Thunderbird this
+// resolves to allowed, preserving existing website behavior. See issue #892.
+(async () => {
+  const telemetryAllowed = await isTelemetryAllowed();
+  if (telemetryAllowed) {
+    initSentry(app);
+  }
+  app.use(router);
+  setupApp(app, telemetryAllowed);
+  mountApp(app, '#app');
+
+  // React to runtime pref changes without requiring a reinstall/reload.
+  onTelemetryChanged((enabled) => {
+    setPosthogConsent(enabled);
+    if (enabled) {
+      initSentry(app);
+    } else {
+      closeSentry();
+    }
+  });
+})();

--- a/packages/send/frontend/src/apps/send/send.telemetry.test.ts
+++ b/packages/send/frontend/src/apps/send/send.telemetry.test.ts
@@ -1,0 +1,226 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  TELEMETRY_STATE_CHANGED,
+  TELEMETRY_STATE_RESPONSE,
+  GET_TELEMETRY_STATE,
+} from '@send-frontend/lib/const';
+
+/**
+ * End-to-end gate test for the hosted Send dashboard (issue #892 / #952).
+ *
+ * The dashboard runs as a plain web page inside Thunderbird (no direct
+ * experiment API), so it learns the telemetry state over the token-bridge.
+ * This exercises the *real* send.js entry, the *real* telemetryConsent bridge
+ * path, and the *real* sentry.ts gate — only `@sentry/vue` and the heavy Vue
+ * wiring are mocked — to lock in the scenario:
+ *
+ *   pref OFF → open dashboard → Sentry never initializes (zero network calls)
+ *   pref ON  → open dashboard → Sentry initializes
+ *   runtime toggle → Sentry starts / stops without a reload
+ *
+ * The bridge→boolean half of the chain is additionally covered by
+ * telemetryConsent.test.ts; here we drive the whole entry so the wiring that
+ * connects "allowed" to initSentry/closeSentry can't silently regress.
+ */
+
+// Observable stand-in for @sentry/vue. `hasClient` mirrors the real client
+// lifecycle so sentry.ts's idempotency guard (getClient()) behaves realistically.
+const sentry = vi.hoisted(() => {
+  const state = { hasClient: false };
+  return {
+    state,
+    init: vi.fn(() => {
+      state.hasClient = true;
+    }),
+    getClient: vi.fn(() => (state.hasClient ? {} : undefined)),
+    close: vi.fn(() => {
+      state.hasClient = false;
+      return Promise.resolve(true);
+    }),
+    setTag: vi.fn(),
+    browserTracingIntegration: vi.fn(),
+    captureConsoleIntegration: vi.fn(),
+  };
+});
+
+vi.mock('@sentry/vue', () => ({
+  init: sentry.init,
+  getClient: sentry.getClient,
+  close: sentry.close,
+  setTag: sentry.setTag,
+  browserTracingIntegration: sentry.browserTracingIntegration,
+  captureConsoleIntegration: sentry.captureConsoleIntegration,
+}));
+
+// Signals the entry has finished its gate decision; called with the resolved
+// telemetry state right after the init decision.
+const wiring = vi.hoisted(() => ({
+  setupApp: vi.fn(),
+  mountApp: vi.fn(),
+  setPosthogConsent: vi.fn(),
+}));
+
+vi.mock('@send-frontend/apps/send/setup', () => ({
+  setupApp: wiring.setupApp,
+  mountApp: wiring.mountApp,
+}));
+
+vi.mock('@send-frontend/plugins/posthog', () => ({
+  default: {},
+  setPosthogConsent: wiring.setPosthogConsent,
+}));
+
+// Keep the entry from building the real app tree / router.
+vi.mock('@send-frontend/apps/send/SendPage.vue', () => ({ default: {} }));
+vi.mock('@send-frontend/apps/send/router', () => ({ default: {} }));
+vi.mock('vue', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('vue')>();
+  return {
+    ...actual,
+    createApp: vi.fn(() => ({
+      use: vi.fn().mockReturnThis(),
+      mount: vi.fn(),
+    })),
+  };
+});
+
+const THUNDERBIRD_UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:140.0) Gecko/20100101 Thunderbird/140.0';
+
+function setUserAgent(ua: string) {
+  Object.defineProperty(navigator, 'userAgent', {
+    value: ua,
+    configurable: true,
+  });
+}
+
+/**
+ * Simulates the token-bridge content script: answer GET_TELEMETRY_STATE with
+ * the given state, exactly as background.ts → token-bridge.js would.
+ */
+function installFakeBridge(enabled: boolean) {
+  const handler = (event: MessageEvent) => {
+    if (event.data?.type === GET_TELEMETRY_STATE) {
+      window.postMessage(
+        { type: TELEMETRY_STATE_RESPONSE, enabled },
+        window.location.origin
+      );
+    }
+  };
+  window.addEventListener('message', handler);
+  return () => window.removeEventListener('message', handler);
+}
+
+/** Runs the entry's IIFE fresh (module state, sentry.ts `initialized`, reset). */
+async function loadDashboardEntry() {
+  vi.resetModules();
+  await import('@send-frontend/apps/send/send');
+}
+
+describe('Send dashboard telemetry gate (bridge → initSentry)', () => {
+  // The entry's onTelemetryChanged() adds a window 'message' listener and
+  // discards the unsubscribe, so a prior test's listener would otherwise leak
+  // onto the shared happy-dom window and double-fire on the next broadcast.
+  // Track every 'message' listener added during a test and remove them after.
+  const originalAddEventListener = window.addEventListener.bind(window);
+  let trackedMessageListeners: EventListenerOrEventListenerObject[] = [];
+
+  beforeEach(() => {
+    setUserAgent(THUNDERBIRD_UA);
+    // No direct experiment API on the dashboard: force the bridge path.
+    // @ts-ignore
+    delete (globalThis as unknown as { browser?: unknown }).browser;
+    sentry.state.hasClient = false;
+    vi.clearAllMocks();
+
+    trackedMessageListeners = [];
+    window.addEventListener = function (
+      this: Window,
+      type: string,
+      listener: EventListenerOrEventListenerObject,
+      options?: boolean | AddEventListenerOptions
+    ) {
+      if (type === 'message' && listener) {
+        trackedMessageListeners.push(listener);
+      }
+      return originalAddEventListener(type, listener, options);
+    } as typeof window.addEventListener;
+  });
+
+  afterEach(() => {
+    window.addEventListener = originalAddEventListener;
+    for (const listener of trackedMessageListeners) {
+      window.removeEventListener('message', listener);
+    }
+  });
+
+  it('opted OUT: bridge reports disabled → Sentry never initializes', async () => {
+    const uninstall = installFakeBridge(false);
+    try {
+      await loadDashboardEntry();
+      // setupApp is called right after the gate decision, so waiting on it
+      // deterministically confirms the async gate resolved.
+      await vi.waitFor(() =>
+        expect(wiring.setupApp).toHaveBeenCalledWith(expect.anything(), false)
+      );
+      expect(sentry.init).not.toHaveBeenCalled();
+      // Initial PostHog consent is applied inside setupApp(app, false).
+    } finally {
+      uninstall();
+    }
+  });
+
+  it('opted IN: bridge reports enabled → Sentry initializes once', async () => {
+    const uninstall = installFakeBridge(true);
+    try {
+      await loadDashboardEntry();
+      await vi.waitFor(() =>
+        expect(wiring.setupApp).toHaveBeenCalledWith(expect.anything(), true)
+      );
+      expect(sentry.init).toHaveBeenCalledTimes(1);
+      // Initial PostHog consent is applied inside setupApp(app, true).
+    } finally {
+      uninstall();
+    }
+  });
+
+  it('runtime opt-IN: TELEMETRY_STATE_CHANGED(true) starts Sentry without a reload', async () => {
+    const uninstall = installFakeBridge(false);
+    try {
+      await loadDashboardEntry();
+      await vi.waitFor(() =>
+        expect(wiring.setupApp).toHaveBeenCalledWith(expect.anything(), false)
+      );
+      expect(sentry.init).not.toHaveBeenCalled();
+
+      // Background broadcasts a pref change to the open dashboard tab.
+      window.postMessage(
+        { type: TELEMETRY_STATE_CHANGED, enabled: true },
+        window.location.origin
+      );
+
+      await vi.waitFor(() => expect(sentry.init).toHaveBeenCalledTimes(1));
+      expect(wiring.setPosthogConsent).toHaveBeenLastCalledWith(true);
+    } finally {
+      uninstall();
+    }
+  });
+
+  it('runtime opt-OUT: TELEMETRY_STATE_CHANGED(false) tears Sentry down without a reload', async () => {
+    const uninstall = installFakeBridge(true);
+    try {
+      await loadDashboardEntry();
+      await vi.waitFor(() => expect(sentry.init).toHaveBeenCalledTimes(1));
+
+      window.postMessage(
+        { type: TELEMETRY_STATE_CHANGED, enabled: false },
+        window.location.origin
+      );
+
+      await vi.waitFor(() => expect(sentry.close).toHaveBeenCalledTimes(1));
+      expect(wiring.setPosthogConsent).toHaveBeenLastCalledWith(false);
+    } finally {
+      uninstall();
+    }
+  });
+});

--- a/packages/send/frontend/src/apps/send/setup.js
+++ b/packages/send/frontend/src/apps/send/setup.js
@@ -1,5 +1,7 @@
 import '@send-frontend/lib/logger';
-import posthogPlugin from '@send-frontend/plugins/posthog';
+import posthogPlugin, {
+  setPosthogConsent,
+} from '@send-frontend/plugins/posthog';
 import { VueQueryPlugin } from '@tanstack/vue-query';
 import '@thunderbirdops/services-ui/style.css';
 import FloatingVue from 'floating-vue';
@@ -43,12 +45,15 @@ const I18nTStub = {
   },
 };
 
-export function setupApp(app) {
+export function setupApp(app, telemetryAllowed = false) {
   const pinia = getSharedPinia();
   app.use(VueQueryPlugin);
   app.use(pinia);
   app.use(FloatingVue);
   app.use(posthogPlugin);
+  // Honor the Thunderbird telemetry opt-out: PostHog only initializes (and
+  // sends anything) when telemetry is allowed. See issue #892.
+  setPosthogConsent(telemetryAllowed);
 
   // TODO: Remove this once proper i18n is configured, currently required for the StandardFooter component.
   // Stub $t and i18n-t for services-ui components until proper i18n is configured

--- a/packages/send/frontend/src/lib/const.ts
+++ b/packages/send/frontend/src/lib/const.ts
@@ -55,3 +55,14 @@ export const STORAGE_KEY_AUTH = 'STORAGE_KEY_AUTH';
 export const PENDING_ADDON_TOKEN = 'tbpro-pending-addon-token';
 export const GET_PENDING_ADDON_TOKEN = 'TB/GET_PENDING_ADDON_TOKEN';
 export const PENDING_ADDON_TOKEN_RESPONSE = 'TB/PENDING_ADDON_TOKEN_RESPONSE';
+
+// Telemetry pref bridge (issue #952). The hosted Send dashboard (send.js) runs
+// as a web page without access to the `browser.Telemetry` experiment API, so it
+// asks the background script for the Thunderbird telemetry pref via the
+// token-bridge instead of reading it directly.
+//   GET_TELEMETRY_STATE      : web page → bridge → background ("what's the pref?")
+//   TELEMETRY_STATE_RESPONSE : background → bridge → web page ("{ enabled }")
+//   TELEMETRY_STATE_CHANGED  : background → bridge → web page (runtime pref change)
+export const GET_TELEMETRY_STATE = 'TB/GET_TELEMETRY_STATE';
+export const TELEMETRY_STATE_RESPONSE = 'TB/TELEMETRY_STATE_RESPONSE';
+export const TELEMETRY_STATE_CHANGED = 'TB/TELEMETRY_STATE_CHANGED';

--- a/packages/send/frontend/src/lib/const.ts
+++ b/packages/send/frontend/src/lib/const.ts
@@ -57,7 +57,7 @@ export const GET_PENDING_ADDON_TOKEN = 'TB/GET_PENDING_ADDON_TOKEN';
 export const PENDING_ADDON_TOKEN_RESPONSE = 'TB/PENDING_ADDON_TOKEN_RESPONSE';
 
 // Telemetry pref bridge (issue #952). The hosted Send dashboard (send.js) runs
-// as a web page without access to the `browser.Telemetry` experiment API, so it
+// as a web page without access to the `browser.thundermailTelemetry` experiment API, so it
 // asks the background script for the Thunderbird telemetry pref via the
 // token-bridge instead of reading it directly.
 //   GET_TELEMETRY_STATE      : web page → bridge → background ("what's the pref?")

--- a/packages/send/frontend/src/lib/sentry.ts
+++ b/packages/send/frontend/src/lib/sentry.ts
@@ -8,13 +8,22 @@ const TRACING_LEVELS_DEV = ['error', 'warn', 'debug'];
 
 const isProduction = import.meta.env.MODE === 'production';
 
+let initialized = false;
+
 export const initSentry = (app: App) => {
+  // Calling Sentry.init again after a close() re-creates the client, so this is
+  // safe to invoke on opt-in. Guard against a redundant double-init.
+  if (initialized && Sentry.getClient()) {
+    return;
+  }
+
   Sentry.init({
     app,
     dsn: import.meta.env.VITE_SENTRY_DSN,
     integrations: [
       Sentry.browserTracingIntegration(),
-      Sentry.replayIntegration(),
+      // Session Replay is intentionally NOT enabled: it records DOM contents
+      // and input, which can capture PII. See issue #892 (privacy hardening).
       Sentry.captureConsoleIntegration({
         levels: isProduction ? TRACING_LEVELS_PROD : TRACING_LEVELS_DEV,
       }),
@@ -23,11 +32,34 @@ export const initSentry = (app: App) => {
     tracesSampleRate: 0.5,
     // Set 'tracePropagationTargets' to control for which URLs distributed tracing should be enabled
     // tracePropagationTargets: ['localhost', /^https:\/\/yourserver\.io\/api/],
-    // Session Replay
-    replaysSessionSampleRate: 0.1, // This sets the sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
-    replaysOnErrorSampleRate: 1.0, // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.
     environment: import.meta.env.MODE,
+    // Privacy hardening: never attach default PII, and scrub user identity /
+    // request payloads from outgoing events.
+    sendDefaultPii: false,
+    beforeSend(event) {
+      delete event.user;
+      if (event.request) {
+        delete event.request.cookies;
+        delete event.request.headers;
+        delete event.request.query_string;
+        delete event.request.data;
+      }
+      return event;
+    },
   });
+
+  Sentry.setTag('environmentName', getEnvironmentName(import.meta.env));
+  initialized = true;
 };
 
-Sentry.setTag('environmentName', getEnvironmentName(import.meta.env));
+/**
+ * Tears down Sentry so it stops sending events/traces. Used when the user opts
+ * out of Thunderbird telemetry at runtime. Safe to call when not initialized.
+ */
+export const closeSentry = (): Promise<boolean> => {
+  if (!Sentry.getClient()) {
+    return Promise.resolve(true);
+  }
+  initialized = false;
+  return Sentry.close();
+};

--- a/packages/send/frontend/src/lib/telemetryConsent.test.ts
+++ b/packages/send/frontend/src/lib/telemetryConsent.test.ts
@@ -49,7 +49,7 @@ describe('isTelemetryAllowed', () => {
   it('honors the pref when enabled inside Thunderbird', async () => {
     setUserAgent(THUNDERBIRD_UA);
     (globalThis as unknown as { browser: unknown }).browser = {
-      Telemetry: { getUploadEnabled: vi.fn().mockResolvedValue(true) },
+      thundermailTelemetry: { isTelemetryEnabled: vi.fn().mockResolvedValue(true) },
     };
     await expect(isTelemetryAllowed()).resolves.toBe(true);
   });
@@ -57,14 +57,14 @@ describe('isTelemetryAllowed', () => {
   it('blocks telemetry when the pref is disabled inside Thunderbird', async () => {
     setUserAgent(THUNDERBIRD_UA);
     (globalThis as unknown as { browser: unknown }).browser = {
-      Telemetry: { getUploadEnabled: vi.fn().mockResolvedValue(false) },
+      thundermailTelemetry: { isTelemetryEnabled: vi.fn().mockResolvedValue(false) },
     };
     await expect(isTelemetryAllowed()).resolves.toBe(false);
   });
 
   it('honors the pref via the token-bridge when the API is absent (dashboard) — enabled', async () => {
     setUserAgent(THUNDERBIRD_UA);
-    // No `browser.Telemetry` (hosted dashboard context), but the bridge answers.
+    // No `browser.thundermailTelemetry` (hosted dashboard context), but the bridge answers.
     const uninstall = installFakeBridge(true);
     try {
       await expect(isTelemetryAllowed()).resolves.toBe(true);
@@ -85,7 +85,7 @@ describe('isTelemetryAllowed', () => {
 
   it('fails closed inside Thunderbird when neither the API nor the bridge answers', async () => {
     setUserAgent(THUNDERBIRD_UA);
-    // No `browser.Telemetry` and no bridge listening: the request times out.
+    // No `browser.thundermailTelemetry` and no bridge listening: the request times out.
     vi.useFakeTimers();
     try {
       const pending = isTelemetryAllowed();
@@ -99,8 +99,8 @@ describe('isTelemetryAllowed', () => {
   it('fails closed inside Thunderbird when reading the pref throws', async () => {
     setUserAgent(THUNDERBIRD_UA);
     (globalThis as unknown as { browser: unknown }).browser = {
-      Telemetry: {
-        getUploadEnabled: vi.fn().mockRejectedValue(new Error('boom')),
+      thundermailTelemetry: {
+        isTelemetryEnabled: vi.fn().mockRejectedValue(new Error('boom')),
       },
     };
     await expect(isTelemetryAllowed()).resolves.toBe(false);

--- a/packages/send/frontend/src/lib/telemetryConsent.test.ts
+++ b/packages/send/frontend/src/lib/telemetryConsent.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  GET_TELEMETRY_STATE,
+  TELEMETRY_STATE_RESPONSE,
+} from './const';
+import { isTelemetryAllowed } from './telemetryConsent';
+
+function setUserAgent(ua: string) {
+  Object.defineProperty(navigator, 'userAgent', {
+    value: ua,
+    configurable: true,
+  });
+}
+
+/**
+ * Simulates the token-bridge content script: when the page asks for the
+ * telemetry state, reply with the given value. Returns an uninstall function.
+ */
+function installFakeBridge(enabled: boolean) {
+  const bridge = (event: MessageEvent) => {
+    if (event.data?.type === GET_TELEMETRY_STATE) {
+      window.postMessage(
+        { type: TELEMETRY_STATE_RESPONSE, enabled },
+        window.location.origin
+      );
+    }
+  };
+  window.addEventListener('message', bridge);
+  return () => window.removeEventListener('message', bridge);
+}
+
+const THUNDERBIRD_UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:140.0) Gecko/20100101 Thunderbird/140.0';
+const WEB_UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:140.0) Gecko/20100101 Firefox/140.0';
+
+describe('isTelemetryAllowed', () => {
+  afterEach(() => {
+    // @ts-ignore — clean up the simulated experiment API
+    delete (globalThis as unknown as { browser?: unknown }).browser;
+    vi.restoreAllMocks();
+  });
+
+  it('allows telemetry outside Thunderbird (public website)', async () => {
+    setUserAgent(WEB_UA);
+    await expect(isTelemetryAllowed()).resolves.toBe(true);
+  });
+
+  it('honors the pref when enabled inside Thunderbird', async () => {
+    setUserAgent(THUNDERBIRD_UA);
+    (globalThis as unknown as { browser: unknown }).browser = {
+      Telemetry: { getUploadEnabled: vi.fn().mockResolvedValue(true) },
+    };
+    await expect(isTelemetryAllowed()).resolves.toBe(true);
+  });
+
+  it('blocks telemetry when the pref is disabled inside Thunderbird', async () => {
+    setUserAgent(THUNDERBIRD_UA);
+    (globalThis as unknown as { browser: unknown }).browser = {
+      Telemetry: { getUploadEnabled: vi.fn().mockResolvedValue(false) },
+    };
+    await expect(isTelemetryAllowed()).resolves.toBe(false);
+  });
+
+  it('honors the pref via the token-bridge when the API is absent (dashboard) — enabled', async () => {
+    setUserAgent(THUNDERBIRD_UA);
+    // No `browser.Telemetry` (hosted dashboard context), but the bridge answers.
+    const uninstall = installFakeBridge(true);
+    try {
+      await expect(isTelemetryAllowed()).resolves.toBe(true);
+    } finally {
+      uninstall();
+    }
+  });
+
+  it('honors the pref via the token-bridge when the API is absent (dashboard) — disabled', async () => {
+    setUserAgent(THUNDERBIRD_UA);
+    const uninstall = installFakeBridge(false);
+    try {
+      await expect(isTelemetryAllowed()).resolves.toBe(false);
+    } finally {
+      uninstall();
+    }
+  });
+
+  it('fails closed inside Thunderbird when neither the API nor the bridge answers', async () => {
+    setUserAgent(THUNDERBIRD_UA);
+    // No `browser.Telemetry` and no bridge listening: the request times out.
+    vi.useFakeTimers();
+    try {
+      const pending = isTelemetryAllowed();
+      await vi.advanceTimersByTimeAsync(2000);
+      await expect(pending).resolves.toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('fails closed inside Thunderbird when reading the pref throws', async () => {
+    setUserAgent(THUNDERBIRD_UA);
+    (globalThis as unknown as { browser: unknown }).browser = {
+      Telemetry: {
+        getUploadEnabled: vi.fn().mockRejectedValue(new Error('boom')),
+      },
+    };
+    await expect(isTelemetryAllowed()).resolves.toBe(false);
+  });
+});

--- a/packages/send/frontend/src/lib/telemetryConsent.ts
+++ b/packages/send/frontend/src/lib/telemetryConsent.ts
@@ -1,21 +1,22 @@
 /**
  * Telemetry consent gate.
  *
- * Honors Thunderbird's telemetry opt-out preference
- * (datareporting.healthreport.uploadEnabled) for Sentry and PostHog.
+ * Honors Thunderbird's telemetry opt-out (enabled only when both
+ * datareporting.policy.dataSubmissionEnabled and
+ * datareporting.healthreport.uploadEnabled are on) for Sentry and PostHog.
  *
  * Behavior by context:
  * - Outside Thunderbird (public website): telemetry behaves as before (allowed).
- * - Inside Thunderbird, on an add-on (moz-extension) page: read the pref via the
- *   `browser.Telemetry` experiment API.
+ * - Inside Thunderbird, on an add-on (moz-extension) page: read the state via
+ *   the `browser.thundermailTelemetry` experiment API.
  * - Inside Thunderbird on the hosted Send dashboard (send.js runs as a web page
- *   with no experiment API): ask the background script for the pref over the
+ *   with no experiment API): ask the background script for the state over the
  *   token-bridge (issue #952).
  * - Inside Thunderbird but neither the experiment API nor the bridge answers:
  *   fail closed (no telemetry).
  *
- * The `browser.Telemetry` namespace is provided by the add-on's experiment API
- * (packages/addon/public/api/Telemetry). The frontend types come from
+ * The `browser.thundermailTelemetry` namespace is provided by the add-on's
+ * experiment API (packages/addon/public/api/Telemetry). The frontend types come from
  * @types/firefox-webext-browser, which does not know about custom experiment
  * APIs, hence the `@ts-ignore` accesses below (matching extension-store.ts).
  */
@@ -38,14 +39,12 @@ const isInsideThunderbird = (): boolean =>
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const getTelemetryApi = (): any => {
-  try {
-    // @ts-ignore — custom experiment API, only present on moz-extension pages
-    if (typeof browser !== 'undefined' && browser?.Telemetry) {
-      // @ts-ignore
-      return browser.Telemetry;
-    }
-  } catch {
-    // `browser` not defined (web context) — fall through
+  // The `typeof browser` guard makes the property access safe in web contexts
+  // where `browser` is undefined, so no try/catch is needed here.
+  // @ts-ignore — custom experiment API, only present on moz-extension pages
+  if (typeof browser !== 'undefined' && browser?.thundermailTelemetry) {
+    // @ts-ignore
+    return browser.thundermailTelemetry;
   }
   return undefined;
 };
@@ -53,7 +52,7 @@ const getTelemetryApi = (): any => {
 /**
  * Requests the Thunderbird telemetry pref from the background script via the
  * token-bridge, for contexts (the hosted Send dashboard) that lack the
- * `browser.Telemetry` experiment API. Resolves false (fail closed) if the
+ * `browser.thundermailTelemetry` experiment API. Resolves false (fail closed) if the
  * bridge does not answer within the timeout.
  */
 function requestTelemetryStateViaBridge(): Promise<boolean> {
@@ -96,10 +95,10 @@ export async function isTelemetryAllowed(): Promise<boolean> {
   }
 
   const api = getTelemetryApi();
-  if (api?.getUploadEnabled) {
-    // moz-extension add-on page: read the pref directly.
+  if (api?.isTelemetryEnabled) {
+    // moz-extension add-on page: read the state directly.
     try {
-      return Boolean(await api.getUploadEnabled());
+      return Boolean(await api.isTelemetryEnabled());
     } catch {
       return false;
     }

--- a/packages/send/frontend/src/lib/telemetryConsent.ts
+++ b/packages/send/frontend/src/lib/telemetryConsent.ts
@@ -1,0 +1,150 @@
+/**
+ * Telemetry consent gate.
+ *
+ * Honors Thunderbird's telemetry opt-out preference
+ * (datareporting.healthreport.uploadEnabled) for Sentry and PostHog.
+ *
+ * Behavior by context:
+ * - Outside Thunderbird (public website): telemetry behaves as before (allowed).
+ * - Inside Thunderbird, on an add-on (moz-extension) page: read the pref via the
+ *   `browser.Telemetry` experiment API.
+ * - Inside Thunderbird on the hosted Send dashboard (send.js runs as a web page
+ *   with no experiment API): ask the background script for the pref over the
+ *   token-bridge (issue #952).
+ * - Inside Thunderbird but neither the experiment API nor the bridge answers:
+ *   fail closed (no telemetry).
+ *
+ * The `browser.Telemetry` namespace is provided by the add-on's experiment API
+ * (packages/addon/public/api/Telemetry). The frontend types come from
+ * @types/firefox-webext-browser, which does not know about custom experiment
+ * APIs, hence the `@ts-ignore` accesses below (matching extension-store.ts).
+ */
+
+import {
+  GET_TELEMETRY_STATE,
+  TELEMETRY_STATE_CHANGED,
+  TELEMETRY_STATE_RESPONSE,
+} from './const';
+
+// How long to wait for the token-bridge to answer before failing closed. The
+// bridge content script is injected at document_start, so it is normally
+// present before this runs; the timeout covers the case where it is not (e.g.
+// the add-on isn't installed).
+const BRIDGE_TIMEOUT_MS = 2000;
+
+const isInsideThunderbird = (): boolean =>
+  typeof navigator !== 'undefined' &&
+  navigator.userAgent.includes('Thunderbird');
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const getTelemetryApi = (): any => {
+  try {
+    // @ts-ignore — custom experiment API, only present on moz-extension pages
+    if (typeof browser !== 'undefined' && browser?.Telemetry) {
+      // @ts-ignore
+      return browser.Telemetry;
+    }
+  } catch {
+    // `browser` not defined (web context) — fall through
+  }
+  return undefined;
+};
+
+/**
+ * Requests the Thunderbird telemetry pref from the background script via the
+ * token-bridge, for contexts (the hosted Send dashboard) that lack the
+ * `browser.Telemetry` experiment API. Resolves false (fail closed) if the
+ * bridge does not answer within the timeout.
+ */
+function requestTelemetryStateViaBridge(): Promise<boolean> {
+  if (typeof window === 'undefined') {
+    return Promise.resolve(false);
+  }
+
+  return new Promise((resolve) => {
+    const cleanup = () => {
+      clearTimeout(timer);
+      window.removeEventListener('message', handler);
+    };
+
+    const timer = setTimeout(() => {
+      // Bridge absent or unresponsive — fail closed.
+      cleanup();
+      resolve(false);
+    }, BRIDGE_TIMEOUT_MS);
+
+    const handler = (event: MessageEvent) => {
+      if (event.data?.type === TELEMETRY_STATE_RESPONSE) {
+        cleanup();
+        resolve(Boolean(event.data.enabled));
+      }
+    };
+
+    window.addEventListener('message', handler);
+    window.postMessage({ type: GET_TELEMETRY_STATE }, window.location.origin);
+  });
+}
+
+/**
+ * Resolves whether telemetry (Sentry + PostHog) is allowed to run.
+ * Fails closed (false) when inside Thunderbird and the pref cannot be read.
+ */
+export async function isTelemetryAllowed(): Promise<boolean> {
+  if (!isInsideThunderbird()) {
+    // Public website (outside Thunderbird): preserve existing behavior.
+    return true;
+  }
+
+  const api = getTelemetryApi();
+  if (api?.getUploadEnabled) {
+    // moz-extension add-on page: read the pref directly.
+    try {
+      return Boolean(await api.getUploadEnabled());
+    } catch {
+      return false;
+    }
+  }
+
+  // Inside Thunderbird without the direct experiment API (the hosted Send
+  // dashboard runs as a web page): ask the background via the token-bridge.
+  return requestTelemetryStateViaBridge();
+}
+
+/**
+ * Subscribes to runtime changes of the Thunderbird telemetry pref. The callback
+ * receives the new boolean value. Returns an unsubscribe function; a no-op when
+ * the experiment API is unavailable (e.g. on the public website).
+ */
+export function onTelemetryChanged(
+  cb: (enabled: boolean) => void
+): () => void {
+  const api = getTelemetryApi();
+  if (api?.onChanged?.addListener) {
+    // moz-extension add-on page: observe the pref directly.
+    const listener = (enabled: boolean) => cb(Boolean(enabled));
+    api.onChanged.addListener(listener);
+
+    return () => {
+      try {
+        api.onChanged.removeListener?.(listener);
+      } catch {
+        // ignore
+      }
+    };
+  }
+
+  // Inside Thunderbird without the direct API (the hosted Send dashboard): the
+  // background pushes pref changes through the token-bridge as window messages.
+  if (isInsideThunderbird() && typeof window !== 'undefined') {
+    const handler = (event: MessageEvent) => {
+      if (event.data?.type === TELEMETRY_STATE_CHANGED) {
+        cb(Boolean(event.data.enabled));
+      }
+    };
+    window.addEventListener('message', handler);
+    return () => window.removeEventListener('message', handler);
+  }
+
+  // Public website (outside Thunderbird): nothing to observe.
+  return () => {};
+}

--- a/packages/send/frontend/src/plugins/posthog.js
+++ b/packages/send/frontend/src/plugins/posthog.js
@@ -2,18 +2,46 @@
 
 import posthog from 'posthog-js';
 
+let initialized = false;
+
+function initPosthog() {
+  if (initialized) {
+    return;
+  }
+  posthog.init(import.meta.env.VITE_POSTHOG_PROJECT_KEY, {
+    api_host: import.meta.env.VITE_POSTHOG_HOST,
+    persistence: 'memory',
+  });
+  posthog.register({
+    service: 'send',
+  });
+  initialized = true;
+}
+
+/**
+ * Enables or disables PostHog capture at runtime in response to the Thunderbird
+ * telemetry opt-out preference (see issue #892).
+ *
+ * When enabled, PostHog is initialized lazily on first opt-in — so while opted
+ * out it is never initialized and makes zero network requests. When disabled,
+ * capture is opted out and the stored distinct id is reset.
+ *
+ * `capture()` / `identify()` calls on the shared instance before init are
+ * no-ops, so callers throughout the app remain safe regardless of consent.
+ */
+export function setPosthogConsent(enabled) {
+  if (enabled) {
+    initPosthog();
+    posthog.opt_in_capturing();
+  } else if (initialized) {
+    posthog.opt_out_capturing();
+    posthog.reset();
+  }
+}
+
 export default {
   install(app) {
-    app.config.globalProperties.$posthog = posthog.init(
-      import.meta.env.VITE_POSTHOG_PROJECT_KEY,
-      {
-        api_host: import.meta.env.VITE_POSTHOG_HOST,
-        persistence: 'memory',
-      }
-    );
-    posthog.register({
-      service: 'send',
-    });
+    app.config.globalProperties.$posthog = posthog;
   },
   rest: posthog,
 };


### PR DESCRIPTION
## What changed?

Makes the TB Pro add-on honor Thunderbird's telemetry opt-out preference
(`datareporting.healthreport.uploadEnabled`) for both **Sentry** and **PostHog**,
so an opted-out user sends **zero** telemetry (no errors, traces, session replay,
console capture, analytics, feature-flag/`decide` calls, `$pageview`, or `identify`).

- **Experiment API** (`packages/addon/public/api/Telemetry/`) exposes the pref
  via `Services.prefs`, reading fail-closed (`false`) on any error.
- **Frontend consent gate** (`telemetryConsent.ts`): outside Thunderbird →
  unchanged (allowed); on `moz-extension://` add-on pages → reads the pref
  directly; **fails closed** when the pref can't be read.
- **Sentry** (`sentry.ts`): init gated on consent + hardened — session replay
  removed, `sendDefaultPii: false`, `beforeSend` scrubs user identity and request
  payloads. `closeSentry()` tears down on runtime opt-out.
- **PostHog** (`posthog.js`): `init()` deferred until first opt-in; runtime
  `setPosthogConsent()` opts in/out.
- **Hosted Send dashboard** (issue #952): the dashboard opens as a regular web
  tab (`send.js`) with no experiment API, so it obtains the pref from the
  background script over the existing `token-bridge.js` relay
  (`GET_TELEMETRY_STATE` / `TELEMETRY_STATE_RESPONSE` / `TELEMETRY_STATE_CHANGED`),
  with runtime opt-in/out and a fail-closed timeout.
- Entry points (`send.js` / `extension.js` / `management.js`) resolve consent
  before initializing telemetry and subscribe to runtime pref changes.
- **Startup hardening** (`background.ts`): `initTelemetryListener()` guards
  against an unavailable `browser.Telemetry` API — if the experiment API isn't
  present in a given build/context, the runtime pref-change broadcast is disabled
  gracefully instead of throwing and aborting the rest of background
  initialization.
- Design note added at `packages/send/docs/TelemetryOptOut.md`.

<sub>**AI disclosure:** implemented with Claude Code (agent-written) under close
human direction — the author scoped the approach, reviewed every change, and
verified the results. This PR description was AI-drafted and human-reviewed.</sub>

## Why?

To support user trust and Mozilla/Thunderbird data-handling expectations: when a
user has opted out of Thunderbird telemetry, the add-on must not send error or
analytics data. The gate reads the same pref Thunderbird uses and fails closed so
telemetry is never sent when the pref state is unknown. See #892 for the full
objective. #952 closes the gap where the hosted Send dashboard (a web page inside
Thunderbird) could not read the pref and therefore never honored it.

## Limitations and Notes

- **Backend out of scope:** server-side Sentry/PostHog can't read a per-user TB
  pref; tracked as a #892 follow-up. Privacy-policy text and the subprocessor
  list are separate #892 follow-ups.
- **Manual verification still required** (can't run headless): temp-load in
  Thunderbird Daily and use DevTools → Network to confirm, for both the popup and
  the **dashboard tab** — pref ON → Sentry/PostHog requests occur; pref OFF →
  zero requests; runtime toggle flips telemetry without reload; fail-closed when
  the API/bridge is unavailable; public website unaffected.
- **Related hardening:** #953 tracks validating `event.origin`/`event.source` in
  `token-bridge.js` (the relay this PR extends).
- Automated checks: `tsc --noEmit` (frontend) clean, ESLint on touched files
  clean, `vitest` telemetry suite green (website-allowed, pref on/off, bridge
  on/off, fail-closed).

## Applicable Issues

- Closes #952
- Refs #892 (frontend gate delivered here; backend + privacy-policy follow-ups remain)

## Screenshots

N/A — no UI changes (telemetry gating is non-visual). Behavior is verified via
DevTools → Network as described above.
