### PR TITLE
docs(send): R2 staging → B2 replication design & feasibility (#959)

### DIFF
--- a/packages/send/docs/R2StagingFeasibility.md
+++ b/packages/send/docs/R2StagingFeasibility.md
@@ -33,7 +33,7 @@ The result: the replication tier's cost is dominated by a $5/mo Workers Paid sub
 | (c) Cloudflare Worker + Queues + R2 event notifications | ~$5 / ~$6.50 / ~$15 all-in | L | Zero egress; push-based; best retry semantics (at-least-once, DLQ) |
 | (d) Always-on dedicated Fargate worker | ~$21 / ~$21 / ~$21–41 | M | Same egress penalty; worst fixed cost |
 
-All pricing claims **confirmed** (Fargate $0.04656/vCPU-hr + $0.00511/GB-hr eu-central-1; Workers Paid $5/mo incl. 10M req + 30M CPU-ms; Queues 1M ops incl. then $0.40/M — official pricing pages, 2026-07-06). Bonus finding from verification: queue-consumer Workers get CPU limits *above* the 5-min standard cap, de-risking (c).
+All pricing claims **confirmed** (Fargate $0.04656/vCPU-hr + $0.00511/GB-hr eu-central-1; Workers Paid $5/mo incl. 10M req + 30M CPU-ms; Queues 1M ops incl. then $0.40/M — official pricing pages, 2026-07-06). Note on Worker limits: queue consumers share the **standard** Worker CPU ceiling — the larger 15-minute figure is *wall-clock* per invocation, not CPU; streaming a copy consumes seconds of wall-clock and well under a second of CPU, so (c) is comfortably inside both.
 
 **Recommended:** (c) as the endgame at any volume above ~1 TB/mo; (a) as an acceptable quick start; avoid (d).
 
@@ -43,7 +43,7 @@ Neither vendor can server-side copy to the other (Super Slurper/Sippy are R2-des
 
 | Option | Total 1/10/50 TB | Effort | Notes |
 |---|---|---|---|
-| (a) Through existing Fargate | ~$82–91 / ~$897 / ~$4,320 | M | $0.09/GB DTO (tiered $0.085 above 10 TB), confirmed via AWS Bulk Price List API. No NAT gateway exists today (verified in Pulumi config) — a future move to private subnets + NAT would add ~$104/TB |
+| (a) Through existing Fargate | ~$92 / ~$922 / ~$4,403 (egress only, binary-TB convention used throughout this doc; AWS's 100 GB/mo free DTO tier could trim ~$9 at the 1 TB scenario if unconsumed elsewhere) | M | $0.09/GB DTO (tiered $0.085 above 10 TB), confirmed via AWS Bulk Price List API. No NAT gateway exists today (verified in Pulumi config) — a future move to private subnets + NAT would add ~$104/TB |
 | (b) Cloudflare Worker replicator | ~$6 / ~$11 / ~$33 | M | R2 egress free, Worker streaming time unbilled (only CPU-ms), B2 ingress free — all confirmed. ~130× cheaper than (a) at 50 TB |
 | (c) Hetzner VPS relay | ~$7 / ~$12 / ~$67 | M | Works, but a pet server + third key-custody domain. **Correction applied:** Hetzner's June 2026 price rise was ~31–38% on entry plans (up to +144–169% mid-tier), not "~20–30%"; the €5.49 entry price and 20 TB included traffic are exact, so the economics stand |
 
@@ -61,7 +61,7 @@ Neither vendor can server-side copy to the other (Super Slurper/Sippy are R2-des
 
 Fallback if c1's staging test fails: add `https://*.r2.cloudflarestorage.com/*` to the manifest and accept the staged-update prompt on the standalone channel — confirmed that the old version *keeps running* if the user doesn't approve (degraded adoption, zero breakage). The built-in/system add-on channel rides Thunderbird releases (ESR lags ~1 year), so **the B2 presign fallback is permanent, not transitional**.
 
-### Caveat 4 — Storage-layer refactor for per-Upload routing (r2|migrating|b2)
+### Caveat 4 — Storage-layer refactor for per-Upload routing (r2|b2|failed)
 
 All options are $0 recurring; differentiators are blast radius and test surface.
 
@@ -71,7 +71,7 @@ All options are $0 recurring; differentiators are blast radius and test surface.
 | (b) Provider registry: `StorageProvider` interface, one @aws-sdk/client-s3 impl for both vendors, required `location` everywhere | M | **Recommended.** Deletes real debt (12h token-renewal setInterval, directClient init race); replication worker consumes the same interface. Hard requirements: `set()` via lib-storage Upload (WS path passes client-stated size), keep the tweedegolf B2 adapter behind an env flag for one release as rollback |
 | (c) R2 staging sidecar module, FileStore untouched | S | Fallback for smallest increment; codifies asymmetry that rots if R2's role ever grows |
 
-All five load-bearing claims confirmed. **Refinements from verification:** the aws-sdk v3.729+ CRC32 checksum incompatibility needs `WHEN_REQUIRED` **only on the B2 client** — Cloudflare fixed R2 server-side on 2025-02-03 (setting it on both remains the sensible uniform choice). Prisma migration (`enum StorageLocation { b2 migrating r2 failed? }`, `@default(b2)`) is metadata-only on PG11+ — safe on the live table.
+All five load-bearing claims confirmed. **Refinements from verification:** the aws-sdk v3.729+ CRC32 checksum incompatibility needs `WHEN_REQUIRED` **only on the B2 client** — Cloudflare fixed R2 server-side on 2025-02-03 (setting it on both remains the sensible uniform choice). Prisma migration — final enum shape is `{ r2 b2 failed }`, no `migrating` state (superseded here; see the design note §2.3): the column/enum/default are metadata-only on PG11+ and safe on the live table, but the accompanying **index must be created out-of-band with `CREATE INDEX CONCURRENTLY`** (Prisma's inline `CREATE INDEX` write-locks the live `Upload` table).
 
 ---
 
@@ -93,7 +93,7 @@ In-process SKIP LOCKED poller (job-infra a) · replication through Fargate (egre
 **Effort:** S+S+S/M — the smallest total diff; zero new deploy surfaces, zero Pulumi changes. **Rollout:** ships fastest; replication shares CPU with the API (tail-latency risk, autoscaler cpu_threshold 80); economically untenable past a few TB/mo.
 
 ### Bundle B — "Cloudflare Worker replication" (endgame)
-R2 event notifications → Queues → consumer Worker streams R2→B2, calls an HMAC-authenticated backend endpoint to flip `storageLocation` (job-infra c / egress b) · capability flag + CORS-only client (a+c1) · provider registry (refactor b).
+R2 event notifications → Queues → consumer Worker streams R2→B2, calls an HMAC-authenticated backend endpoint to flip `storageLocation` (job-infra c / egress b) · capability flag + CORS-only client (a+c1) · provider registry (refactor b). **Compliance note:** this bundle (like every R2-staging variant, but stated here because it is the recommendation) onboards Cloudflare as a new subprocessor transiently holding E2E-encrypted user content **and processing end-user IP addresses** (TLS termination on every direct PUT and pre-flip GET) — requiring a DPA with transfer mechanism (SCCs/DPF — Cloudflare is US-HQ), subprocessor-list and privacy-policy updates, Art. 30 records, and a DPIA refresh. R2's EU jurisdiction guarantees **storage at rest only**; request processing and Queues have no residency guarantee.
 
 | | 1 TB | 10 TB | 50 TB |
 |---|---|---|---|
@@ -134,7 +134,7 @@ Justification:
 2. **Is a second production runtime (Wrangler deploys, B2 keys in Cloudflare secrets, split observability) organizationally acceptable?** This is the only real argument against Bundle B.
 3. **Expected upload volume** — below ~1 TB/mo indefinitely, Bundle A alone is defensible.
 4. **R2 grace period before delete** — staging cost scales linearly with residency (2 days ≈ 2× the $0.55/$5.55/$28 line).
-5. **EU jurisdiction bucket?** An EU-jurisdiction R2 bucket changes the hostname to `<ACCOUNT_ID>.eu.r2.cloudflarestorage.com` (affects CSP strings and the manifest fallback); decide before pinning hostnames.
+5. **EU jurisdiction bucket?** An EU-jurisdiction R2 bucket changes the hostname to `<ACCOUNT_ID>.eu.r2.cloudflarestorage.com` (affects CSP strings and the manifest fallback); decide before pinning hostnames. Jurisdiction covers storage **at rest only** — see the Bundle B compliance note for the processing-side obligations (DPA, SCCs/DPF, subprocessor list, Art. 30, DPIA).
 6. **Alerting** — replication backlog depth/age must page somewhere (CloudWatch group exists; Workers need their own hook). Old-client share is unmeasurable today (no version header) — accept the B2 presign path as permanent.
 7. **NAT guard-rail** — add a loud Pulumi comment: introducing a NAT gateway adds ~$104/TB to any AWS-resident replicator.
 
@@ -151,7 +151,7 @@ Of 31 verified claims, 30 were confirmed exactly; 1 needed correction. Nuances t
 | 3 | R2 wildcard `AllowedHeaders '*'` doesn't work (client-rollout c1) | confirmed, weak sourcing | Community-verified (multiple independent write-ups + Cloudflare Community), **absent from official Cloudflare docs** — covered by the mandatory staging test; enumerate `['content-type']` regardless |
 | 4 | `WHEN_REQUIRED` checksum fix cited to pingvin-share issue (storage-refactor) | confirmed, attribution fixed | That issue documents only the error; the fix belongs to the nocobase issue + AWS official docs. **Materially: R2 no longer needs the workaround at all** (Cloudflare fixed server-side 2025-02-03) — only the B2 client requires it |
 | 5 | AWS egress ~$92 at 1 TB (job-infra, egress-cost) | confirmed, minor nuance | AWS's 100 GB/mo global free DTO tier could trim ~$9 at the 1 TB scenario if unconsumed — immaterial |
-| 6 | Worker 5-min CPU cap (job-infra c) | confirmed, favorable nuance | Queue-consumer Workers get CPU limits *above* the standard cap — slightly de-risks the copier |
+| 6 | Queue-consumer Workers get CPU limits above the 5-min standard cap | **needs-correction** | Consumers share the standard Worker **CPU** ceiling; the 15-minute figure is *wall-clock* per invocation. Immaterial to the copier (streaming uses seconds of wall-clock, <1 s CPU) but recorded here as a correction, not a confirmation |
 | 7 | "B2 can't list moz-extension:// origins, hence the Origin-strip hack" (client-rollout) | confirmed, causal nuance | A bare `'*'` in B2 allowedOrigins matches *any* origin, so the hack wasn't the only theoretically possible approach; the stated fact (specific extension origin unlistable) is accurate and doesn't affect the R2 plan |
 
-No verification result changed any recommendation. The largest uncertainty ranges remaining are behavioral (staging tests in open question 1), not financial: every dollar figure above is anchored to official vendor pricing fetched 2026-07-06, except Worker CPU-ms per 100 MB object (estimated 10–30 ms; even a 10× miss adds only ~$2.6/mo at 50 TB).
+No verification result changed any recommendation. The largest uncertainty ranges remaining are behavioral (staging tests in open question 1), not financial: every dollar figure above is anchored to official vendor pricing fetched 2026-07-06, except Worker CPU-ms per 100 MB object — budgeted conservatively at ~500 ms (matching the design note's `cpu_ms` sizing); even that conservative figure adds only ~$2–3/mo at 50 TB.

--- a/packages/send/docs/R2StagingFeasibility.md
+++ b/packages/send/docs/R2StagingFeasibility.md
@@ -2,10 +2,13 @@
 
 Status: **Draft for review** — feasibility deliverable for
 [thunderbird/tbpro-add-on#959](https://github.com/thunderbird/tbpro-add-on/issues/959).
-This note evaluates the four feasibility caveats of the proposal (job
-infrastructure, replication byte-path cost, client rollout, storage-layer
-refactor), prices the coherent architecture bundles, and recommends one. The
-selected design (Bundle B) is fully specified in the companion note
+**The goal is upload reliability**: make Send uploads succeed when a direct
+upload to Backblaze B2 stalls and fails (`UPLOAD_FAILED`, #959). This note
+asks whether the R2-fallback approach to that problem is feasible and what it
+costs — it evaluates the four feasibility caveats (job infrastructure,
+replication byte-path cost, client rollout, storage-layer refactor), prices the
+coherent architecture bundles, and recommends one. The selected design
+(Bundle B) is fully specified in the companion note
 [R2StagingReplicationDesign.md](./R2StagingReplicationDesign.md).
 
 **Date:** 2026-07-06 · **Scope:** four fact-checked caveat evaluations, all pricing verified against official vendor sources on 2026-07-06 unless noted. Volume scenarios: 1 / 10 / 50 TB uploaded per month (~10,500 / 105,000 / 525,000 objects at ~100 MB parts).

--- a/packages/send/docs/R2StagingFeasibility.md
+++ b/packages/send/docs/R2StagingFeasibility.md
@@ -1,0 +1,157 @@
+# Feasibility & Cost Evaluation: R2 Staging → B2 Replication for Send
+
+Status: **Draft for review** — feasibility deliverable for
+[thunderbird/tbpro-add-on#959](https://github.com/thunderbird/tbpro-add-on/issues/959).
+This note evaluates the four feasibility caveats of the proposal (job
+infrastructure, replication byte-path cost, client rollout, storage-layer
+refactor), prices the coherent architecture bundles, and recommends one. The
+selected design (Bundle B) is fully specified in the companion note
+[R2StagingReplicationDesign.md](./R2StagingReplicationDesign.md).
+
+**Date:** 2026-07-06 · **Scope:** four fact-checked caveat evaluations, all pricing verified against official vendor sources on 2026-07-06 unless noted. Volume scenarios: 1 / 10 / 50 TB uploaded per month (~10,500 / 105,000 / 525,000 objects at ~100 MB parts).
+
+## 0. Why staging in R2 is nearly free: the billing mechanics
+
+Three verified billing properties make the staging tier cost negligible relative to the data volume moved through it:
+
+1. **R2 storage is metered as GB-month, "calculated by averaging the _peak_ storage per day over a billing period (30 days)"** ([R2 pricing](https://developers.cloudflare.com/r2/pricing/)). Transient objects are not free — they count toward the day's peak — but an object resident <24 h contributes roughly `size × (1 day / 30)` of the $0.015/GB-month rate (≈ $0.0005/GB). At 10 TB/mo of uploads with ~1-day residency, steady-state staged data is ~333 GB, costing ~$5/mo.
+2. **Egress from R2 is free, by any path** (Workers API, S3 API, public domains) — the R2→B2 replication reads cost nothing in bandwidth.
+3. **Workers bill CPU-time, not wall-clock or bandwidth** — streaming a 100 MB body through a Worker consumes milliseconds of billed CPU while the I/O time is free.
+
+The result: the replication tier's cost is dominated by a $5/mo Workers Paid subscription plus cents of operations, instead of the ~$0.09/GB AWS egress that any AWS-resident copier would pay.
+
+---
+
+## 1. Per-caveat summaries
+
+### Caveat 1 — Background-job infrastructure (repo has none today)
+
+| Option | Job-infra cost 1/10/50 TB | Effort | Notes |
+|---|---|---|---|
+| (a) In-process poller in existing Fargate tasks (SKIP LOCKED) | ~$0 / ~$0 / $0–40 | S | Cross-ref: forces AWS egress ~$92/$922/$4,403 (caveat 2) |
+| (b) EventBridge Scheduler → ECS RunTask | ~$3 / ~$4.50 / ~$11–15 | M | Same egress penalty; new hand-rolled Pulumi pattern |
+| (c) Cloudflare Worker + Queues + R2 event notifications | ~$5 / ~$6.50 / ~$15 all-in | L | Zero egress; push-based; best retry semantics (at-least-once, DLQ) |
+| (d) Always-on dedicated Fargate worker | ~$21 / ~$21 / ~$21–41 | M | Same egress penalty; worst fixed cost |
+
+All pricing claims **confirmed** (Fargate $0.04656/vCPU-hr + $0.00511/GB-hr eu-central-1; Workers Paid $5/mo incl. 10M req + 30M CPU-ms; Queues 1M ops incl. then $0.40/M — official pricing pages, 2026-07-06). Bonus finding from verification: queue-consumer Workers get CPU limits *above* the 5-min standard cap, de-risking (c).
+
+**Recommended:** (c) as the endgame at any volume above ~1 TB/mo; (a) as an acceptable quick start; avoid (d).
+
+### Caveat 2 — Replication byte-path egress cost (the decision-dominating line)
+
+Neither vendor can server-side copy to the other (Super Slurper/Sippy are R2-destination-only — confirmed). Every byte transits compute somewhere.
+
+| Option | Total 1/10/50 TB | Effort | Notes |
+|---|---|---|---|
+| (a) Through existing Fargate | ~$82–91 / ~$897 / ~$4,320 | M | $0.09/GB DTO (tiered $0.085 above 10 TB), confirmed via AWS Bulk Price List API. No NAT gateway exists today (verified in Pulumi config) — a future move to private subnets + NAT would add ~$104/TB |
+| (b) Cloudflare Worker replicator | ~$6 / ~$11 / ~$33 | M | R2 egress free, Worker streaming time unbilled (only CPU-ms), B2 ingress free — all confirmed. ~130× cheaper than (a) at 50 TB |
+| (c) Hetzner VPS relay | ~$7 / ~$12 / ~$67 | M | Works, but a pet server + third key-custody domain. **Correction applied:** Hetzner's June 2026 price rise was ~31–38% on entry plans (up to +144–169% mid-tier), not "~20–30%"; the €5.49 entry price and 20 TB included traffic are exact, so the economics stand |
+
+**Recommended:** (b). The ~$5/mo flat Worker vs ~$900–4,400/mo AWS egress asymmetry is fully verified and decides the architecture.
+
+### Caveat 3 — Client rollout (add-on manifest, CORS, old versions)
+
+| Option | Marginal cost | Effort | Verdict |
+|---|---|---|---|
+| (a) Capability flag in `POST uploads/signed` + env kill switch | $0 | S | **Recommended control plane.** Old clients never send the flag → get B2 forever by construction; rollback is an env flip |
+| (b) Version-header % rollout | $0 | M | Degenerates into (a) (no version header exists today); keep only the server-side % gate layered on (a), hashed per-file/per-user to avoid mixed-location parts of one file |
+| (c1) CORS-only direct R2, **no manifest change** | $0 | S | **Recommended transport, pending staging verification.** R2 per-bucket CORS works with presigned URLs (confirmed); B2's server-side preflight denial that forced the Origin-strip hack doesn't exist on R2. Set `forcePathStyle: true` so the host is one stable string; enumerate `AllowedHeaders: ['content-type']` (wildcard is **community-verified** not to work on R2 — not in official docs, so staging must prove it) |
+| (c2) Proxy uploads through backend | ~$135 / ~$1,006 / **~$4,570** (corrected) | M | Rejected — pure egress waste, relocates B2's flakiness class onto your own infra. **Correction:** 50 TB egress is ~$4,394–4,403 with proper tiering, not ~$4,600 (~5% overstatement; conclusion unchanged) |
+| (c3) Worker on custom domain fronting R2 | $5/mo | L | Rejected — doesn't avoid the manifest problem, and encrypted ~100 MB parts collide with the 100 MB Worker body limit (Free/Pro zones, confirmed) |
+
+Fallback if c1's staging test fails: add `https://*.r2.cloudflarestorage.com/*` to the manifest and accept the staged-update prompt on the standalone channel — confirmed that the old version *keeps running* if the user doesn't approve (degraded adoption, zero breakage). The built-in/system add-on channel rides Thunderbird releases (ESR lags ~1 year), so **the B2 presign fallback is permanent, not transitional**.
+
+### Caveat 4 — Storage-layer refactor for per-Upload routing (r2|migrating|b2)
+
+All options are $0 recurring; differentiators are blast radius and test surface.
+
+| Option | Effort | Verdict |
+|---|---|---|
+| (a) Thread optional `location` param through FileStore | M | Optional-parameter footgun: forgotten arg silently touches B2 at the two delete sites — data-loss class |
+| (b) Provider registry: `StorageProvider` interface, one @aws-sdk/client-s3 impl for both vendors, required `location` everywhere | M | **Recommended.** Deletes real debt (12h token-renewal setInterval, directClient init race); replication worker consumes the same interface. Hard requirements: `set()` via lib-storage Upload (WS path passes client-stated size), keep the tweedegolf B2 adapter behind an env flag for one release as rollback |
+| (c) R2 staging sidecar module, FileStore untouched | S | Fallback for smallest increment; codifies asymmetry that rots if R2's role ever grows |
+
+All five load-bearing claims confirmed. **Refinements from verification:** the aws-sdk v3.729+ CRC32 checksum incompatibility needs `WHEN_REQUIRED` **only on the B2 client** — Cloudflare fixed R2 server-side on 2025-02-03 (setting it on both remains the sensible uniform choice). Prisma migration (`enum StorageLocation { b2 migrating r2 failed? }`, `@default(b2)`) is metadata-only on PG11+ — safe on the live table.
+
+---
+
+## 2. Architecture bundles
+
+R2 staging costs (Class A PUTs + ~1-day residency + Class B reads ≈ $0.55 / $5.55 / $28 per month) are part of the base #959 design and appear in every bundle. A longer R2 grace period scales that line linearly.
+
+### Bundle A — "AWS-minimal quick ship"
+In-process SKIP LOCKED poller (job-infra a) · replication through Fargate (egress a) · capability flag + CORS-only client (rollout a+c1) · R2 sidecar or provider registry (refactor c or b).
+
+| | 1 TB | 10 TB | 50 TB |
+|---|---|---|---|
+| Fixed | $0 | $0 | $0 |
+| AWS egress | ~$92 | ~$922 | ~$4,403 |
+| R2 staging | ~$0.55 | ~$5.55 | ~$28 |
+| Autoscale overflow | — | — | $0–40 |
+| **Total/mo** | **~$93** | **~$928** | **~$4,470** |
+
+**Effort:** S+S+S/M — the smallest total diff; zero new deploy surfaces, zero Pulumi changes. **Rollout:** ships fastest; replication shares CPU with the API (tail-latency risk, autoscaler cpu_threshold 80); economically untenable past a few TB/mo.
+
+### Bundle B — "Cloudflare Worker replication" (endgame)
+R2 event notifications → Queues → consumer Worker streams R2→B2, calls an HMAC-authenticated backend endpoint to flip `storageLocation` (job-infra c / egress b) · capability flag + CORS-only client (a+c1) · provider registry (refactor b).
+
+| | 1 TB | 10 TB | 50 TB |
+|---|---|---|---|
+| Workers Paid (fixed) | $5 | $5 | $5 |
+| CPU-ms / Queues overage | ~$0 | ~$0–1.50 | ~$1–10 |
+| R2 staging | ~$0.55 | ~$5.55 | ~$28 |
+| AWS egress | $0 | $0 | $0 |
+| **Total/mo** | **~$6** | **~$11–13** | **~$34–43** |
+
+**Effort:** L (Worker + Queues + event notifications + CI deploy + backend callback endpoint + secrets in a second cloud) + S client + M refactor. **Rollout:** new platform for this team, but the Pulumi stack already carries Cloudflare provider credentials (DNS). Best retry semantics of any option (at-least-once, DLQ, no polling). Must-prototype-first: fixed-length streaming PUT to B2 within the 128 MB Worker memory limit, and the event-before-row race (callback returns retryable-404, Queues redelivers).
+
+### Bundle C — "Hetzner relay" (no-second-runtime alternative)
+Tiny EU VPS pumps R2→B2, driven by a backend job API (egress c) · same client and refactor choices as B.
+
+| | 1 TB | 10 TB | 50 TB |
+|---|---|---|---|
+| Server (fixed) | ~$6.50 | ~$6.50 | ~$6.50 (+$6.50 if doubled) |
+| Traffic overage | $0 | $0 | ~$33 |
+| R2 staging | ~$0.55 | ~$5.55 | ~$28 |
+| **Total/mo** | **~$7** | **~$12** | **~$67** |
+
+**Effort:** M, plus permanent ops ownership of an out-of-band pet server. **Rollout:** matches B's economics but adds a third key-custody domain and a GDPR processor review — likely fails security review before it fails on cost. Included only as the fallback if a second *managed* runtime is vetoed.
+
+---
+
+## 3. Recommendation
+
+**Adopt Bundle B (Cloudflare Worker replication), phased through Bundle A's job code if speed-to-ship matters.**
+
+Justification:
+- **The egress line decides it.** Every AWS-resident replicator pays $0.09/GB out of eu-central-1 — ~$922/mo at 10 TB, ~$4,403/mo at 50 TB, likely exceeding the entire current hosting bill — while the Worker path moves the same bytes for a flat ~$5–15/mo. Both sides of this asymmetry were confirmed against official vendor pricing on 2026-07-06.
+- **The incremental surface is smaller than it looks.** The Cloudflare account and Pulumi provider already exist in this stack; the client change is one JSON field; the refactor (provider registry) is needed by any bundle and deletes existing tech debt.
+- **Phasing is cheap if designed for.** If the team wants #959 live before the Worker is proven: ship the in-process SKIP LOCKED poller (Bundle A) *but* implement the `storageLocation` pointer-flip as a standalone authenticated internal endpoint from day one. The copier then relocates to the Worker with zero schema or API changes when volume — and the egress bill — grows. Break-even vs the Worker's $5/mo floor is roughly 60 GB/mo of uploads; above ~1 TB/mo Bundle A is strictly worse.
+- Bundle C is dominated: similar cost to B, worse security/ops story.
+
+**Open questions a human must decide:**
+1. **Staging verification (blocking, both cheap):** (i) can a TB 140 MV2 extension PUT to `<ACCOUNT_ID>.r2.cloudflarestorage.com` with *no* manifest permission under R2 CORS `AllowedOrigins ['*']` (moz-extension:// / null Origin accepted)? (ii) does a Worker's fixed-length streamed fetch PUT succeed against B2's S3 endpoint? If (ii) fails, the Worker design needs rework (buffering is impossible at 128 MB).
+2. **Is a second production runtime (Wrangler deploys, B2 keys in Cloudflare secrets, split observability) organizationally acceptable?** This is the only real argument against Bundle B.
+3. **Expected upload volume** — below ~1 TB/mo indefinitely, Bundle A alone is defensible.
+4. **R2 grace period before delete** — staging cost scales linearly with residency (2 days ≈ 2× the $0.55/$5.55/$28 line).
+5. **EU jurisdiction bucket?** An EU-jurisdiction R2 bucket changes the hostname to `<ACCOUNT_ID>.eu.r2.cloudflarestorage.com` (affects CSP strings and the manifest fallback); decide before pinning hostnames.
+6. **Alerting** — replication backlog depth/age must page somewhere (CloudWatch group exists; Workers need their own hook). Old-client share is unmeasurable today (no version header) — accept the B2 presign path as permanent.
+7. **NAT guard-rail** — add a loud Pulumi comment: introducing a NAT gateway adds ~$104/TB to any AWS-resident replicator.
+
+---
+
+## 4. Appendix — corrected / refuted claims from fact-checking
+
+Of 31 verified claims, 30 were confirmed exactly; 1 needed correction. Nuances that adjust numbers are listed too.
+
+| # | Claim (caveat) | Verdict | Correction / nuance |
+|---|---|---|---|
+| 1 | Hetzner June 2026 price rise "~20–30%" (egress-cost) | **needs-correction** | Entry plans rose ~31–38% (CX23 €3.99→€5.49 = +38%); mid-tier up to +144–169%. The load-bearing €5.49/mo entry price, 20 TB included traffic, and €1/TB overage are exact — relay economics (~$7–67/mo) intact |
+| 2 | Backend-proxy egress at 50 TB "~$4,600/mo" (client-rollout c2) | confirmed with correction | Correct tiered figure is ~$4,394–4,403 (10 TiB @ $0.09 + 40 TiB @ $0.085) — ~5% overstatement; "pure waste" conclusion unchanged |
+| 3 | R2 wildcard `AllowedHeaders '*'` doesn't work (client-rollout c1) | confirmed, weak sourcing | Community-verified (multiple independent write-ups + Cloudflare Community), **absent from official Cloudflare docs** — covered by the mandatory staging test; enumerate `['content-type']` regardless |
+| 4 | `WHEN_REQUIRED` checksum fix cited to pingvin-share issue (storage-refactor) | confirmed, attribution fixed | That issue documents only the error; the fix belongs to the nocobase issue + AWS official docs. **Materially: R2 no longer needs the workaround at all** (Cloudflare fixed server-side 2025-02-03) — only the B2 client requires it |
+| 5 | AWS egress ~$92 at 1 TB (job-infra, egress-cost) | confirmed, minor nuance | AWS's 100 GB/mo global free DTO tier could trim ~$9 at the 1 TB scenario if unconsumed — immaterial |
+| 6 | Worker 5-min CPU cap (job-infra c) | confirmed, favorable nuance | Queue-consumer Workers get CPU limits *above* the standard cap — slightly de-risks the copier |
+| 7 | "B2 can't list moz-extension:// origins, hence the Origin-strip hack" (client-rollout) | confirmed, causal nuance | A bare `'*'` in B2 allowedOrigins matches *any* origin, so the hack wasn't the only theoretically possible approach; the stated fact (specific extension origin unlistable) is accurate and doesn't affect the R2 plan |
+
+No verification result changed any recommendation. The largest uncertainty ranges remaining are behavioral (staging tests in open question 1), not financial: every dollar figure above is anchored to official vendor pricing fetched 2026-07-06, except Worker CPU-ms per 100 MB object (estimated 10–30 ms; even a 10× miss adds only ~$2.6/mo at 50 TB).

--- a/packages/send/docs/R2StagingReplicationDesign.md
+++ b/packages/send/docs/R2StagingReplicationDesign.md
@@ -7,13 +7,17 @@ implementation approach, pending three blocking prototypes (§3, Phase 0) and th
 human decisions in §6. The option analysis and cost model behind this choice
 live in the companion note [R2StagingFeasibility.md](./R2StagingFeasibility.md).
 
-**Background.** Production uploads to Backblaze B2 fail with `UPLOAD_FAILED`
-connection stalls on long-haul client paths (e.g. Costa Rica → `eu-central-003`):
-the PUT stalls mid-transfer with no HTTP status, retries exhaust, and the upload
-hard-fails (see #959; #913 analyzes the same stall for the resumable-upload
-track). This design terminates the client PUT at Cloudflare's nearby edge (R2),
-so the fragile long-haul hop rides Cloudflare's backbone instead, then
-asynchronously replicates to B2 — which remains the serving tier.
+## Goal
+
+**Make Send uploads succeed when a direct upload to Backblaze B2 stalls and fails.** That is the entire problem this design exists to solve (#959): on long-haul client paths (e.g. Costa Rica → `eu-central-003`) the B2 PUT stalls mid-transfer with no HTTP status, retries exhaust, and the upload hard-fails as `UPLOAD_FAILED`. #913 attacks the same stall from the resumable-upload angle; this note attacks it by giving the client a nearby, more reliable place to land the bytes.
+
+The mechanism, in one sentence: a client uploads to B2 as it does today, and **only when that fails** does it re-upload to a nearby Cloudflare R2 edge; a background job then replicates that object to B2, which stays the single serving tier. Everything else in this note is machinery in service of that one sentence.
+
+### Non-goals (scope guards)
+
+- **Downloads are not changing.** B2 serves every download exactly as today. Serving a not-yet-replicated file directly from R2 is an *optional* stopgap for the brief pre-replication window — not a goal, and droppable if replication is fast enough (as raised in the #959 thread). The design keeps it behind the same provider pointer so it costs nothing to omit.
+- **This is not a general multi-cloud or redundant-storage system.** R2 holds data only transiently, only for the uploads that B2 rejected.
+- **Not resumable/chunked upload** (that is #913) and **no change to the E2E encryption model.**
 
 All platform claims (limits, behaviors, pricing) were verified against
 official vendor documentation on 2026-07-06; claims that could not be verified

--- a/packages/send/docs/R2StagingReplicationDesign.md
+++ b/packages/send/docs/R2StagingReplicationDesign.md
@@ -1,0 +1,493 @@
+# Design Note: R2 Staging → B2 Replication for Send
+
+Status: **Draft for review** — design-first deliverable for
+[thunderbird/tbpro-add-on#959](https://github.com/thunderbird/tbpro-add-on/issues/959).
+No production code changes accompany this note; it selects and specifies an
+implementation approach, pending two blocking prototypes (§3, Phase 0) and the
+human decisions in §6. The option analysis and cost model behind this choice
+live in the companion note [R2StagingFeasibility.md](./R2StagingFeasibility.md).
+
+All platform claims (limits, behaviors, pricing) were fact-checked against
+official vendor documentation on 2026-07-06; claims that could not be verified
+on paper are explicitly marked ⚠ and gated on the Phase 0 prototypes (§7).
+
+**One-paragraph summary.** Capability-flagged clients get presigned PUTs to a Cloudflare R2 staging bucket instead of Backblaze B2 (old clients keep B2 presigns forever). R2 object-create events feed a Cloudflare Queue; a consumer Worker verifies the DB row exists, streams the object R2→B2 with server-side integrity checks, calls an HMAC-authenticated backend endpoint to flip `Upload.storageLocation` from `r2` to `b2`, then enqueues a delayed grace-period delete of the R2 staging object. Downloads always presign from whichever provider the row points at. Postgres is the single source of truth; every queue message is a regenerable hint, backstopped by a backend reconciliation sweep and an R2 lifecycle rule.
+
+---
+
+## 1. Architecture overview
+
+```
+                        THUNDERBIRD ADD-ON / WEB CLIENT (Vue, packages/send/frontend + packages/addon)
+                        │
+                        │ 1. POST /api/uploads/signed {type, size, capabilities:['r2']}   (JWT cookie)
+                        ▼
+   ┌────────────────────────────────────┐
+   │ BACKEND (Express/tRPC/Prisma,      │ 2. r2Gate(uniqueHash)? → presign PUT on R2 staging
+   │ ECS Fargate eu-central-1, 2 tasks) │    else → presign PUT on B2 (permanent legacy path)
+   └────────────────────────────────────┘
+                        │ returns {id, url, bucket}
+                        ▼
+        3. client XHR PUT (E2E-encrypted ~100MB part) ──────────► R2 BUCKET send-staging-{env}  (jurisdiction=eu)
+                        │                                              │
+        4. POST /api/uploads {id, size, bucket:'r2'}                   │ 5. event notification: object-create (PutObject)
+           → createUpload(): HeadObject on R2, row created             ▼
+             with storageLocation='r2'                        QUEUE send-{env}-r2-events ──(DLQ: send-{env}-r2-dlq,
+                        ▲                                              │                     alert-and-ack consumer)
+                        │                                              ▼ push consumer, batch=1
+                        │                              ┌───────────────────────────────┐
+   6. GET  /api/internal/uploads/:id  (HMAC) ◄─────────│ COPIER WORKER                 │
+      404 → retry/orphan-ack;  'b2' → ack;  'r2' ↓     │ packages/send/copier          │
+                                                       │ R2 binding get() → digest     │
+   7. stream copy: R2 ReadableStream ──────────────────│ TransformStream →             │──► B2 BUCKET (send-{env},
+      FixedLengthStream(size) + Content-MD5 from R2    │ FixedLengthStream → aws4fetch │    s3.eu-central-003)
+      → B2 verifies MD5 server-side, size HEAD-checked │ SigV4 PUT (UNSIGNED-PAYLOAD)  │
+                                                       └───────────────────────────────┘
+   8. POST /api/internal/uploads/:id/flip (HMAC) ◄─────────────┘
+      CAS: storageLocation r2→b2 (+B2 HeadObject re-verify)
+                        │
+                        │ 9. Worker enqueues {DeleteStaged, key} → QUEUE send-{env}-r2-deletes, delaySeconds=21600 (6h)
+                        ▼
+   10. delete consumer: row=='b2'? + B2 HEAD ok? → R2 DeleteObject (staging copy gone)
+
+   DOWNLOADS (unchanged route): GET /api/download/:id/signed → presign GET from row.storageLocation
+   (R2 pre-flip — egress free; B2 post-flip)
+
+   BACKSTOPS: R2 lifecycle (delete objects @7d, abort multipart @1d)
+              backend reconciliation sweep every 15min: rows stuck 'r2' >1h → re-enqueue via Queues HTTP API
+              Sentry alert if any row stuck 'r2' >24h
+```
+
+### Component inventory
+
+| # | Component | Where | New/changed |
+|---|---|---|---|
+| 1 | Client capability flag + bucket echo | `packages/send/frontend/src/lib/{filesync,upload}.ts`, chat components | changed |
+| 2 | Backend storage provider registry (R2+B2+fs, drop tweedegolf) | `packages/send/backend/src/storage/` | rewritten |
+| 3 | Prisma `StorageLocation` enum + `migratedAt` + index | `packages/send/backend/prisma/schema.prisma:138-150` | migration |
+| 4 | `uploads/signed` gate (kill switch + % rollout) | `backend/src/routes/uploads.ts:162-178` | changed |
+| 5 | Internal HMAC router (precheck / flip / dead-letter) | `backend/src/routes/internal.ts` (new), mounted at `backend/src/index.ts:133-144` | new |
+| 6 | Location-aware downloads + dual-store delete | `backend/src/routes/download.ts`, `backend/src/models.ts:264-272`, `backend/src/models/sharing.ts:738-742` | changed |
+| 7 | Reconciliation sweep | `backend/src/jobs/reconcileStaged.ts` (new) | new |
+| 8 | Copier Worker (3 queue consumers) | `packages/send/copier/` (new pnpm workspace member) | new |
+| 9 | Cloudflare infra: bucket, CORS, lifecycle, 3 queues, notification rule | `packages/send/pulumi/cloudflare_r2.py` (new) — see §2.5 for the Pulumi-vs-wrangler decision | new |
+| 10 | CI: worker validate/deploy jobs, secrets | `.github/workflows/{validate,merge,release}.yml` | changed |
+| 11 | CSP updates (two sources of truth) | `frontend/csp.config.js` + `pulumi/config.{stage,prod}.yaml` `frontend-csp-header` | changed |
+| 12 | Sentry URL scrubbing (pre-existing leak, ship independently) | `frontend/src/lib/sentry.ts:11-31`, `backend/src/sentry.ts:30-32` | changed |
+
+---
+
+## 2. Per-component design
+
+### 2.1 Copier Worker (`packages/send/copier/`)
+
+**Runtime dependency: `aws4fetch` only** (6.4 kB; verified: when `X-Amz-Content-Sha256` is pre-set it is used verbatim and the body is never inspected, so a `ReadableStream` body flows straight to `fetch()`). No `@aws-sdk/client-s3` in the Worker — this sidesteps the v3.729+ CRC32-checksum headers that B2 rejects.
+
+**Load-bearing pipeline** (all links verified against July-2026 docs except the two marked ⚠, which are exactly what Prototype 2 tests):
+
+R2 binding `get()` → `R2ObjectBody` with `body: ReadableStream`, `size`, and `checksums.md5` (present by default for all **non-multipart** objects — our client does single presigned PUTs) → digest coupled *inside* a `TransformStream` (never `tee()`: per WHATWG spec, tee buffers the slower branch unboundedly — a 100 MB memory trap in a 128 MB isolate) → `FixedLengthStream(obj.size)` (documented: becomes `Content-Length`, avoids chunked encoding, errors on byte-count mismatch — mandatory because B2's native API rejects chunked TE ⚠ *S3-layer inheritance is inference-grade*) → `aws4fetch` SigV4 PUT with `x-amz-content-sha256: UNSIGNED-PAYLOAD` (⚠ evidenced by Backblaze's own `cloudflare-b2` sample, not B2 docs) and `Content-MD5` copied from R2's stored checksum, so **B2 itself verifies the received bytes server-side**.
+
+```ts
+// packages/send/copier/src/copy.ts — core (illustrative, carried from fact-checked design)
+const obj = await env.STAGING.get(key);
+if (!obj) return { outcome: 'gone' };                    // lifecycle beat us → ack
+const md5 = obj.checksums.md5;                           // ArrayBuffer; absent only for multipart (out-of-contract)
+const sha = new crypto.DigestStream('SHA-256');          // Workers streaming digest, no buffering
+const w = sha.getWriter();
+const body = obj.body
+  .pipeThrough(new TransformStream({
+    async transform(c, ctrl) { await w.write(c); ctrl.enqueue(c); },
+    async flush() { await w.close(); },
+  }))
+  .pipeThrough(new FixedLengthStream(obj.size));
+const b2 = new AwsClient({ accessKeyId: env.B2_APPLICATION_KEY_ID,
+  secretAccessKey: env.B2_APPLICATION_KEY, service: 's3', region: 'eu-central-003' });
+const headers: Record<string,string> = {
+  'x-amz-content-sha256': 'UNSIGNED-PAYLOAD',
+  'content-type': obj.httpMetadata?.contentType ?? 'application/octet-stream',
+};
+if (md5) headers['content-md5'] = btoa(String.fromCharCode(...new Uint8Array(md5)));
+const res = await b2.fetch(`${env.B2_ENDPOINT}/${env.B2_BUCKET}/${encodeURIComponent(key)}`,
+  { method: 'PUT', headers, body });
+if (!res.ok) throw new RetryableError(`B2 PUT ${res.status}`);
+// then: HEAD B2, assert content-length === obj.size; record hex(await sha.digest) for the flip payload
+```
+
+**Multipart fallback (first-class, not afterthought):** fact-check corollary — R2 objects uploaded via multipart have **no** `checksums.md5`. If `checksums.md5` is absent (event `action === 'CompleteMultipartUpload'`, out-of-contract client): two-pass — pass 1 pipes through `DigestStream('MD5')` only (one extra free-tier-cheap Class B read), pass 2 re-`get()`s and uploads with the computed `Content-MD5`. Log loudly.
+
+**Consumer choreography — check-first** (reconciled across angles; copy-first was rejected because abandoned uploads would waste 100 MB copies + need a B2 janitor, and security invariant I6 requires that abandoned PUTs never produce a B2 write):
+
+```ts
+// on send-{env}-r2-events message {account, action, bucket, object:{key,size,eTag}, eventTime}
+// NOTE (fact-check): delete events omit size/eTag; create events may carry copySource — parse defensively.
+const row = await hmacGet(env, `/api/internal/uploads/${key}`);
+if (row.status === 404) {
+  const age = Date.now() - Date.parse(msg.body.eventTime);
+  if (age > 24*3600e3) return msg.ack();                 // abandoned upload: no copy ever made; lifecycle purges R2
+  return msg.retry({ delaySeconds: Math.min(30 * 2 ** msg.attempts, 600) });   // event-before-row race
+}
+const { storageLocation } = await row.json();
+if (storageLocation !== 'r2') return msg.ack();          // 'b2' duplicate, or 'failed' (human-gated) → ack
+const r = await copyToB2(env, key);                      // §above; throws → retry w/ backoff
+if (r.outcome === 'gone') return msg.ack();
+const flip = await hmacPost(env, `/api/internal/uploads/${key}/flip`,
+  { from:'r2', to:'b2', size:r.size, sha256:r.sha256Hex, md5:r.md5Hex, b2ETag:r.b2ETag });
+switch (flip.status) {
+  case 200: await env.DELETE_QUEUE.send({ key }, { delaySeconds: 21600 }); return msg.ack();
+  case 410: return msg.ack();      // row deleted mid-copy: BACKEND deletes the B2 orphan (see §2.3) — worker key has no delete
+  case 409: return msg.ack();      // integrity mismatch: backend CAS'd r2→failed + Sentry; terminal-until-human
+  case 401: return msg.retry({ delaySeconds: 3600 });    // secret rotation heals in place
+  default:  return msg.retry({ delaySeconds: Math.min(30 * 2 ** msg.attempts, 10800) });
+}
+```
+
+**Grace-delete consumer** (`send-{env}-r2-deletes`): HMAC precheck says row is `b2` (row absent → ack: `deleteEverywhere` already ran) **and** B2 `HeadObject` size matches → `env.STAGING.delete(key)` (free, idempotent). Any check fails → retry. *The only destructive op in the Worker is an R2-staging delete gated on confirmed B2 presence.* Grace = 6 h: exceeds the 1 h presigned-GET expiry and a deploy/rollback cycle, comfortably under the verified 24 h `delaySeconds` cap.
+
+**DLQ (`send-{env}-r2-dlq`): alert-and-ack.** Consumer POSTs a summary to `/api/internal/dead-letter` (→ Sentry) and acks. Safe because the DB is the source of truth and the sweep (§2.3) regenerates any real work from `storageLocation='r2'` rows. Attaching a consumer also neutralizes the verified platform trap that unconsumed DLQ messages persist only 4 days.
+
+**wrangler.toml** (one script, wrangler environments; queue names frozen as API surface):
+
+```toml
+name = "send-copier"
+main = "src/index.ts"
+compatibility_date = "2026-06-01"
+[limits]
+cpu_ms = 60000                      # SHA-256 over 100MB ≈ 0.5s; queue-consumer CPU default is 30s — raise explicitly
+
+[env.prod]
+name = "send-copier-prod"
+[[env.prod.r2_buckets]]
+binding = "STAGING"
+bucket_name = "send-staging-prod"
+jurisdiction = "eu"                 # required in the binding for EU-jurisdiction buckets (verified)
+[[env.prod.queues.consumers]]
+queue = "send-prod-r2-events"
+max_batch_size = 1                  # one ~100MB copy per invocation: full 15-min wall clock, clean per-object retry
+max_retries = 25                    # + in-code exponential backoff to 3h cap ≈ 52h of coverage before DLQ
+dead_letter_queue = "send-prod-r2-dlq"
+max_concurrency = 20                # protects B2 + backend; platform allows 250
+[[env.prod.queues.consumers]]
+queue = "send-prod-r2-deletes"
+max_batch_size = 10
+max_retries = 10
+dead_letter_queue = "send-prod-r2-dlq"
+[[env.prod.queues.consumers]]
+queue = "send-prod-r2-dlq"
+max_batch_size = 10
+max_retries = 5
+[[env.prod.queues.producers]]
+binding = "DELETE_QUEUE"
+queue = "send-prod-r2-deletes"
+[env.prod.vars]
+B2_ENDPOINT = "https://s3.eu-central-003.backblazeb2.com"
+B2_BUCKET   = "tb-send-suite-prod-object-store-eu-central-1"
+BACKEND_URL = "https://send-backend.tb.pro"
+# secrets via wrangler: B2_APPLICATION_KEY_ID, B2_APPLICATION_KEY, COPIER_HMAC_SECRET
+```
+
+**Budgets (verified limits):** 128 MB isolate — streaming keeps residency at chunk granularity ⚠ *provided outbound `fetch()` doesn't buffer the request body: undocumented, Prototype 2's 150 MB case is the proof*. Wall clock 15 min/invocation vs expected 20–90 s per copy. At 50 TB/mo (~525k objects, ~0.2/s), a 100× burst drains at 20 concurrent in minutes; platform caps (5,000 msg/s, 25 GB backlog, 250 concurrency) are orders of magnitude away.
+
+### 2.2 Event plumbing (R2 → Queues)
+
+- **Notification rule:** object-create only, actions `PutObject` + `CompleteMultipartUpload`, no prefix filter (single-purpose bucket). Do **not** subscribe `CopyObject` or object-delete (our own grace delete would echo). ⚠ Docs never state that presigned PUTs fire events, nor any delivery guarantee/latency for event *generation* — Prototype 1 confirms the firing; the sweep is the correctness mechanism for loss.
+- **Retention:** set all three queues to the 14-day max (default is 4 days) so bringup ordering and long incidents never expire messages.
+- **Ordering:** Queues is verified at-least-once, explicitly non-FIFO. Fine: 1 message = 1 independent object (parts are separate `Upload` rows — `prisma/schema.prisma:146` `part Int?`), and every consumer action is idempotent or self-verifying.
+
+### 2.3 Backend
+
+**Prisma migration** (`schema.prisma:138-150`):
+
+```prisma
+enum StorageLocation { r2 b2 failed }
+model Upload {
+  // ...existing fields
+  storageLocation StorageLocation @default(b2)   // backfills every legacy row for free
+  migratedAt      DateTime?
+  @@index([storageLocation, createdAt])          // serves the sweep
+}
+```
+
+`failed` is terminal-until-human (set on flip 409 integrity mismatch): the sweep must skip poisoned rows and downloads must keep serving them from R2. No `migrating` state — the backend never observes an in-flight copy. No `attempts` column — Queues tracks attempts natively.
+
+**Provider registry** (rewrite of `backend/src/storage/index.ts`; delete `storage/s3b2.ts`, `@tweedegolf/storage-abstraction`, and the 12 h token `setInterval` at `storage/index.ts:79-87` including its `directClient` re-attach race):
+
+```ts
+// backend/src/storage/provider.ts
+export interface StorageProvider {
+  getUploadUrl(key: string, contentType: string, size: number): Promise<string>;  // presigned PUT, 1h
+  getDownloadUrl(key: string): Promise<string>;
+  set(key: string, stream: Readable, size?: number): Promise<boolean>;
+  get(key: string): Promise<Readable>;
+  length(key: string): Promise<number>;
+  del(key: string): Promise<boolean>;
+}
+export function getStorage(loc: 'r2' | 'b2' | 'failed'): StorageProvider {
+  if (process.env.STORAGE_BACKEND === 'fs') return fsProvider;      // dev/CI: everything collapses to fs
+  return loc === 'b2' ? b2 : r2;                                    // 'failed' rows still live in R2
+}
+```
+
+B2 client config **must** carry `requestChecksumCalculation: 'WHEN_REQUIRED'` and `responseChecksumValidation: 'WHEN_REQUIRED'` (AWS officially documents the v3.729+ CRC32 default; B2 rejection is field-evidenced; the setting is a no-op if B2 has since fixed it — cite `docs.aws.amazon.com/sdkref/latest/guide/feature-dataintegrity.html`, *not* the pingvin-share issue). R2 client: `endpoint = https://<acct>.eu.r2.cloudflarestorage.com` (EU jurisdiction, §6), `forcePathStyle: true` (single exact CSP entry). Note: the 2024-06-01 "B2 S3 API errors" comment at `storage/index.ts:42-43` is stale — presigning has run through B2's S3 API in prod ever since; still, prove `set/get/del` via the existing cred-gated `test/storage/backblaze.test.ts` before deleting tweedegolf.
+
+Exhaustive call-site list (from the fact-checked file plan): `routes/uploads.ts:171` (presign via registry), `routes/uploads.ts:38-45,98-105` (schema + bucket pass-through), `models/uploads.ts:28,38-48,58` (location-aware length check, persist column, `statUpload`), `routes/download.ts:20,22,75` (row lookup then provider), `models.ts:266` + `models/sharing.ts:740` (`deleteEverywhere`), `wsUploadHandler.ts:81` (`getStorage('b2').set`), storage tests rewritten to construct providers directly.
+
+**Capability gate** (`routes/uploads.ts:162-178`):
+
+```ts
+const { uniqueHash } = getDataFromAuthenticatedRequest(req);
+const wantsR2 = Array.isArray(req.body.capabilities) && req.body.capabilities.includes('r2');
+const bucket = wantsR2 && r2Gate(uniqueHash) ? 'r2' : 'b2';
+const url = await getStorage(bucket).getUploadUrl(uploadId, type, size);
+return res.json({ id: uploadId, url, bucket });
+
+function r2Gate(uniqueHash: string): boolean {
+  if (process.env.UPLOADS_R2_ENABLED !== 'true') return false;               // kill switch
+  const pct = Number(process.env.UPLOADS_R2_ROLLOUT_PERCENT ?? 100);
+  const n = parseInt(createHash('sha256').update(uniqueHash).digest('hex').slice(0, 8), 16);
+  return n % 100 < pct;
+}
+```
+
+- Old clients send no `capabilities` → B2 forever (system add-on rides Thunderbird ESR — the B2 path is **permanent**).
+- Client echoes `bucket` into `POST /api/uploads` (`createUploadSchema` gains `bucket: z.enum(['r2','b2']).default('b2')`); the echo is self-verifying — `createUpload`'s length check (`models/uploads.ts:28`) runs `getStorage(bucket).length(id)`, so a lying client fails HeadObject on the claimed provider. (Server-side re-derivation was rejected: a kill-switch flip between the two requests would strand a completed R2 PUT.)
+- **Content-Length pinning** (fixes today's quota-evasion hole: `checkStorageLimit` reads `req.body.size` defaulting to 0 — `middleware.ts:372` — and `s3b2.ts` signs no length): `/signed` now takes `size`, the presign signs `ContentLength` via `signableHeaders: new Set(['content-type','content-length'])`, and `createUpload` checks `sizeOnDisk == size` (not `>=`) for R2-era uploads. ⚠ R2's enforcement of a signed content-length on presigned PUT is documented nowhere official — Prototype 1 assertion; if refuted, keep the exact-size `createUpload` check as the enforcement point.
+
+**Internal HMAC router** (`backend/src/routes/internal.ts`, new; mounted beside the others at `index.ts:133-144`, before the 404 catch-all at `:152`, with its own `express.raw({ type: 'application/json', limit: '16kb' })` — the global `express.json` at `index.ts:54` is not byte-stable for signing — plus `express-rate-limit` on this router; the repo currently has **zero** rate limiting anywhere):
+
+Wire format: `x-tbsend-keyid`, `x-tbsend-timestamp` (unix ms), `x-tbsend-signature = hex(HMAC-SHA256(secret[keyid], `${method}\n${path}\n${timestamp}\n${sha256hex(rawBody)}`))`; reject if `|now − ts| > 300s`; compare with `crypto.timingSafeEqual`. Key-id enables two-secret zero-downtime rotation (`COPIER_HMAC_SECRET` + `_PREVIOUS`).
+
+Routes:
+- `GET /api/internal/uploads/:id` → `{ storageLocation }` or 404. (Worker precheck.)
+- `POST /api/internal/uploads/:id/flip` — the pointer flip, made **self-verifying** so a forged/replayed request can only enact the legitimate transition:
+
+```ts
+router.post('/uploads/:id/flip', requireCopierHmac, wrapAsyncHandler(async (req, res) => {
+  const { id } = req.params; const { size } = JSON.parse(req.body);
+  const upload = await prisma.upload.findUnique({ where: { id } });
+  if (!upload) {                                   // precheck saw the row → user deleted mid-copy
+    await deleteEverywhere(id);                    // backend (full B2 key) removes the fresh B2 orphan + staging
+    return res.status(410).json({});
+  }
+  const b2len = await getStorage('b2').length(id).catch(() => -1);   // independent re-verify (never trust caller)
+  if (b2len < Number(upload.size) || BigInt(size) < upload.size) {
+    await prisma.upload.updateMany({ where: { id, storageLocation: 'r2' },
+      data: { storageLocation: 'failed' } });
+    Sentry.captureMessage(`upload ${id} flip integrity mismatch`);
+    return res.status(409).json({});
+  }
+  const r = await prisma.upload.updateMany({       // atomic CAS: absorbs at-least-once duplicates & double-flip races
+    where: { id, storageLocation: 'r2' },
+    data: { storageLocation: 'b2', migratedAt: new Date() } });
+  return res.status(200).json({ status: r.count ? 'flipped' : 'already-b2' });
+}));
+```
+
+  (HMAC over Cloudflare Access service tokens / mTLS was upheld by fact-check: Access requires fronting the API through Cloudflare's proxy — the zone's DNS is on Cloudflare but traffic ingresses via CloudFront/ALB, so re-fronting is a material infra change for no gain over HMAC + self-verify.)
+- `POST /api/internal/dead-letter` → log + `Sentry.captureMessage` (Sentry wired at `index.ts:9,156`).
+
+**Ordering dependency (flagged by two angles):** `createUpload` (`models/uploads.ts:28`) must run its length check against **R2** for `bucket='r2'` uploads — at `POST /api/uploads` time the object is R2-only.
+
+**Downloads** (`routes/download.ts:61-83`): look up the row, `getStorage(row.storageLocation).getDownloadUrl(id)`. Files are downloadable the instant the PUT finishes (pre-flip GETs come from R2 — egress free); post-flip the 6 h grace makes in-flight presigned R2 GETs safe. Behavior change to flag: `/:id/signed` today presigns blindly with no DB read — unregistered ids will now 404 (tightens the surface; all real flows register first, `filesync.ts:97-99`). The `checkIdAgainstSuspiciousFiles` gate (`download.ts:66-73`) is DB-side and provider-agnostic — unchanged. (Pre-existing gap: unauthenticated `GET /api/download/:id` skips it — ticket #101, not the R2-staging design; see §6.)
+
+**Dual-store delete** — replaces `storage.del(id)` at `models.ts:266` and `models/sharing.ts:740`:
+
+```ts
+export async function deleteEverywhere(id: string): Promise<void> {
+  const results = await Promise.allSettled(
+    [...new Set([getStorage('b2'), getStorage('r2')])].map((p) => p.del(id)));
+  if (results.some((r) => r.status === 'rejected')) throw new BaseError(UPLOAD_NOT_DELETED_FROM_STORAGE);
+}
+```
+
+(S3 DeleteObject returns 204 for absent keys — no existence branching; the Set dedupes in fs mode; `UPLOAD_NOT_DELETED_FROM_STORAGE` at `errors/models.ts:26-27` keeps meaning "a provider errored".)
+
+**Reconciliation sweep** (`backend/src/jobs/reconcileStaged.ts`, `setInterval` precedent: the old token renewer): every 15 min, `findMany({ where: { storageLocation: 'r2', createdAt: { lt: now-1h } }, take: 100 })` → re-enqueue synthetic R2-event-shaped messages via the verified Queues HTTP push API (`POST /accounts/{acct}/queues/{queue_id}/messages`, Queues-Edit token — **note (fact-check): the path takes the queue UUID, not the name** — store the ID in config). Sentry alert if any row is stuck >24 h. Both Fargate tasks run it; duplicates are harmless (consumer precheck dedupes on `storageLocation`). Rejected: copying from the backend directly (public-subnet ECS → B2 traffic pays AWS DTO at $0.09/GB — the entire reason the copier lives on Cloudflare).
+
+**Sentry scrubbing (ship first, independent):** `frontend/src/lib/sentry.ts:11-31` has no `beforeBreadcrumb`/URL scrubbing while the upload XHR PUTs bearer presigned URLs (`helpers.ts:301-363`) — live 1 h upload URLs are very likely shipping to Sentry **today** with B2. Strip query strings on `r2.cloudflarestorage.com|backblazeb2.com` in `beforeBreadcrumb`/`beforeSend`, set `tracePropagationTargets`, audit replay network capture; backend `captureConsoleIntegration` (`backend/src/sentry.ts:30-32`) gets the same treatment.
+
+### 2.4 Client (`packages/send/frontend`, shared with `packages/addon`)
+
+- `filesync.ts:154-186` (`sendBlob`): send `capabilities: ['r2']` and `size`; return `{ id, bucket }`. Ripple (mechanical, must be complete — the frontend bundle ships inside the add-on): `upload.ts:217` and the bucket echo at `upload.ts:248-257`, `apps/chat/components/{Send,MessageSend}.vue`, tests `src/test/lib/{upload,filesync,filesync-fs}.test.ts`.
+- `helpers.ts` `uploadWithTracker` (`:301-363`): **no change** — it PUTs with `Content-Type: application/octet-stream`, exactly what the presign signs; the browser sets Content-Length from the Blob.
+- **CSP:** add the exact host `https://<ACCT>.eu.r2.cloudflarestorage.com` to `connect-src` in **both** `frontend/csp.config.js` and the baked `frontend-csp-header` strings in `pulumi/config.stage.yaml:8` / `config.prod.yaml:9` — one PR, both files. Keep `https://*.backblazeb2.com` forever.
+- **R2 bucket CORS:** `AllowedOrigins: ['*']` (CORS is not the auth boundary — the URL is the bearer secret, and ACAO:* forbids credentialed requests; extension `moz-extension://` origins can't be enumerated anyway), `AllowedMethods: ['PUT','GET']`, `AllowedHeaders: ['content-type']` — **enumerated, not wildcard** (⚠ "wildcard broken on R2" is community lore either way; enumeration matches the docs' own example and Prototype 1 validates it).
+- **Origin-strip hack:** expected NOT needed — the existing `webRequest` hack (`packages/addon/src/background.ts:159-178`) matches only `https://*.backblazeb2.com/*` and R2 has real per-bucket CORS. Prototype 1 is the gate. Fallback if it fails: clone the hack for `https://*.r2.cloudflarestorage.com/*` + manifest host permission, shipped in the same add-on release as the capability flag — costs a diff, not a schedule slip.
+
+### 2.5 IaC / CI / secrets
+
+**Decided split:** Pulumi owns slow-changing Cloudflare resources (bucket, CORS, lifecycle, queues, DLQ, notification rule) + backend env/secrets/CSP; **wrangler in CI** owns the Worker script, queue-consumer registration (batch/retry tuning ships with the code that depends on it), and Worker secrets.
+
+**Hard prerequisite with a gate:** `packages/send/pulumi/requirements.txt:2` pins `pulumi_cloudflare==5.48.0`, which **lacks** `R2BucketCors` / `R2BucketLifecycle` / `R2BucketEventNotification` / `QueueConsumer` (verified against SDK trees at both tags). Plan A: in-place upgrade to `>=6.17,<7` — `cloudflare.Record` survives as a deprecated alias of `DnsRecord`; migrate the two CNAMEs (`fargate.py:63-74`, `cloudfront.py:116-127`) with `pulumi.Alias`. **Gate: `pulumi preview --diff` on ci/stage must show no replaces on the DNS records** — a surprise replace of prod `send`/`send-backend` CNAMEs is an outage. Plan B (fallback, championed by the plumbing angle): keep v5, provision the new Cloudflare surface via wrangler/REST in CI (`wrangler queues create … --message-retention-period-secs 1209600`, `wrangler r2 bucket notification create …`, `wrangler r2 bucket lifecycle …`), or a separate v6-pinned Pulumi project. *This is Open Decision D2.*
+
+New module `packages/send/pulumi/cloudflare_r2.py` (v6 shapes verified: `R2Bucket{jurisdiction:'eu'}`, `R2BucketCors{rules[].allowed.{methods,origins,headers}, max_age_seconds}`, `R2BucketEventNotification{queue_id, jurisdiction, rules[].actions}` — requires Workers R2 Storage Read+Write on the provider token, **does not support `pulumi import`** — `R2BucketLifecycle`, `Queue{settings.message_retention_period}`). Every R2 resource must carry `jurisdiction='eu'`. The existing `cloudflare:apiToken` (`Pulumi.{stage,prod}.yaml:19-20`) is presumably DNS-scoped and must gain Workers R2 Storage Edit + Queues Edit.
+
+**Secrets matrix:**
+
+| Secret | Source of truth | Delivery | Consumer |
+|---|---|---|---|
+| Existing B2 key pair | Pulumi config secret | PulumiSecretsManager → AWS SM → Fargate `valueFrom` (verified pattern, `config.stage.yaml:119-121`) | backend |
+| NEW backend R2 S3 keypair (Object Read & Write, staging bucket only; access_key = token id, secret = SHA-256(token value) — verified) | Pulumi config secret | same rails | backend presigner + HeadObject |
+| NEW copier B2 key — **separate** `b2_create_key`: `writeFiles`+`readFiles`, **no `deleteFiles`, no `listFiles`**, `bucketIds` = send bucket (verified capabilities model) | GH Actions secret | `wrangler secret put` / `--secrets-file` (verified: secrets persist across deploys) | Worker |
+| NEW `COPIER_HMAC_SECRET` (+`_PREVIOUS`) | Pulumi config secret (canonical) | (a) SM→Fargate; (b) same value → GH secret → `wrangler secret put` | backend + Worker |
+| NEW `CLOUDFLARE_API_TOKEN` for CI (Workers Scripts Edit + Queues Edit) | GH Actions environment secret | `wrangler deploy` | CI |
+| NEW Queues-Edit token + queue UUIDs | Pulumi config secret → SM → Fargate | sweep's HTTP publish | backend |
+
+Fact-check correction folded in: pulumi-cloudflare v6 has **no** Worker-secret resource at all (the claimed `WorkersForPlatformsScriptSecret` does not exist in the SDK; v5's `WorkersSecret` was removed). Pulumi *could* set secrets via `WorkersScript`'s inline `secret_text` binding, but the Worker isn't Pulumi-managed here — wrangler is the decided path.
+
+Worker key compromise blast radius (why no-delete matters): confidentiality is E2E-safe regardless; without `deleteFiles` the key cannot destroy data; B2 retains prior file versions on overwrite (ensure bucket lifecycle keeps them); no `listFiles` → keys not enumerable.
+
+**CI:** Worker at `packages/send/copier` joins `pnpm-workspace.yaml`. `validate.yml`: add `worker-changed: ['packages/send/copier/**']` path filter (`validate.yml:31-42` pattern) + job running tsc, `@cloudflare/vitest-pool-workers` tests, and `wrangler deploy --dry-run`. `merge.yml`: `worker-deploy-stage` (`wrangler deploy --env stage`, environment `send-stage`), parallel to `backend-deploy-stage-aws`. `release.yml`: prod mirror behind the existing manual gate. The `iac-changed` filter already lints `packages/send/pulumi/**`.
+
+**Local dev limits (both verified, the second community-lore-confirmed):** Miniflare emulates R2 as a *binding*, not an S3 HTTP endpoint — presigned URLs can't target local R2; and local R2 writes do **not** fire event notifications into local queues. So: unit tests inject synthetic event messages into the queue handler (`{account, action:'PutObject', bucket, object:{key,size,eTag}, eventTime}`) with B2/backend mocked via fetchMock; semi-local dev = `wrangler dev` + stage B2 key + `BACKEND_URL=http://localhost:8080` against docker-compose; true E2E = stage only. Day-to-day compose dev stays on `STORAGE_BACKEND=fs`; add one MinIO service with two buckets to `compose.yml` for registry/dual-delete integration tests (both providers speak S3 — one MinIO suffices).
+
+**Cost sanity (verified anchors, 50 TB/mo tier):** Workers Paid $5/mo (10M req incl.; ~525k invocations); Queues ~3 ops/message ≈ 1.6M ops/mo ≈ $0.24 after included 1M (free tier's 10k ops/day would NOT cover this tier — Paid stands); R2 staging residency at 7-day lifecycle worst case ≈ $175/mo insurance; R2 Class A/B negligible; R2→Worker→B2 egress free both ways. Total incremental ≈ low tens of $/mo + staging storage.
+
+---
+
+## 3. Sequenced delivery plan
+
+### Phase 0 — blocking prototypes (run both in week 1, in parallel; each ≤1 day build)
+
+**P1 — MV2 extension → R2 presigned PUT (client-side gate).**
+*Question:* does the Thunderbird MV2 add-on's XHR PUT to `https://<acct>.eu.r2.cloudflarestorage.com` succeed with bucket CORS and **no** manifest host permission / Origin-strip hack?
+*Steps:* (1) create an **EU-jurisdiction** R2 bucket + CORS `{origins:['*'], methods:['PUT','GET'], headers:['content-type']}`; (2) backend-style presign (aws-sdk v3, `forcePathStyle`, sign `content-type` and `content-length`); (3) from a dev build of the add-on (no manifest changes), run the real `uploadWithTracker` path with a ~100 MB blob; (4) attach a notification rule → scratch queue → trivial consumer; (5) after PUT, pull the queue.
+*Assert:* (a) PUT 200 from the extension context, no CORS failure in console; (b) repeat from the web app origin; (c) object-create event arrives for the presigned PUT — record delivery lag; (d) PUT with Content-Length ≠ signed value → 403 `SignatureDoesNotMatch` (record result either way — undocumented behavior); (e) CORS preflight succeeds with enumerated `content-type` header.
+*Success:* a+b+c pass. *Kill/fallback:* (a) fails → ship the Origin-strip twin + manifest permission in the same add-on release (schedule impact ~zero); (c) fails → replace event trigger with backend-side enqueue at `POST /api/uploads` time (sweep code path reused; the design survives); (d) fails → enforce size only via exact-size `createUpload` check.
+
+**P2 — Worker streamed PUT to B2 (worker-side gate).**
+*Question:* can a deployed Worker `fetch()` PUT a ~100/150 MB `FixedLengthStream` body to B2's S3 endpoint without buffering into the 128 MB isolate, and does B2 verify integrity as assumed?
+*Steps:* throwaway Worker with the §2.1 pipeline verbatim behind a `GET /copy?key=` handler; R2 bucket bound as `STAGING` (seed via **presigned single PUT** — the production path, guaranteeing `checksums.md5`; use the EU bucket from P1); scratch B2 bucket in eu-central-003; run deployed (not local — local stream behavior unrepresentative).
+*Assert:* (1) copy completes at 100 MB **and 150 MB** (the >128 MB case is the memory proof), B2 HEAD length == R2 size; (2) no memory/1102 errors in `wrangler tail`; (3) wall < 5 min, record CPU; (4) `checksums.md5` present on the seeded R2 object (EU bucket); (5) **negative:** deliberately wrong `Content-MD5` → B2 rejects the PUT (400 BadDigest-class) — this is the server-side verification the design leans on, currently field-evidence-grade; (6) **negative:** `FixedLengthStream(size+1)` → local stream error, no successful request; (7) record whether B2's PutObject ETag == hex MD5 (decides keeping the secondary ETag cross-check).
+*Success:* 1–3 at both sizes, 5 passes. *Kill/fallback:* if 150 MB fails on memory (Workers buffers outbound bodies), switch to B2 S3 **multipart from the Worker** — five ~20 MB buffered parts, per-part Content-MD5 + final size check. the design survives; only the pipeline section changes.
+
+### Workstreams (PR-sized)
+
+| WS | Content | Effort | Depends on | Touches |
+|---|---|---|---|---|
+| WS1 | Sentry URL scrubbing (frontend `beforeBreadcrumb`/`beforeSend` + backend console capture) | S | nothing — **ship immediately** | `frontend/src/lib/sentry.ts`, `backend/src/sentry.ts` |
+| WS2 | Prisma migration (`StorageLocation`, `migratedAt`, index) + persist location in `createUpload` | S | — | `schema.prisma`, `models/uploads.ts:38-48` |
+| WS3 | Provider registry refactor; delete tweedegolf + `setInterval`; rewrite storage tests; MinIO in compose | M | WS2 | `storage/*`, `wsUploadHandler.ts:81`, `compose.yml`, `test/storage/*` |
+| WS4 | `uploads/signed` gate + `size` in body + Content-Length pinning + bucket echo + exact-size check | S–M | WS2, WS3, **P1(d)** | `routes/uploads.ts`, `models/uploads.ts`, `middleware.ts:372`, `.env.sample` |
+| WS5 | Internal router (HMAC middleware, precheck, flip CAS + B2 re-verify, dead-letter) + `deleteEverywhere` + location-aware downloads + rate limit | M | WS2, WS3 | `routes/internal.ts` (new), `index.ts`, `download.ts`, `models.ts`, `models/sharing.ts` |
+| WS6 | IaC: Pulumi v6 upgrade **gated by preview** (or Plan B), `cloudflare_r2.py`, queue/bucket/CORS/lifecycle/notification, CSP + Fargate env/secrets in config yamls | M | **D1 (EU jurisdiction), D2 (Pulumi path)** | `pulumi/*`, `frontend/csp.config.js` |
+| WS7 | Copier Worker: copy pipeline, 3 consumers, HMAC client, wrangler envs, vitest-pool-workers | M | **P2**, WS5 contract, WS6 (for stage deploy) | `packages/send/copier/` (new) |
+| WS8 | Reconciliation sweep + Sentry stuck-row alert + queue-UUID config | S | WS2, WS6 (queue IDs) | `backend/src/jobs/reconcileStaged.ts` (new) |
+| WS9 | Client: `sendBlob` capabilities + `{id,bucket}` ripple + chat components + frontend tests | S–M | WS4, **P1(a)** | `frontend/src/lib/*`, `apps/chat/*`; `addon/src/background.ts` only if P1 fails |
+| WS10 | CI: worker validate/deploy jobs, GH secrets, secrets runbook | S–M | WS7 scaffold | `.github/workflows/*` |
+| WS11 | E2E: MinIO-backed upload→flip(curl w/ test HMAC)→re-download; legacy-client (no capabilities) asserts B2 presign; stage canary after each worker deploy | M | WS4, WS5, WS7 | `packages/send/e2e` |
+| WS12 | Rollout: stage soak, prod `UPLOADS_R2_ENABLED=true` at `ROLLOUT_PERCENT=1→5→25→100`, DLQ-depth + stuck-row dashboards, runbook (DLQ triage, secret rotation, kill switch) | S | all | env config |
+
+**Parallelization:** Week 1: P1 ∥ P2 ∥ WS1 ∥ WS2. Then WS3→(WS4 ∥ WS5) ∥ WS6 ∥ WS7-scaffold ∥ WS10. Then WS7 ∥ WS8 ∥ WS9 ∥ WS11 → WS12. Backend track ≈ 2–3 eng-weeks; Worker ≈ 1 week; IaC/CI ≈ 1.5–2 weeks (risk-driven, code small). Roughly 5–6 engineer-weeks total across 2–3 people.
+
+---
+
+## 4. Failure modes and data-loss invariants
+
+### Invariants (each must have a test; consolidated from security + plumbing angles)
+
+- **I1 — no flip without durable copy:** `storageLocation='b2'` ⇒ a B2 object with key `id` exists whose length ≥ row size, verified twice (B2's server-side Content-MD5 check at PUT; backend HeadObject at flip). *Test: flip with missing/short B2 object → 409, row stays `r2`.*
+- **I2 — no premature staging delete:** R2 object deleted only when the row reads `b2` at delete time (re-checked immediately before delete) and B2 HEAD confirms, ≥6 h after flip. *Test: kill the flip between copy and delete → R2 object survives.*
+- **I3 — lifecycle fuse > detection + response window:** staging lifecycle N (7 d) > sweep alert (24 h) + human runway; sweep re-enqueues until day 7. *Test: config assertion in IaC review; see D3 for the 7-vs-28-day dispute.*
+- **I4 — idempotent consumer:** duplicate delivery of the same object-create message yields the same terminal state (verified: Queues is at-least-once with documented rare duplicates). *Test: deliver twice → one B2 object, one flip, both acks.*
+- **I5 — no re-copy after flip:** consumer acks any event whose row is already `b2` — also the defense against overwrite-after-copy via a leaked presigned URL re-firing object-create. *Test: PUT to staging key after flip → no B2 write.*
+- **I6 — event-before-row:** object-create precedes `POST /api/uploads`; consumer retries on 404, acks as orphan at eventTime >24 h; abandoned PUTs drain via lifecycle, **never via a B2 write** (check-first choreography). *Test: event with no row → retried then orphan-acked, zero B2 objects.*
+- **I7 — user-delete wins:** deletes go to both stores (`deleteEverywhere`); flip on a deleted row → 410 + backend deletes the B2 orphan. *Test: delete row mid-copy → no orphan in either store after grace.*
+- **I8 — double-flip race:** CAS (`updateMany where storageLocation:'r2'`) makes the loser a no-op 200. *Test: concurrent flips → exactly one transition, both 2xx.*
+- **I9 — reconciliation closes the loop:** sweep re-enqueues rows stuck `r2` >1 h (skipping `failed`), alerts >24 h; covers event loss, DLQ drops, and Postgres-restore desync. *Test: fabricate stuck rows → repaired; `failed` rows skipped.*
+
+### Failure-mode table
+
+| Failure | System behavior | Data at risk | Recovery |
+|---|---|---|---|
+| R2→Queue event never generated (guarantees undocumented) | Row stays `r2`; downloads presign from R2 — user-invisible | none | sweep re-enqueues ≥1 h; Sentry >24 h (I9) |
+| Event-before-row race (normal, seconds) | Precheck 404 → backoff retry 30 s→10 min | none | automatic (I6) |
+| Row never created (client died between PUT and `POST /uploads`) | 404 persists → orphan-ack at eventTime>24 h; nothing copied | none (orphan bytes) | R2 lifecycle @7 d (I6) |
+| B2 down 48 h | In-queue backoff 30 s→3 h over 25 retries ≈ 52 h coverage; stragglers → DLQ alert-and-ack | none (R2 holds bytes ≤7 d) | retries self-heal; sweep regenerates acked work |
+| Consumer down 48 h (bad deploy / CF incident) | Backlog grows (~35k msgs ≪ 25 GB cap); retention 14 d | none | autoscaled drain on recovery; 24 h alert fires |
+| Duplicate delivery / client re-PUT pre-flip | Precheck `b2`→ack; mid-copy duplicate overwrites same key with identical bytes; CAS idempotent | none | by design (I4/I5/I8) |
+| Mid-stream B2 failure / truncation | `FixedLengthStream` errors locally, or B2 rejects Content-MD5 → whole-object retry (streams not seekable) | none | retry w/ backoff |
+| Flip integrity mismatch (B2 shorter than row size) | 409 → CAS `r2→failed` + Sentry; downloads keep serving from R2 | none | human-gated redrive |
+| HMAC secret drift/rotation skew | 401s → long-delay retries; copies keep succeeding; flips stall; downloads unaffected (rows still `r2`) | none | dual-secret acceptance; DLQ depth = pager |
+| User deletes mid-copy | Flip 410 → backend `deleteEverywhere` removes B2 orphan | GDPR exposure if unhandled | I7 |
+| Flip ok but grace-delete message lost | R2 object lingers ≤7 d | none (B2 verified) | lifecycle backstop |
+| Grace delete fires against a bad state | Delete consumer re-verifies row==`b2` + B2 HEAD before the only destructive op | none | I2 |
+| Uncopied object reaches lifecycle day 7 | **The one true data-loss path** — requires ~6 days of ignored Sentry alerts | loss | I3 + alerting SLA (D3) |
+| Postgres restored to older snapshot (row says `b2`, delete already ran / row says `r2`, object gone) | desync | possible dangling pointers | sweep spot-checks + I3 margin; document RPO in runbook |
+
+---
+
+## 5. Risk register (top 10)
+
+| # | Risk | L×I | Mitigation | Owner |
+|---|---|---|---|---|
+| 1 | Workers outbound `fetch()` buffers the streamed body → 100 MB copy impossible in 128 MB isolate | L-M × H | **P2** (150 MB case is decisive); contingency: B2 multipart in ~20 MB buffered parts — pipeline-only change | worker |
+| 2 | MV2 extension PUT to R2 blocked (CORS/Origin behavior) | M × H | **P1**; fallback Origin-strip twin + manifest permission in same add-on release | client |
+| 3 | Presigned bearer URLs leaking to Sentry (happening **today** with B2) | H × M-H | WS1 scrubbing, ship before the R2-staging design; replay-policy audit | client + backend |
+| 4 | Pulumi v5→v6 upgrade produces destructive diff on prod DNS CNAMEs | M × H | `pulumi preview --diff` gate on ci/stage; `pulumi.Alias`; Plan B (wrangler provisioning / separate project) | infra |
+| 5 | Copy-pipeline data loss (flip-before-verify, premature delete, lifecycle vs outage) | M × H | invariants I1–I3, I9 with tests; delete gated on double verification | worker + backend |
+| 6 | CSP dual-source drift (csp.config.js vs pulumi yaml) silently blocks gated users' PUTs | M × H | single PR touching both; stage e2e; 1–5% initial rollout + kill switch | client + infra |
+| 7 | B2 write-path surprises when replacing tweedegolf native API with aws-sdk S3 (`WHEN_REQUIRED` lore; stale 2024 comment) | M × M | cred-gated live B2 test suite must pass before tweedegolf removal; keep `WHEN_REQUIRED` (no-op if fixed) | backend |
+| 8 | HMAC secret drift between Worker (GH secret) and backend (Pulumi/SM) → silent flip stall | M × M | dual-secret acceptance; stage canary exercising callback after each worker deploy; DLQ-depth alert | infra |
+| 9 | R2 event generation loss / undocumented delivery guarantees | L × M | sweep is the correctness mechanism (not an optimization); 24 h alert; P1 measures real lag | backend |
+| 10 | Worker B2 key compromise corrupts served objects | L × H | key has no `deleteFiles`/`listFiles`, bucket-scoped; B2 file versioning retained as undo; E2E encryption preserves confidentiality regardless | infra |
+
+Honorable mentions: quota evasion via unsigned Content-Length (pre-existing; fixed by WS4, enforcement mechanism gated on P1(d)); event-before-row DLQ noise (L×H likelihood but zero-cost by design); Queues delaySeconds cap ambiguity (resolved — verified 24 h; 6 h grace is safe).
+
+---
+
+## 6. Open decisions for humans
+
+| ID | Decision | Options / recommendation | Blocks |
+|---|---|---|---|
+| **D1** | **EU jurisdiction for the staging bucket** (immutable at creation; changes endpoint to `<acct>.eu.r2.cloudflarestorage.com`, CSP string, all IaC `jurisdiction` params; legal posture for a GDPR-sensitive product) | Recommend `eu` from day one (B2 is eu-central-003). Note: Queues/Workers are global — object bytes transit the Worker; state this in the privacy review | **WS6, and ideally P1/P2** (prototype against the real endpoint) |
+| **D2** | **Pulumi v6 in-place upgrade vs wrangler-provisioned Cloudflare surface** (two angles disagreed) | Recommend attempting v6 gated on a clean `preview --diff`; fall back to wrangler-in-CI. Either way the Worker deploys via wrangler | **WS6** |
+| **D3** | **Lifecycle fuse N + grace period** | Decided defaults: N=7 d, grace 6 h. Security angle argued N=28 d (> 14 d queue retention + backup-restore window; ~+$175→ balance vs cost at 50 TB/mo). Ops must pair N=7 with a committed 24 h-alert response SLA, or pick 28 | WS6 config only |
+| **D4** | Cloudflare DPA / subprocessor list / privacy-policy update (Cloudflare transiently holds E2E-encrypted content ≤N days; metadata = uuid keys, sizes, timestamps) | Legal/MZLA; engineering not blocked but **prod rollout (WS12) is** | WS12 |
+| **D5** | One Cloudflare account for stage+prod? Workers Paid enabled? (bucket names are account-global; Queues free tier can't cover the 50 TB tier) | Confirm before WS6 naming | WS6 |
+| **D6** | Rollout gate default when `UPLOADS_R2_ROLLOUT_PERCENT` unset (design: 100, behind kill switch) + rollout schedule | Ops preference | WS12 |
+| **D7** | Flip-409 policy: `failed` enum state + Sentry (decided) — does ops also want quarantine/suspicious-file marking or an attempts/lastError column? | Default: enum only | none |
+| **D8** | DLQ/stuck-row alerting surface: Cloudflare-side queue-depth alerting is a new monitoring surface (no CloudWatch equivalent in `tb_pulumi.cloudwatch`); plus who owns weekly DLQ triage | Ops runbook decision | WS12 |
+| **D9** | Sentry session replay on upload/download screens at all (signed URLs in network activity)? | Recommend disabling replay network capture for storage hosts | WS1 scope |
+| **D10** | Close pre-existing gaps opportunistically? (a) unauthenticated direct-stream `GET /api/download/:id` skipping the suspicious-file check (ticket #101) — the registry refactor touches this file anyway; (b) repo-wide absence of rate limiting (the R2-staging design adds it only on the internal router) | Recommend yes to (a) | none |
+| **D11** | R2 S3-credential automation: attempt `cloudflare.ApiToken`-based generation (EU permission-group naming under-documented) vs documented one-time dashboard token per env (like the existing manual B2 key step, `pulumi/README.md:54-55`) | Recommend manual + runbook now, automate later | WS6 (minor) |
+
+---
+
+## 7. Appendix — fact-check ledger
+
+### Corrected claims (design uses the corrected reality)
+
+| Claim as originally made | Correction |
+|---|---|
+| Backblaze's `cloudflare-b2` sample sets `UNSIGNED-PAYLOAD` unconditionally | It's the *default path* (only when the header isn't in ALLOWED_HEADERS). B2's acceptance of UNSIGNED-PAYLOAD is sample-code-grade evidence → P2 asserts it |
+| B2 S3 docs show Content-MD5 support/enforcement | The s3-put-object page never mentions Content-MD5; enforcement is field-evidence-grade (Object Lock runtime error, sftpgo #1336) → **P2 assertion 5 (wrong-MD5 → 400) is mandatory, not optional** |
+| `WHEN_REQUIRED` fix documented in pingvin-share #798 | #798 documents only the breakage. Cite AWS's official reference: `docs.aws.amazon.com/sdkref/latest/guide/feature-dataintegrity.html` (+ v3.729.0 release notes) |
+| v6 has `WorkersForPlatformsScriptSecret` for Worker secrets | **Refuted:** v6.17.0 ships *no* secret resource of any kind (v5's `WorkersSecret` was removed). Alternatives: `WorkersScript.secret_text` inline binding (value in Pulumi state; drift behavior untested) or wrangler — design uses wrangler |
+| Queues requires Workers Paid | Stale: free tier exists (10k ops/day hard cap) — insufficient at the 50 TB tier (~52k ops/day at ~3 ops/message), so Paid remains the planning assumption; dev/stage could run free |
+| workers-sdk #5514 (EU event notifications) needs wrangler v4+ | Fixed **platform-side** Nov 2024 (aligned with the 2024-10-21 R2 release note); no wrangler version requirement — and the rule is IaC-configured anyway |
+| Only Logpush excluded on jurisdiction buckets | Super Slurper is also excluded (neither is used) |
+| Queues delaySeconds cap 12 h (older docs) | Verified **24 h** — 6 h grace delete is comfortably legal |
+| Consumer concurrency "GA'd Sep 2024" | Conflated: Sep 2024 was Queues' own GA (raised concurrency to 250, throughput to 5,000 msg/s). Net capability as claimed |
+| `signQuery` signs only host by default | aws4fetch-specific; the repo presigns with `@aws-sdk/s3-request-presigner`, which signs headers set on the command (Content-Type is signed today, `s3b2.ts:32-41`) |
+| At-least-once cited from batching-retries page | Lives at `queues/reference/delivery-guarantees/` (facts correct) |
+
+### Unverifiable-on-paper claims → prototype gates
+
+| Claim | Grade | Gate |
+|---|---|---|
+| Workers outbound `fetch()` streams (doesn't buffer) a fixed-length request body | undocumented platform behavior | **P2** assertions 1–2 @150 MB (the decisive test) |
+| B2's S3 layer rejects chunked transfer encoding (inherited from native API) | inference from native docs | P2 (FixedLengthStream costs nothing regardless) |
+| B2 single-part S3 ETag == hex MD5 | doc example only (32-hex shown); community reports quoting quirks | P2 assertion 7 — record; drop the secondary ETag check if unreliable |
+| Presigned S3 PUT fires an R2 `PutObject` event | docs list actions, never mention presigned URLs | **P1** assertion (c); fallback: backend-side enqueue |
+| R2 event *generation* delivery guarantees / latency | entirely undocumented | sweep is load-bearing by design; P1 measures lag |
+| R2 enforces a signed `Content-Length` on presigned PUT (quota fix) | documented nowhere official (Content-Type analog is documented) | **P1** assertion (d); fallback: exact-size `createUpload` check |
+| MV2 extension PUT to R2 S3 host without manifest permission works under CORS `['*']` | untested | **P1** assertions (a)(e) |
+| Wildcard `AllowedHeaders` broken on R2 | community lore either way | design enumerates `['content-type']` (matches docs' example); P1 validates |
+| B2 accepts `x-amz-checksum-*` since ~July 2025 (could drop `WHEN_REQUIRED`) | Backblaze evangelist forum comment, no release note | keep `WHEN_REQUIRED` (documented no-op-if-fixed); optionally test live |
+| Local R2 writes don't fire event notifications into local queues | community-confirmed gap, docs silent | accepted; test strategy designed around it (synthetic events + stage E2E) |
+| `cloudflare.ApiToken` can mint bucket-scoped R2 S3 creds for an EU bucket | permission-group naming under-documented | 30-min spike or D11 manual fallback |
+| `checksums.md5` present on EU-jurisdiction bucket objects via presigned PUT | documented for non-multipart generally; EU path less traveled | P2 assertion 4 (seed via presigned PUT on EU bucket) |
+
+### Implementation footnotes surfaced by verification (easy to lose, all incorporated above)
+
+Queues HTTP publish addresses queues by **UUID**, not name (sweep config). DLQ 4-day persistence applies only without an active consumer (ours has one). R2 delete events omit `size`/`eTag`; create events may include `copySource` (defensive parsing). Multipart-uploaded R2 objects have **no** `checksums.md5` (two-pass fallback is first-class). Queue-consumer CPU default is 30 s — `cpu_ms` raised explicitly. `R2BucketEventNotification` does not support `pulumi import`. Free-plan Queues retention is fixed at 24 h (irrelevant on Paid).

--- a/packages/send/docs/R2StagingReplicationDesign.md
+++ b/packages/send/docs/R2StagingReplicationDesign.md
@@ -3,15 +3,23 @@
 Status: **Draft for review** — design-first deliverable for
 [thunderbird/tbpro-add-on#959](https://github.com/thunderbird/tbpro-add-on/issues/959).
 No production code changes accompany this note; it selects and specifies an
-implementation approach, pending two blocking prototypes (§3, Phase 0) and the
+implementation approach, pending three blocking prototypes (§3, Phase 0) and the
 human decisions in §6. The option analysis and cost model behind this choice
 live in the companion note [R2StagingFeasibility.md](./R2StagingFeasibility.md).
 
-All platform claims (limits, behaviors, pricing) were fact-checked against
+**Background.** Production uploads to Backblaze B2 fail with `UPLOAD_FAILED`
+connection stalls on long-haul client paths (e.g. Costa Rica → `eu-central-003`):
+the PUT stalls mid-transfer with no HTTP status, retries exhaust, and the upload
+hard-fails (see #959; #913 analyzes the same stall for the resumable-upload
+track). This design terminates the client PUT at Cloudflare's nearby edge (R2),
+so the fragile long-haul hop rides Cloudflare's backbone instead, then
+asynchronously replicates to B2 — which remains the serving tier.
+
+All platform claims (limits, behaviors, pricing) were verified against
 official vendor documentation on 2026-07-06; claims that could not be verified
 on paper are explicitly marked ⚠ and gated on the Phase 0 prototypes (§7).
 
-**One-paragraph summary.** Capability-flagged clients get presigned PUTs to a Cloudflare R2 staging bucket instead of Backblaze B2 (old clients keep B2 presigns forever). R2 object-create events feed a Cloudflare Queue; a consumer Worker verifies the DB row exists, streams the object R2→B2 with server-side integrity checks, calls an HMAC-authenticated backend endpoint to flip `Upload.storageLocation` from `r2` to `b2`, then enqueues a delayed grace-period delete of the R2 staging object. Downloads always presign from whichever provider the row points at. Postgres is the single source of truth; every queue message is a regenerable hint, backstopped by a backend reconciliation sweep and an R2 lifecycle rule.
+**One-paragraph summary.** Uploads stay **B2-first**: the client PUTs to the B2 presigned URL as today, and only after its existing retry budget fails does it request an R2 presigned URL and retry there (per maintainer direction on #959 — this proves R2 resolves B2 failures with a built-in per-upload control, keeps the majority of traffic on the direct path, and cuts R2 volume/cost to the failing fraction; the server-side gate can widen to region-based or full R2 routing later if the data supports it). Objects that land in R2 replicate **push-fashion, immediately**: the R2 object-create event feeds a Cloudflare Queue; a consumer Worker verifies the DB row exists, streams the object R2→B2 with server-side integrity checks, calls an HMAC-authenticated backend endpoint to flip `Upload.storageLocation` from `r2` to `b2`, then enqueues a short grace-period delete of the staging object. Expected R2 residency is **minutes** (copy latency + 1 h grace) — the multi-day lifecycle rule is an orphan fuse, not the normal path. Downloads presign from whichever provider the row points at. Postgres is the single source of truth; every queue message is a regenerable hint, backstopped by a backend reconciliation sweep and the lifecycle rule.
 
 ---
 
@@ -20,11 +28,12 @@ on paper are explicitly marked ⚠ and gated on the Phase 0 prototypes (§7).
 ```
                         THUNDERBIRD ADD-ON / WEB CLIENT (Vue, packages/send/frontend + packages/addon)
                         │
-                        │ 1. POST /api/uploads/signed {type, size, capabilities:['r2']}   (JWT cookie)
+                        │ 0. PUT to B2 presigned URL (today's path). On retry-budget exhaustion only:
+                        │ 1. POST /api/uploads/signed {type, size, capabilities:['r2'], fallback:true}
                         ▼
    ┌────────────────────────────────────┐
    │ BACKEND (Express/tRPC/Prisma,      │ 2. r2Gate(uniqueHash)? → presign PUT on R2 staging
-   │ ECS Fargate eu-central-1, 2 tasks) │    else → presign PUT on B2 (permanent legacy path)
+   │ ECS Fargate eu-central-1, 2 tasks) │    else → presign PUT on B2 (also the permanent old-client path)
    └────────────────────────────────────┘
                         │ returns {id, url, bucket}
                         ▼
@@ -38,15 +47,15 @@ on paper are explicitly marked ⚠ and gated on the Phase 0 prototypes (§7).
                         │                              ┌───────────────────────────────┐
    6. GET  /api/internal/uploads/:id  (HMAC) ◄─────────│ COPIER WORKER                 │
       404 → retry/orphan-ack;  'b2' → ack;  'r2' ↓     │ packages/send/copier          │
-                                                       │ R2 binding get() → digest     │
-   7. stream copy: R2 ReadableStream ──────────────────│ TransformStream →             │──► B2 BUCKET (send-{env},
-      FixedLengthStream(size) + Content-MD5 from R2    │ FixedLengthStream → aws4fetch │    s3.eu-central-003)
+                                                       │ R2 binding get() →            │
+   7. stream copy: R2 ReadableStream ──────────────────│ FixedLengthStream →           │──► B2 BUCKET (send-{env},
+      FixedLengthStream(size) + Content-MD5 from R2    │ aws4fetch (retries: 0)        │    s3.eu-central-003)
       → B2 verifies MD5 server-side, size HEAD-checked │ SigV4 PUT (UNSIGNED-PAYLOAD)  │
                                                        └───────────────────────────────┘
    8. POST /api/internal/uploads/:id/flip (HMAC) ◄─────────────┘
       CAS: storageLocation r2→b2 (+B2 HeadObject re-verify)
                         │
-                        │ 9. Worker enqueues {DeleteStaged, key} → QUEUE send-{env}-r2-deletes, delaySeconds=21600 (6h)
+                        │ 9. Worker enqueues {DeleteStaged, key} → QUEUE send-{env}-r2-deletes, delaySeconds=3600 (1h)
                         ▼
    10. delete consumer: row=='b2'? + B2 HEAD ok? → R2 DeleteObject (staging copy gone)
 
@@ -73,7 +82,7 @@ on paper are explicitly marked ⚠ and gated on the Phase 0 prototypes (§7).
 | 9 | Cloudflare infra: bucket, CORS, lifecycle, 3 queues, notification rule | `packages/send/pulumi/cloudflare_r2.py` (new) — see §2.5 for the Pulumi-vs-wrangler decision | new |
 | 10 | CI: worker validate/deploy jobs, secrets | `.github/workflows/{validate,merge,release}.yml` | changed |
 | 11 | CSP updates (two sources of truth) | `frontend/csp.config.js` + `pulumi/config.{stage,prod}.yaml` `frontend-csp-header` | changed |
-| 12 | Sentry URL scrubbing (pre-existing leak, ship independently) | `frontend/src/lib/sentry.ts:11-31`, `backend/src/sentry.ts:30-32` | changed |
+| 12 | Sentry URL scrubbing (bearer presigned URLs must never reach telemetry — ship first, independently) | `frontend/src/lib/sentry.ts:11-31`, `backend/src/sentry.ts:30-32` | changed |
 
 ---
 
@@ -81,27 +90,21 @@ on paper are explicitly marked ⚠ and gated on the Phase 0 prototypes (§7).
 
 ### 2.1 Copier Worker (`packages/send/copier/`)
 
-**Runtime dependency: `aws4fetch` only** (6.4 kB; verified: when `X-Amz-Content-Sha256` is pre-set it is used verbatim and the body is never inspected, so a `ReadableStream` body flows straight to `fetch()`). No `@aws-sdk/client-s3` in the Worker — this sidesteps the v3.729+ CRC32-checksum headers that B2 rejects.
+**Runtime dependency: `aws4fetch` only** (6.4 kB; verified: when `X-Amz-Content-Sha256` is pre-set it is used verbatim and the body is never inspected, so a `ReadableStream` body flows straight to `fetch()`). No `@aws-sdk/client-s3` in the Worker — this sidesteps the v3.729+ CRC32-checksum headers that B2 rejects. One sharp edge: **`AwsClient` defaults to `retries: 10`**, and an internal retry would re-send an already-consumed `ReadableStream` (surfacing as an opaque `TypeError` on the first transient B2 5xx/429). Construct with `retries: 0` — the queue is the retry mechanism.
 
 **Load-bearing pipeline** (all links verified against July-2026 docs except the two marked ⚠, which are exactly what Prototype 2 tests):
 
-R2 binding `get()` → `R2ObjectBody` with `body: ReadableStream`, `size`, and `checksums.md5` (present by default for all **non-multipart** objects — our client does single presigned PUTs) → digest coupled *inside* a `TransformStream` (never `tee()`: per WHATWG spec, tee buffers the slower branch unboundedly — a 100 MB memory trap in a 128 MB isolate) → `FixedLengthStream(obj.size)` (documented: becomes `Content-Length`, avoids chunked encoding, errors on byte-count mismatch — mandatory because B2's native API rejects chunked TE ⚠ *S3-layer inheritance is inference-grade*) → `aws4fetch` SigV4 PUT with `x-amz-content-sha256: UNSIGNED-PAYLOAD` (⚠ evidenced by Backblaze's own `cloudflare-b2` sample, not B2 docs) and `Content-MD5` copied from R2's stored checksum, so **B2 itself verifies the received bytes server-side**.
+R2 binding `get()` → `R2ObjectBody` with `body: ReadableStream`, `size`, and `checksums.md5` (present by default for all **non-multipart** objects — our client does single presigned PUTs) → `FixedLengthStream(obj.size)` (documented: becomes `Content-Length`, avoids chunked encoding, errors on byte-count mismatch — mandatory because B2's native API rejects chunked TE ⚠ *S3-layer inheritance is inference-grade*) → `aws4fetch` SigV4 PUT (`retries: 0`) with `x-amz-content-sha256: UNSIGNED-PAYLOAD` (production's own presigned PUTs already run UNSIGNED-PAYLOAD in the query form; P2 asserts the header form) and `Content-MD5` copied from R2's stored checksum, so **B2 itself verifies the received bytes server-side**; the same MD5 travels to the flip payload for the backend's independent ETag comparison. There is no digesting in the hot path — integrity rides R2's stored checksum plus B2's server-side verification — and never `tee()` a 100 MB stream in a 128 MB isolate (per WHATWG spec, tee buffers the slower branch unboundedly); the multipart fallback's pass-1 digest pipes through `DigestStream` alone.
 
 ```ts
-// packages/send/copier/src/copy.ts — core (illustrative, carried from fact-checked design)
+// packages/send/copier/src/copy.ts — core (illustrative)
 const obj = await env.STAGING.get(key);
-if (!obj) return { outcome: 'gone' };                    // lifecycle beat us → ack
+if (!obj) return { outcome: 'gone' };                    // choreography decides: heal, or terminal-fail (see below)
 const md5 = obj.checksums.md5;                           // ArrayBuffer; absent only for multipart (out-of-contract)
-const sha = new crypto.DigestStream('SHA-256');          // Workers streaming digest, no buffering
-const w = sha.getWriter();
-const body = obj.body
-  .pipeThrough(new TransformStream({
-    async transform(c, ctrl) { await w.write(c); ctrl.enqueue(c); },
-    async flush() { await w.close(); },
-  }))
-  .pipeThrough(new FixedLengthStream(obj.size));
+const body = obj.body.pipeThrough(new FixedLengthStream(obj.size));
 const b2 = new AwsClient({ accessKeyId: env.B2_APPLICATION_KEY_ID,
-  secretAccessKey: env.B2_APPLICATION_KEY, service: 's3', region: 'eu-central-003' });
+  secretAccessKey: env.B2_APPLICATION_KEY, service: 's3', region: 'eu-central-003',
+  retries: 0 });                                         // default 10 would re-send a consumed stream; the queue owns retries
 const headers: Record<string,string> = {
   'x-amz-content-sha256': 'UNSIGNED-PAYLOAD',
   'content-type': obj.httpMetadata?.contentType ?? 'application/octet-stream',
@@ -110,38 +113,52 @@ if (md5) headers['content-md5'] = btoa(String.fromCharCode(...new Uint8Array(md5
 const res = await b2.fetch(`${env.B2_ENDPOINT}/${env.B2_BUCKET}/${encodeURIComponent(key)}`,
   { method: 'PUT', headers, body });
 if (!res.ok) throw new RetryableError(`B2 PUT ${res.status}`);
-// then: HEAD B2, assert content-length === obj.size; record hex(await sha.digest) for the flip payload
+// then: HEAD B2, assert content-length === obj.size; pass hex(md5) + B2's PutObject ETag in the flip payload
 ```
 
-**Multipart fallback (first-class, not afterthought):** fact-check corollary — R2 objects uploaded via multipart have **no** `checksums.md5`. If `checksums.md5` is absent (event `action === 'CompleteMultipartUpload'`, out-of-contract client): two-pass — pass 1 pipes through `DigestStream('MD5')` only (one extra free-tier-cheap Class B read), pass 2 re-`get()`s and uploads with the computed `Content-MD5`. Log loudly.
+**Multipart fallback (first-class, not afterthought):** verified corollary — R2 objects uploaded via multipart have **no** `checksums.md5`. If `checksums.md5` is absent (event `action === 'CompleteMultipartUpload'`, out-of-contract client): two-pass — pass 1 pipes through `DigestStream('MD5')` only (one extra free-tier-cheap Class B read), pass 2 re-`get()`s and uploads with the computed `Content-MD5`. Log loudly.
 
-**Consumer choreography — check-first** (reconciled across angles; copy-first was rejected because abandoned uploads would waste 100 MB copies + need a B2 janitor, and security invariant I6 requires that abandoned PUTs never produce a B2 write):
+**Consumer choreography — check-first** (copy-first was rejected because abandoned uploads would waste 100 MB copies + need a B2 janitor, and invariant I6 requires that abandoned PUTs never produce a *lasting* B2 write). Two paths are deliberately B2-aware: the aged-404 path must not assume "no copy was ever made" (a prior attempt may have completed the B2 PUT and died before the flip — acking blind would strand a permanent B2 orphan of a possibly-deleted file), and the `'gone'` path must not ack without a terminal state (post-restore desync would otherwise livelock the sweep):
 
 ```ts
 // on send-{env}-r2-events message {account, action, bucket, object:{key,size,eTag}, eventTime}
-// NOTE (fact-check): delete events omit size/eTag; create events may carry copySource — parse defensively.
+// NOTE: delete events omit size/eTag; create events may carry copySource — parse defensively.
 const row = await hmacGet(env, `/api/internal/uploads/${key}`);
 if (row.status === 404) {
   const age = Date.now() - Date.parse(msg.body.eventTime);
-  if (age > 24*3600e3) return msg.ack();                 // abandoned upload: no copy ever made; lifecycle purges R2
-  return msg.retry({ delaySeconds: Math.min(30 * 2 ** msg.attempts, 600) });   // event-before-row race
-}
+  if (age > 24*3600e3) {                                 // abandoned upload — but never assume "no copy was made":
+    await hmacPost(env, '/api/internal/dead-letter',     //   backend HEADs B2 and deleteEverywhere()s any orphan a
+      { key, reason: 'aged-404' });                      //   died-mid-flip attempt left behind (worker key can't delete)
+    return msg.ack();                                    // R2 side drains via lifecycle
+  }
+  return msg.retry({ delaySeconds: Math.min(30 * 2 ** msg.attempts, 7200) });   // event-before-row race;
+}                                                        // 2h cap keeps the 24h branch reachable inside max_retries=25
 const { storageLocation } = await row.json();
 if (storageLocation !== 'r2') return msg.ack();          // 'b2' duplicate, or 'failed' (human-gated) → ack
 const r = await copyToB2(env, key);                      // §above; throws → retry w/ backoff
-if (r.outcome === 'gone') return msg.ack();
+if (r.outcome === 'gone') {                              // row says 'r2' but staging object is missing:
+  const b2 = await headB2(env, key);
+  if (b2.ok) {                                           //   durable copy already exists (e.g. Postgres restored to a
+    await hmacPost(env, `/api/internal/uploads/${key}/flip`, { md5: null });   // pre-flip snapshot) → auto-heal
+    return msg.ack();
+  }
+  await hmacPost(env, '/api/internal/dead-letter',       //   truly gone: backend CAS r2→failed + Sentry — a terminal
+    { key, reason: 'staging-gone' });                    //   state, so the sweep stops re-enqueueing (no livelock)
+  return msg.ack();
+}
 const flip = await hmacPost(env, `/api/internal/uploads/${key}/flip`,
-  { from:'r2', to:'b2', size:r.size, sha256:r.sha256Hex, md5:r.md5Hex, b2ETag:r.b2ETag });
+  { from:'r2', to:'b2', size:r.size, md5:r.md5Hex, b2ETag:r.b2ETag });
 switch (flip.status) {
-  case 200: await env.DELETE_QUEUE.send({ key }, { delaySeconds: 21600 }); return msg.ack();
+  case 200: await env.DELETE_QUEUE.send({ key }, { delaySeconds: 3600 }); return msg.ack();
   case 410: return msg.ack();      // row deleted mid-copy: BACKEND deletes the B2 orphan (see §2.3) — worker key has no delete
-  case 409: return msg.ack();      // integrity mismatch: backend CAS'd r2→failed + Sentry; terminal-until-human
+  case 409: return msg.ack();      // CONFIRMED short/corrupt copy: backend CAS'd r2→failed + recurring Sentry alerts
+  case 503: return msg.retry({ delaySeconds: 600 });     // backend could not VERIFY (transient B2 HEAD failure) — row stays 'r2'
   case 401: return msg.retry({ delaySeconds: 3600 });    // secret rotation heals in place
   default:  return msg.retry({ delaySeconds: Math.min(30 * 2 ** msg.attempts, 10800) });
 }
 ```
 
-**Grace-delete consumer** (`send-{env}-r2-deletes`): HMAC precheck says row is `b2` (row absent → ack: `deleteEverywhere` already ran) **and** B2 `HeadObject` size matches → `env.STAGING.delete(key)` (free, idempotent). Any check fails → retry. *The only destructive op in the Worker is an R2-staging delete gated on confirmed B2 presence.* Grace = 6 h: exceeds the 1 h presigned-GET expiry and a deploy/rollback cycle, comfortably under the verified 24 h `delaySeconds` cap.
+**Grace-delete consumer** (`send-{env}-r2-deletes`): HMAC precheck says row is `b2` (row absent → ack: `deleteEverywhere` already ran) **and** B2 `HeadObject` size matches → `env.STAGING.delete(key)` (free, idempotent). Any check fails → retry. *The only destructive op in the Worker is an R2-staging delete gated on confirmed B2 presence.* Grace = 1 h: the floor is the 1 h presigned-GET expiry (an R2 GET presigned an instant before the flip must outlive the delete), and maintainer direction on #959 is to keep Cloudflare residency to minutes — so the grace sits exactly at that floor. Comfortably under the verified 24 h `delaySeconds` cap.
 
 **DLQ (`send-{env}-r2-dlq`): alert-and-ack.** Consumer POSTs a summary to `/api/internal/dead-letter` (→ Sentry) and acks. Safe because the DB is the source of truth and the sweep (§2.3) regenerates any real work from `storageLocation='r2'` rows. Attaching a consumer also neutralizes the verified platform trap that unconsumed DLQ messages persist only 4 days.
 
@@ -180,7 +197,7 @@ binding = "DELETE_QUEUE"
 queue = "send-prod-r2-deletes"
 [env.prod.vars]
 B2_ENDPOINT = "https://s3.eu-central-003.backblazeb2.com"
-B2_BUCKET   = "tb-send-suite-prod-object-store-eu-central-1"
+B2_BUCKET   = "<prod B2 bucket — from pulumi config>"
 BACKEND_URL = "https://send-backend.tb.pro"
 # secrets via wrangler: B2_APPLICATION_KEY_ID, B2_APPLICATION_KEY, COPIER_HMAC_SECRET
 ```
@@ -207,7 +224,9 @@ model Upload {
 }
 ```
 
-`failed` is terminal-until-human (set on flip 409 integrity mismatch): the sweep must skip poisoned rows and downloads must keep serving them from R2. No `migrating` state — the backend never observes an in-flight copy. No `attempts` column — Queues tracks attempts natively.
+`failed` marks a **confirmed** integrity problem only (backend-verified short/corrupt/missing B2 copy) — a transient verification error (e.g. a momentary B2 HEAD failure) returns 503 and leaves the row `r2` so the queue retries; it must never poison a row. `failed` rows keep serving downloads from R2, are excluded from the sweep's re-enqueue, and **re-alert on a recurring schedule** until a human redrives or deletes them — a `failed` row silently aging into the staging-lifecycle fuse would be data loss of a possibly fully-copied file, so the alerting is load-bearing, not cosmetic. No `migrating` state — the backend never observes an in-flight copy. No `attempts` column — Queues tracks attempts natively.
+
+Migration mechanics: the enum + column + `@default(b2)` are metadata-only on PostgreSQL 11+ (**verify the prod RDS version before relying on this**). The index must **not** ship inside the same Prisma migration — Prisma emits a plain `CREATE INDEX`, which SHARE-locks `Upload` for the scan and stalls all writes mid rolling deploy. Create it out-of-band with `CREATE INDEX CONCURRENTLY` (and consider a partial index `WHERE "storageLocation" = 'r2'` — the sweep only ever reads that slice).
 
 **Provider registry** (rewrite of `backend/src/storage/index.ts`; delete `storage/s3b2.ts`, `@tweedegolf/storage-abstraction`, and the 12 h token `setInterval` at `storage/index.ts:79-87` including its `directClient` re-attach race):
 
@@ -229,50 +248,60 @@ export function getStorage(loc: 'r2' | 'b2' | 'failed'): StorageProvider {
 
 B2 client config **must** carry `requestChecksumCalculation: 'WHEN_REQUIRED'` and `responseChecksumValidation: 'WHEN_REQUIRED'` (AWS officially documents the v3.729+ CRC32 default; B2 rejection is field-evidenced; the setting is a no-op if B2 has since fixed it — cite `docs.aws.amazon.com/sdkref/latest/guide/feature-dataintegrity.html`, *not* the pingvin-share issue). R2 client: `endpoint = https://<acct>.eu.r2.cloudflarestorage.com` (EU jurisdiction, §6), `forcePathStyle: true` (single exact CSP entry). Note: the 2024-06-01 "B2 S3 API errors" comment at `storage/index.ts:42-43` is stale — presigning has run through B2's S3 API in prod ever since; still, prove `set/get/del` via the existing cred-gated `test/storage/backblaze.test.ts` before deleting tweedegolf.
 
-Exhaustive call-site list (from the fact-checked file plan): `routes/uploads.ts:171` (presign via registry), `routes/uploads.ts:38-45,98-105` (schema + bucket pass-through), `models/uploads.ts:28,38-48,58` (location-aware length check, persist column, `statUpload`), `routes/download.ts:20,22,75` (row lookup then provider), `models.ts:266` + `models/sharing.ts:740` (`deleteEverywhere`), `wsUploadHandler.ts:81` (`getStorage('b2').set`), storage tests rewritten to construct providers directly.
+Exhaustive call-site list: `routes/uploads.ts:171` (presign via registry), `routes/uploads.ts:38-45,98-105` (schema + bucket pass-through), `models/uploads.ts:28,38-48,58` (location-aware length check, persist column, `statUpload`), `routes/download.ts:20,22,75` (row lookup then provider), `models.ts:266` + `models/sharing.ts:740` (`deleteEverywhere`), `wsUploadHandler.ts:81` (`getStorage('b2').set`), storage tests rewritten to construct providers directly.
 
-**Capability gate** (`routes/uploads.ts:162-178`):
+**Capability gate — B2-first, R2 on fallback** (`routes/uploads.ts:162-178`; routing mode per maintainer direction on #959):
 
 ```ts
 const { uniqueHash } = getDataFromAuthenticatedRequest(req);
 const wantsR2 = Array.isArray(req.body.capabilities) && req.body.capabilities.includes('r2');
-const bucket = wantsR2 && r2Gate(uniqueHash) ? 'r2' : 'b2';
+const isFallback = req.body.fallback === true;           // client exhausted its B2 retry budget for this part
+const bucket = wantsR2 && r2Mode(uniqueHash, isFallback) ? 'r2' : 'b2';
 const url = await getStorage(bucket).getUploadUrl(uploadId, type, size);
 return res.json({ id: uploadId, url, bucket });
 
-function r2Gate(uniqueHash: string): boolean {
-  if (process.env.UPLOADS_R2_ENABLED !== 'true') return false;               // kill switch
-  const pct = Number(process.env.UPLOADS_R2_ROLLOUT_PERCENT ?? 100);
-  const n = parseInt(createHash('sha256').update(uniqueHash).digest('hex').slice(0, 8), 16);
-  return n % 100 < pct;
+function r2Mode(uniqueHash: string, isFallback: boolean): boolean {
+  const mode = process.env.UPLOADS_R2_MODE ?? 'off';     // off | fallback | all — the kill switch stays one env flip away
+  if (mode === 'off') return false;
+  if (mode === 'all') return gatePct(uniqueHash);        // future widening (region cohorts / full routing) if the data supports it
+  return isFallback && gatePct(uniqueHash);              // launch mode: R2 only after B2 has actually failed
 }
 ```
 
+- **Fallback choreography (client):** `uploadWithTracker` PUTs to B2 exactly as today; when its existing retry budget (`UPLOAD_HTTP_RETRY_LIMIT`) exhausts, `sendBlob` requests a second signed URL with `fallback: true` and retries the same encrypted blob against R2. Every upload taking this path is a **built-in per-upload A/B pair** — the same file, client, and network just failed on B2, then did-or-didn't succeed on R2 — the conclusive evidence the maintainers asked for, collected continuously in production rather than in a one-off canary.
+- This collapses the R2 cost surface to the *failing fraction* of traffic and keeps the majority of uploads on today's direct single-hop path.
 - Old clients send no `capabilities` → B2 forever (system add-on rides Thunderbird ESR — the B2 path is **permanent**).
 - Client echoes `bucket` into `POST /api/uploads` (`createUploadSchema` gains `bucket: z.enum(['r2','b2']).default('b2')`); the echo is self-verifying — `createUpload`'s length check (`models/uploads.ts:28`) runs `getStorage(bucket).length(id)`, so a lying client fails HeadObject on the claimed provider. (Server-side re-derivation was rejected: a kill-switch flip between the two requests would strand a completed R2 PUT.)
-- **Content-Length pinning** (fixes today's quota-evasion hole: `checkStorageLimit` reads `req.body.size` defaulting to 0 — `middleware.ts:372` — and `s3b2.ts` signs no length): `/signed` now takes `size`, the presign signs `ContentLength` via `signableHeaders: new Set(['content-type','content-length'])`, and `createUpload` checks `sizeOnDisk == size` (not `>=`) for R2-era uploads. ⚠ R2's enforcement of a signed content-length on presigned PUT is documented nowhere official — Prototype 1 assertion; if refuted, keep the exact-size `createUpload` check as the enforcement point.
+- **Content-Length pinning (hardening):** `/signed` now requires the **encrypted** size — `calculateEncryptedSize(blob.size)`, deterministic and already used by the client at `filesync.ts:141`; storage holds ECE ciphertext, which is strictly larger than the plaintext, so pinning or comparing the plaintext number would reject every legitimate upload. The presign signs `ContentLength` via `signableHeaders: new Set(['content-type','content-length'])`, `checkStorageLimit` runs against the same value, and `createUpload` checks `sizeOnDisk == calculateEncryptedSize(size)` (today's check is `>=`). `Upload.size` keeps its plaintext semantics so quota accounting and size display don't shift. ⚠ R2's enforcement of a signed content-length on presigned PUT is documented nowhere official — Prototype 1 assertion (d); if refuted, the exact-size `createUpload` check is the enforcement point.
 
-**Internal HMAC router** (`backend/src/routes/internal.ts`, new; mounted beside the others at `index.ts:133-144`, before the 404 catch-all at `:152`, with its own `express.raw({ type: 'application/json', limit: '16kb' })` — the global `express.json` at `index.ts:54` is not byte-stable for signing — plus `express-rate-limit` on this router; the repo currently has **zero** rate limiting anywhere):
+**Internal HMAC router** (`backend/src/routes/internal.ts`, new; mounted beside the others at `index.ts:133-144`, before the 404 catch-all at `:152`, with its own `express.raw({ type: 'application/json', limit: '16kb' })` — the global `express.json` at `index.ts:54` is not byte-stable for signing — plus `express-rate-limit` scoped to this router — the route set is Worker-only, so the budget can be tight):
 
 Wire format: `x-tbsend-keyid`, `x-tbsend-timestamp` (unix ms), `x-tbsend-signature = hex(HMAC-SHA256(secret[keyid], `${method}\n${path}\n${timestamp}\n${sha256hex(rawBody)}`))`; reject if `|now − ts| > 300s`; compare with `crypto.timingSafeEqual`. Key-id enables two-secret zero-downtime rotation (`COPIER_HMAC_SECRET` + `_PREVIOUS`).
 
 Routes:
 - `GET /api/internal/uploads/:id` → `{ storageLocation }` or 404. (Worker precheck.)
-- `POST /api/internal/uploads/:id/flip` — the pointer flip, made **self-verifying** so a forged/replayed request can only enact the legitimate transition:
+- `POST /api/internal/uploads/:id/flip` — the pointer flip. The backend verifies against **its own** B2 HeadObject and treats the caller's payload as advisory, so a forged request cannot flip an uncopied upload to `b2`. It *can* still force a copied upload into `failed` (recoverable — that is what the recurring `failed` alerts and redrive runbook exist for); see the `COPIER_HMAC_SECRET` blast radius in §2.5. Critically, the handler distinguishes **transient** verification failures (503 — row untouched, queue retries) from **confirmed** mismatches (409 — `failed`): a momentary B2 blip must never poison a fully-copied upload into a state the lifecycle can eat.
 
 ```ts
 router.post('/uploads/:id/flip', requireCopierHmac, wrapAsyncHandler(async (req, res) => {
-  const { id } = req.params; const { size } = JSON.parse(req.body);
+  const { id } = req.params; const { md5 } = JSON.parse(req.body);   // caller payload is ADVISORY only
   const upload = await prisma.upload.findUnique({ where: { id } });
   if (!upload) {                                   // precheck saw the row → user deleted mid-copy
     await deleteEverywhere(id);                    // backend (full B2 key) removes the fresh B2 orphan + staging
     return res.status(410).json({});
   }
-  const b2len = await getStorage('b2').length(id).catch(() => -1);   // independent re-verify (never trust caller)
-  if (b2len < Number(upload.size) || BigInt(size) < upload.size) {
+  let head;
+  try {
+    head = await getStorage('b2').head(id);        // the backend's OWN verification — never the caller's numbers
+  } catch (e) {
+    return res.status(503).json({});               // TRANSIENT verify failure: row stays 'r2', queue retries
+  }
+  const expected = calculateEncryptedSize(Number(upload.size));      // storage holds ECE ciphertext (see §2.3 pinning)
+  const md5Mismatch = !!(head.eTag && md5 && head.eTag !== md5);     // single-part ETag == MD5, gated on P2 assertion 7
+  if (head.length < expected || md5Mismatch) {     // CONFIRMED short/corrupt copy
     await prisma.upload.updateMany({ where: { id, storageLocation: 'r2' },
       data: { storageLocation: 'failed' } });
-    Sentry.captureMessage(`upload ${id} flip integrity mismatch`);
+    Sentry.captureMessage(`upload ${id} flip integrity mismatch`);   // 'failed' rows re-alert recurringly (sweep)
     return res.status(409).json({});
   }
   const r = await prisma.upload.updateMany({       // atomic CAS: absorbs at-least-once duplicates & double-flip races
@@ -282,12 +311,12 @@ router.post('/uploads/:id/flip', requireCopierHmac, wrapAsyncHandler(async (req,
 }));
 ```
 
-  (HMAC over Cloudflare Access service tokens / mTLS was upheld by fact-check: Access requires fronting the API through Cloudflare's proxy — the zone's DNS is on Cloudflare but traffic ingresses via CloudFront/ALB, so re-fronting is a material infra change for no gain over HMAC + self-verify.)
-- `POST /api/internal/dead-letter` → log + `Sentry.captureMessage` (Sentry wired at `index.ts:9,156`).
+  (HMAC over Cloudflare Access service tokens / mTLS: Access requires fronting the API through Cloudflare's proxy — the zone's DNS is on Cloudflare but traffic ingresses via CloudFront/ALB, so re-fronting is a material infra change for no gain over HMAC + backend-owned verification.)
+- `POST /api/internal/dead-letter` → log + `Sentry.captureMessage` (Sentry wired at `index.ts:9,156`). Two structured reasons get active handling beyond logging: **`aged-404`** — no row exists; the backend HEADs B2 and `deleteEverywhere()`s any orphan a died-between-copy-and-flip attempt left behind (the Worker's key deliberately cannot delete); and **`staging-gone`** — the row reads `r2` but the staging object is gone and B2 holds no copy; the backend CASes `r2→failed` + alerts, giving the sweep a terminal state instead of a re-enqueue livelock.
 
-**Ordering dependency (flagged by two angles):** `createUpload` (`models/uploads.ts:28`) must run its length check against **R2** for `bucket='r2'` uploads — at `POST /api/uploads` time the object is R2-only.
+**Ordering dependency:** `createUpload` (`models/uploads.ts:28`) must run its length check against **R2** for `bucket='r2'` uploads — at `POST /api/uploads` time the object is R2-only.
 
-**Downloads** (`routes/download.ts:61-83`): look up the row, `getStorage(row.storageLocation).getDownloadUrl(id)`. Files are downloadable the instant the PUT finishes (pre-flip GETs come from R2 — egress free); post-flip the 6 h grace makes in-flight presigned R2 GETs safe. Behavior change to flag: `/:id/signed` today presigns blindly with no DB read — unregistered ids will now 404 (tightens the surface; all real flows register first, `filesync.ts:97-99`). The `checkIdAgainstSuspiciousFiles` gate (`download.ts:66-73`) is DB-side and provider-agnostic — unchanged. (Pre-existing gap: unauthenticated `GET /api/download/:id` skips it — ticket #101, not the R2-staging design; see §6.)
+**Downloads** (`routes/download.ts:61-83`): look up the row, `getStorage(row.storageLocation).getDownloadUrl(id)`. Files are downloadable the instant the PUT finishes (pre-flip GETs come from R2 — egress free); post-flip the 1 h grace (= presigned-GET expiry) makes in-flight presigned R2 GETs safe. Behavior note: `/:id/signed` already performs a DB read via `checkIdAgainstSuspiciousFiles` (`download.ts:66-73` — a `findUnique` whose destructuring throws on unregistered ids today, surfacing as a 5xx); the location lookup turns that into an intentional 404. The suspicious-files gate itself is DB-side and provider-agnostic — unchanged.
 
 **Dual-store delete** — replaces `storage.del(id)` at `models.ts:266` and `models/sharing.ts:740`:
 
@@ -301,14 +330,14 @@ export async function deleteEverywhere(id: string): Promise<void> {
 
 (S3 DeleteObject returns 204 for absent keys — no existence branching; the Set dedupes in fs mode; `UPLOAD_NOT_DELETED_FROM_STORAGE` at `errors/models.ts:26-27` keeps meaning "a provider errored".)
 
-**Reconciliation sweep** (`backend/src/jobs/reconcileStaged.ts`, `setInterval` precedent: the old token renewer): every 15 min, `findMany({ where: { storageLocation: 'r2', createdAt: { lt: now-1h } }, take: 100 })` → re-enqueue synthetic R2-event-shaped messages via the verified Queues HTTP push API (`POST /accounts/{acct}/queues/{queue_id}/messages`, Queues-Edit token — **note (fact-check): the path takes the queue UUID, not the name** — store the ID in config). Sentry alert if any row is stuck >24 h. Both Fargate tasks run it; duplicates are harmless (consumer precheck dedupes on `storageLocation`). Rejected: copying from the backend directly (public-subnet ECS → B2 traffic pays AWS DTO at $0.09/GB — the entire reason the copier lives on Cloudflare).
+**Reconciliation sweep** (`backend/src/jobs/reconcileStaged.ts`, `setInterval` precedent: the old token renewer): every 15 min, `findMany({ where: { storageLocation: 'r2', createdAt: { lt: now-1h } }, take: 100 })` → re-enqueue synthetic R2-event-shaped messages via the verified Queues HTTP push API (`POST /accounts/{acct}/queues/{queue_id}/messages`, Queues-Edit token — note: the path takes the queue **UUID**, not the name — store the ID in config). The same cycle emits a **backlog gauge** — count and max age of `r2` rows — with graduated thresholds (warn at >500 rows or >6 h; page at >24 h), giving early warning of B2 degradation long before the page fires, and **re-alerts on `failed` rows recurringly** (they are excluded from re-enqueue but must never age out silently — see §2.3). Both Fargate tasks run it; duplicates are harmless (consumer precheck dedupes on `storageLocation`). Rejected: copying from the backend directly (public-subnet ECS → B2 traffic pays AWS DTO at $0.09/GB — the entire reason the copier lives on Cloudflare).
 
-**Sentry scrubbing (ship first, independent):** `frontend/src/lib/sentry.ts:11-31` has no `beforeBreadcrumb`/URL scrubbing while the upload XHR PUTs bearer presigned URLs (`helpers.ts:301-363`) — live 1 h upload URLs are very likely shipping to Sentry **today** with B2. Strip query strings on `r2.cloudflarestorage.com|backblazeb2.com` in `beforeBreadcrumb`/`beforeSend`, set `tracePropagationTargets`, audit replay network capture; backend `captureConsoleIntegration` (`backend/src/sentry.ts:30-32`) gets the same treatment.
+**Sentry URL scrubbing (ship first, independent):** presigned upload/download URLs are bearer secrets and must never reach telemetry. Scrub query strings on `r2.cloudflarestorage.com|backblazeb2.com` in `beforeBreadcrumb` and `beforeSend`, **and in `beforeSendTransaction`** — at `tracesSampleRate: 0.5`, `http.client` spans record full request URLs, so breadcrumb scrubbing alone leaves the tracing path open; disable or scope session-replay network capture for storage hosts; the backend's `captureConsoleIntegration` (`backend/src/sentry.ts:30-32`) gets the same scrub. Sentry's server-side data-scrubbing rules on `X-Amz-*` query params are a useful zero-deploy stopgap. Specifics are tracked in the private issue tracker.
 
 ### 2.4 Client (`packages/send/frontend`, shared with `packages/addon`)
 
-- `filesync.ts:154-186` (`sendBlob`): send `capabilities: ['r2']` and `size`; return `{ id, bucket }`. Ripple (mechanical, must be complete — the frontend bundle ships inside the add-on): `upload.ts:217` and the bucket echo at `upload.ts:248-257`, `apps/chat/components/{Send,MessageSend}.vue`, tests `src/test/lib/{upload,filesync,filesync-fs}.test.ts`.
-- `helpers.ts` `uploadWithTracker` (`:301-363`): **no change** — it PUTs with `Content-Type: application/octet-stream`, exactly what the presign signs; the browser sets Content-Length from the Blob.
+- `filesync.ts:154-186` (`sendBlob`): send `capabilities: ['r2']` and the **encrypted** size (`calculateEncryptedSize(blob.size)` — already computed at `filesync.ts:141`); on `uploadWithTracker` retry-budget exhaustion, request a second signed URL with `fallback: true` and retry the same encrypted blob against the returned R2 URL (tagging the outcome for the rescue-rate metric); return `{ id, bucket }`. Ripple (mechanical, must be complete — the frontend bundle ships inside the add-on): `upload.ts:217` and the bucket echo at `upload.ts:248-257`, `apps/chat/components/{Send,MessageSend}.vue`, tests `src/test/lib/{upload,filesync,filesync-fs}.test.ts`.
+- `helpers.ts` `uploadWithTracker` (`:301-363`): **no change** — it already sends `Content-Type: application/octet-stream`, matching what WS4's presign will sign (today's presign signs neither Content-Type nor Content-Length — see §7); the browser sets Content-Length from the Blob.
 - **CSP:** add the exact host `https://<ACCT>.eu.r2.cloudflarestorage.com` to `connect-src` in **both** `frontend/csp.config.js` and the baked `frontend-csp-header` strings in `pulumi/config.stage.yaml:8` / `config.prod.yaml:9` — one PR, both files. Keep `https://*.backblazeb2.com` forever.
 - **R2 bucket CORS:** `AllowedOrigins: ['*']` (CORS is not the auth boundary — the URL is the bearer secret, and ACAO:* forbids credentialed requests; extension `moz-extension://` origins can't be enumerated anyway), `AllowedMethods: ['PUT','GET']`, `AllowedHeaders: ['content-type']` — **enumerated, not wildcard** (⚠ "wildcard broken on R2" is community lore either way; enumeration matches the docs' own example and Prototype 1 validates it).
 - **Origin-strip hack:** expected NOT needed — the existing `webRequest` hack (`packages/addon/src/background.ts:159-178`) matches only `https://*.backblazeb2.com/*` and R2 has real per-bucket CORS. Prototype 1 is the gate. Fallback if it fails: clone the hack for `https://*.r2.cloudflarestorage.com/*` + manifest host permission, shipped in the same add-on release as the capability flag — costs a diff, not a schedule slip.
@@ -317,7 +346,7 @@ export async function deleteEverywhere(id: string): Promise<void> {
 
 **Decided split:** Pulumi owns slow-changing Cloudflare resources (bucket, CORS, lifecycle, queues, DLQ, notification rule) + backend env/secrets/CSP; **wrangler in CI** owns the Worker script, queue-consumer registration (batch/retry tuning ships with the code that depends on it), and Worker secrets.
 
-**Hard prerequisite with a gate:** `packages/send/pulumi/requirements.txt:2` pins `pulumi_cloudflare==5.48.0`, which **lacks** `R2BucketCors` / `R2BucketLifecycle` / `R2BucketEventNotification` / `QueueConsumer` (verified against SDK trees at both tags). Plan A: in-place upgrade to `>=6.17,<7` — `cloudflare.Record` survives as a deprecated alias of `DnsRecord`; migrate the two CNAMEs (`fargate.py:63-74`, `cloudfront.py:116-127`) with `pulumi.Alias`. **Gate: `pulumi preview --diff` on ci/stage must show no replaces on the DNS records** — a surprise replace of prod `send`/`send-backend` CNAMEs is an outage. Plan B (fallback, championed by the plumbing angle): keep v5, provision the new Cloudflare surface via wrangler/REST in CI (`wrangler queues create … --message-retention-period-secs 1209600`, `wrangler r2 bucket notification create …`, `wrangler r2 bucket lifecycle …`), or a separate v6-pinned Pulumi project. *This is Open Decision D2.*
+**Hard prerequisite with a gate:** `packages/send/pulumi/requirements.txt:2` pins `pulumi_cloudflare==5.48.0`, which **lacks** `R2BucketCors` / `R2BucketLifecycle` / `R2BucketEventNotification` / `QueueConsumer` (verified against SDK trees at both tags). Plan A: in-place upgrade to `>=6.17,<7` — `cloudflare.Record` survives as a deprecated alias of `DnsRecord`; migrate the two CNAMEs (`fargate.py:63-74`, `cloudfront.py:116-127`) with `pulumi.Alias`. **Gate: `pulumi preview --diff` on ci/stage must show no replaces on the DNS records** — a surprise replace of prod `send`/`send-backend` CNAMEs is an outage. Plan B (fallback): keep v5, provision the new Cloudflare surface via wrangler/REST in CI (`wrangler queues create … --message-retention-period-secs 1209600`, `wrangler r2 bucket notification create …`, `wrangler r2 bucket lifecycle …`), or a separate v6-pinned Pulumi project. *This is Open Decision D2.*
 
 New module `packages/send/pulumi/cloudflare_r2.py` (v6 shapes verified: `R2Bucket{jurisdiction:'eu'}`, `R2BucketCors{rules[].allowed.{methods,origins,headers}, max_age_seconds}`, `R2BucketEventNotification{queue_id, jurisdiction, rules[].actions}` — requires Workers R2 Storage Read+Write on the provider token, **does not support `pulumi import`** — `R2BucketLifecycle`, `Queue{settings.message_retention_period}`). Every R2 resource must carry `jurisdiction='eu'`. The existing `cloudflare:apiToken` (`Pulumi.{stage,prod}.yaml:19-20`) is presumably DNS-scoped and must gain Workers R2 Storage Edit + Queues Edit.
 
@@ -332,21 +361,30 @@ New module `packages/send/pulumi/cloudflare_r2.py` (v6 shapes verified: `R2Bucke
 | NEW `CLOUDFLARE_API_TOKEN` for CI (Workers Scripts Edit + Queues Edit) | GH Actions environment secret | `wrangler deploy` | CI |
 | NEW Queues-Edit token + queue UUIDs | Pulumi config secret → SM → Fargate | sweep's HTTP publish | backend |
 
-Fact-check correction folded in: pulumi-cloudflare v6 has **no** Worker-secret resource at all (the claimed `WorkersForPlatformsScriptSecret` does not exist in the SDK; v5's `WorkersSecret` was removed). Pulumi *could* set secrets via `WorkersScript`'s inline `secret_text` binding, but the Worker isn't Pulumi-managed here — wrangler is the decided path.
+Verified caveat: pulumi-cloudflare v6 (at the recommended `>=6.17` pin) has **no** Worker-secret resource (v5's `WorkersSecret` was removed). Pulumi *could* set secrets via `WorkersScript`'s inline `secret_text` binding, but the Worker isn't Pulumi-managed here — wrangler is the decided path.
 
-Worker key compromise blast radius (why no-delete matters): confidentiality is E2E-safe regardless; without `deleteFiles` the key cannot destroy data; B2 retains prior file versions on overwrite (ensure bucket lifecycle keeps them); no `listFiles` → keys not enumerable.
+**Key-compromise blast radius (both secrets analyzed):**
+
+- *Worker's B2 key* (why no-delete matters): confidentiality is E2E-safe regardless; without `deleteFiles` the key cannot destroy data; B2 retains prior file versions on overwrite (ensure bucket lifecycle keeps them); no `listFiles` → keys not enumerable.
+- *`COPIER_HMAC_SECRET`* — the **wider** distribution surface (Worker secret, GitHub Actions, Pulumi state, AWS SM, Fargate env). A holder can call the internal routes for any known upload id. The flip handler's backend-owned HeadObject verification means they **cannot** flip an uncopied upload to `b2`; they **can** force a copied-but-unflipped upload into `failed` (recoverable — the recurring `failed` alerts and redrive runbook exist precisely so this cannot silently reach the lifecycle fuse) and can invoke the 410 path's `deleteEverywhere` only for ids whose rows are already deleted. Treat this secret with the same custody bar as the B2 key; rotation is the two-secret zero-downtime scheme (§2.3).
 
 **CI:** Worker at `packages/send/copier` joins `pnpm-workspace.yaml`. `validate.yml`: add `worker-changed: ['packages/send/copier/**']` path filter (`validate.yml:31-42` pattern) + job running tsc, `@cloudflare/vitest-pool-workers` tests, and `wrangler deploy --dry-run`. `merge.yml`: `worker-deploy-stage` (`wrangler deploy --env stage`, environment `send-stage`), parallel to `backend-deploy-stage-aws`. `release.yml`: prod mirror behind the existing manual gate. The `iac-changed` filter already lints `packages/send/pulumi/**`.
 
 **Local dev limits (both verified, the second community-lore-confirmed):** Miniflare emulates R2 as a *binding*, not an S3 HTTP endpoint — presigned URLs can't target local R2; and local R2 writes do **not** fire event notifications into local queues. So: unit tests inject synthetic event messages into the queue handler (`{account, action:'PutObject', bucket, object:{key,size,eTag}, eventTime}`) with B2/backend mocked via fetchMock; semi-local dev = `wrangler dev` + stage B2 key + `BACKEND_URL=http://localhost:8080` against docker-compose; true E2E = stage only. Day-to-day compose dev stays on `STORAGE_BACKEND=fs`; add one MinIO service with two buckets to `compose.yml` for registry/dual-delete integration tests (both providers speak S3 — one MinIO suffices).
 
-**Cost sanity (verified anchors, 50 TB/mo tier):** Workers Paid $5/mo (10M req incl.; ~525k invocations); Queues ~3 ops/message ≈ 1.6M ops/mo ≈ $0.24 after included 1M (free tier's 10k ops/day would NOT cover this tier — Paid stands); R2 staging residency at 7-day lifecycle worst case ≈ $175/mo insurance; R2 Class A/B negligible; R2→Worker→B2 egress free both ways. Total incremental ≈ low tens of $/mo + staging storage.
+**Cost sanity (verified anchors):** the figures below assume the worst case — **all** 50 TB/mo routed through R2. In the launch `fallback` mode only the failing fraction of uploads touches R2, so real costs sit far below these ceilings. Workers Paid $5/mo (10M req incl.; ~525k invocations at the all-traffic ceiling); Queues ~3 ops/message ≈ 1.6M ops/mo ≈ $0.24 after included 1M (free tier's 10k ops/day would NOT cover the all-traffic tier — Paid stands); R2 staging at the minutes-residency norm is near-zero (storage bills on peak-per-day GB-month), with the 7-day orphan fuse holding only abandoned uploads; R2 Class A/B negligible; R2→Worker→B2 egress free both ways. Total incremental ≈ $5/mo fixed + cents-to-dollars variable.
 
 ---
 
 ## 3. Sequenced delivery plan
 
-### Phase 0 — blocking prototypes (run both in week 1, in parallel; each ≤1 day build)
+### Phase 0 — blocking prototypes (run all three in week 1, in parallel; each ≤1 day build)
+
+**P0 — Region reliability canary (the project's premise; required in-scope by #959).**
+*Question:* does client→R2 actually fix the long-haul stall? #959 explicitly requires "a region canary validating client→R2 reliability from affected regions **before committing**." If R2's edge does not beat B2 from affected geographies, every other workstream in this note is moot.
+*Steps:* from an affected geography (a Costa Rica-resident tester, or the closest VPN approximation, plus one unaffected control location), run N≥50 alternating ~100 MB PUTs to a presigned R2 URL and to the production B2 presigned-PUT path — same client hardware and network — recording stalls, timeouts, retries, and hard failures per attempt (reuse the thunderbird/platform-infrastructure bench harness from the #913 investigation if available).
+*Assert:* the R2 failure+stall rate from the affected geography is materially lower than B2's, and not worse from the control.
+*Success:* clear separation. *Kill:* no separation → the stall is not the long-haul hop; stop this track and reassess (#913's resumable-upload design becomes the primary fix). Note: the B2-first fallback rollout (§2.3) later supersedes this with continuous per-upload production evidence; P0 is the cheap pre-commitment check that the premise is even plausible.
 
 **P1 — MV2 extension → R2 presigned PUT (client-side gate).**
 *Question:* does the Thunderbird MV2 add-on's XHR PUT to `https://<acct>.eu.r2.cloudflarestorage.com` succeed with bucket CORS and **no** manifest host permission / Origin-strip hack?
@@ -357,8 +395,8 @@ Worker key compromise blast radius (why no-delete matters): confidentiality is E
 **P2 — Worker streamed PUT to B2 (worker-side gate).**
 *Question:* can a deployed Worker `fetch()` PUT a ~100/150 MB `FixedLengthStream` body to B2's S3 endpoint without buffering into the 128 MB isolate, and does B2 verify integrity as assumed?
 *Steps:* throwaway Worker with the §2.1 pipeline verbatim behind a `GET /copy?key=` handler; R2 bucket bound as `STAGING` (seed via **presigned single PUT** — the production path, guaranteeing `checksums.md5`; use the EU bucket from P1); scratch B2 bucket in eu-central-003; run deployed (not local — local stream behavior unrepresentative).
-*Assert:* (1) copy completes at 100 MB **and 150 MB** (the >128 MB case is the memory proof), B2 HEAD length == R2 size; (2) no memory/1102 errors in `wrangler tail`; (3) wall < 5 min, record CPU; (4) `checksums.md5` present on the seeded R2 object (EU bucket); (5) **negative:** deliberately wrong `Content-MD5` → B2 rejects the PUT (400 BadDigest-class) — this is the server-side verification the design leans on, currently field-evidence-grade; (6) **negative:** `FixedLengthStream(size+1)` → local stream error, no successful request; (7) record whether B2's PutObject ETag == hex MD5 (decides keeping the secondary ETag cross-check).
-*Success:* 1–3 at both sizes, 5 passes. *Kill/fallback:* if 150 MB fails on memory (Workers buffers outbound bodies), switch to B2 S3 **multipart from the Worker** — five ~20 MB buffered parts, per-part Content-MD5 + final size check. the design survives; only the pipeline section changes.
+*Assert:* (1) copy completes at 100 MB **and 150 MB** (the >128 MB case is the memory proof), B2 HEAD length == R2 size; (2) no memory/1102 errors in `wrangler tail`; (3) wall < 5 min, record CPU; (4) `checksums.md5` present on the seeded R2 object (EU bucket); (5) **negative:** deliberately wrong `Content-MD5` → B2 rejects the PUT (400 BadDigest-class) — this is the server-side verification the design leans on, currently field-evidence-grade; (6) **negative:** `FixedLengthStream(size+1)` → local stream error, no successful request; (7) record whether B2's PutObject ETag == hex MD5 (decides keeping the secondary ETag cross-check); (8) **throughput + billing (maintainer-requested):** run ~20 copies back-to-back, record sustained R2→B2 throughput (expect data-center-to-backbone speeds; if a 100 MB copy takes more than low single-digit minutes, the residency premise needs re-evaluation), then inspect the Cloudflare billing/analytics panel after the run — Class A/B op counts as predicted, **zero egress line items**, no surprise charges.
+*Success:* 1–3 at both sizes, 5 and 8 pass. *Kill/fallback:* if 150 MB fails on memory (Workers buffers outbound bodies), switch to B2 S3 **multipart from the Worker** — five ~20 MB buffered parts, per-part Content-MD5 + final size check (the design survives; only the pipeline section changes). If throughput in (8) is poor, the architecture premise fails — stop and re-evaluate before building anything.
 
 ### Workstreams (PR-sized)
 
@@ -372,47 +410,56 @@ Worker key compromise blast radius (why no-delete matters): confidentiality is E
 | WS6 | IaC: Pulumi v6 upgrade **gated by preview** (or Plan B), `cloudflare_r2.py`, queue/bucket/CORS/lifecycle/notification, CSP + Fargate env/secrets in config yamls | M | **D1 (EU jurisdiction), D2 (Pulumi path)** | `pulumi/*`, `frontend/csp.config.js` |
 | WS7 | Copier Worker: copy pipeline, 3 consumers, HMAC client, wrangler envs, vitest-pool-workers | M | **P2**, WS5 contract, WS6 (for stage deploy) | `packages/send/copier/` (new) |
 | WS8 | Reconciliation sweep + Sentry stuck-row alert + queue-UUID config | S | WS2, WS6 (queue IDs) | `backend/src/jobs/reconcileStaged.ts` (new) |
-| WS9 | Client: `sendBlob` capabilities + `{id,bucket}` ripple + chat components + frontend tests | S–M | WS4, **P1(a)** | `frontend/src/lib/*`, `apps/chat/*`; `addon/src/background.ts` only if P1 fails |
+| WS9 | Client: B2-retry-exhaustion → `fallback: true` re-request in `sendBlob`, capabilities flag, `{id,bucket}` ripple + chat components + frontend tests | M | WS4, **P1(a)** | `frontend/src/lib/*`, `apps/chat/*`; `addon/src/background.ts` only if P1 fails |
 | WS10 | CI: worker validate/deploy jobs, GH secrets, secrets runbook | S–M | WS7 scaffold | `.github/workflows/*` |
 | WS11 | E2E: MinIO-backed upload→flip(curl w/ test HMAC)→re-download; legacy-client (no capabilities) asserts B2 presign; stage canary after each worker deploy | M | WS4, WS5, WS7 | `packages/send/e2e` |
-| WS12 | Rollout: stage soak, prod `UPLOADS_R2_ENABLED=true` at `ROLLOUT_PERCENT=1→5→25→100`, DLQ-depth + stuck-row dashboards, runbook (DLQ triage, secret rotation, kill switch) | S | all | env config |
+| WS12 | Rollout: stage soak, prod `UPLOADS_R2_MODE=fallback` ramped per the success metrics below, runbook (DLQ triage, `failed`-row redrive, secret rotation, kill switch) | S | all, WS13/WS14 | env config |
+| WS13 | Observability: sweep backlog gauge + graduated alerts, recurring `failed`-row alerts, DLQ-depth alerting surface (new — see D8), dashboards | S–M | WS8 | backend jobs + alerting config |
+| WS14 | Add-on release vehicle: ship the capability-flag client in an ATN add-on release and coordinate the calendar — the frontend compiles *into* the add-on, so the prod ramp is gated on client adoption cadence, not just env vars | S code, calendar-bound | WS9 | `packages/addon` release process |
 
-**Parallelization:** Week 1: P1 ∥ P2 ∥ WS1 ∥ WS2. Then WS3→(WS4 ∥ WS5) ∥ WS6 ∥ WS7-scaffold ∥ WS10. Then WS7 ∥ WS8 ∥ WS9 ∥ WS11 → WS12. Backend track ≈ 2–3 eng-weeks; Worker ≈ 1 week; IaC/CI ≈ 1.5–2 weeks (risk-driven, code small). Roughly 5–6 engineer-weeks total across 2–3 people.
+**Parallelization:** Week 1: P0 ∥ P1 ∥ P2 ∥ WS1 ∥ WS2. Then WS3→(WS4 ∥ WS5) ∥ WS6 ∥ WS7-scaffold ∥ WS10. Then WS7 ∥ WS8 ∥ WS9 ∥ WS11 ∥ WS13 → WS14 → WS12. Backend track ≈ 2–3 eng-weeks; Worker ≈ 1 week; IaC/CI ≈ 1.5–2 weeks (risk-driven, code small); client/E2E/observability/rollout ≈ 1.5–2 weeks. **Roughly 6–9 engineer-weeks total across 2–3 people** (the 5–6-week floor holds only if Phase 0 produces zero rework and no release-calendar stalls).
+
+### Rollout success metrics (gates for the % ramp)
+
+#959 defines success as a near-zero `UPLOAD_FAILED` rate — plumbing health alone (DLQ depth, stuck rows) does not prove that. The B2-first fallback mode makes the measurement direct: every fallback attempt is a same-file/same-client/same-network A/B pair. Before the ramp: capture a 2-week `UPLOAD_FAILED` baseline from Sentry and tag upload outcomes with the path taken (`b2-direct`, `r2-fallback-success`, `r2-fallback-failed`). **Primary metric: fallback rescue rate** — the fraction of uploads that exhausted B2 retries and then succeeded on R2 (target: near-100%); secondary: overall `UPLOAD_FAILED` trending to near-zero, replication p95 lag < 5 min (consistent with the minutes-residency policy), zero new `failed` rows, DLQ empty across the soak window (48 h at 1% and 5%; one week at 25%). Kill-switch triggers (`UPLOADS_R2_MODE=off`): rescue rate below the b2-retry baseline (R2 not actually helping), any data-loss invariant violation (§4), or replication backlog age > 12 h.
 
 ---
 
 ## 4. Failure modes and data-loss invariants
 
-### Invariants (each must have a test; consolidated from security + plumbing angles)
+### Invariants (each must have a test)
 
-- **I1 — no flip without durable copy:** `storageLocation='b2'` ⇒ a B2 object with key `id` exists whose length ≥ row size, verified twice (B2's server-side Content-MD5 check at PUT; backend HeadObject at flip). *Test: flip with missing/short B2 object → 409, row stays `r2`.*
-- **I2 — no premature staging delete:** R2 object deleted only when the row reads `b2` at delete time (re-checked immediately before delete) and B2 HEAD confirms, ≥6 h after flip. *Test: kill the flip between copy and delete → R2 object survives.*
+- **I1 — no flip without durable copy:** `storageLocation='b2'` ⇒ a B2 object with key `id` exists whose length equals the expected encrypted size, verified twice (B2's server-side Content-MD5 check at PUT; the backend's own HeadObject length + R2-MD5-vs-B2-ETag comparison at flip — the ETag leg gated on P2 assertion 7). *Test: flip with missing/short B2 object → 409, row stays `r2`.*
+- **I2 — no premature staging delete:** R2 object deleted only when the row reads `b2` at delete time (re-checked immediately before delete) and B2 HEAD confirms, ≥1 h after flip (the presigned-GET expiry floor). *Test: kill the flip between copy and delete → R2 object survives.*
 - **I3 — lifecycle fuse > detection + response window:** staging lifecycle N (7 d) > sweep alert (24 h) + human runway; sweep re-enqueues until day 7. *Test: config assertion in IaC review; see D3 for the 7-vs-28-day dispute.*
 - **I4 — idempotent consumer:** duplicate delivery of the same object-create message yields the same terminal state (verified: Queues is at-least-once with documented rare duplicates). *Test: deliver twice → one B2 object, one flip, both acks.*
 - **I5 — no re-copy after flip:** consumer acks any event whose row is already `b2` — also the defense against overwrite-after-copy via a leaked presigned URL re-firing object-create. *Test: PUT to staging key after flip → no B2 write.*
-- **I6 — event-before-row:** object-create precedes `POST /api/uploads`; consumer retries on 404, acks as orphan at eventTime >24 h; abandoned PUTs drain via lifecycle, **never via a B2 write** (check-first choreography). *Test: event with no row → retried then orphan-acked, zero B2 objects.*
-- **I7 — user-delete wins:** deletes go to both stores (`deleteEverywhere`); flip on a deleted row → 410 + backend deletes the B2 orphan. *Test: delete row mid-copy → no orphan in either store after grace.*
+- **I6 — event-before-row:** object-create precedes `POST /api/uploads`; consumer retries on 404 (delay cap 2 h keeps the 24 h branch reachable inside the retry budget), and the aged-404 path is **B2-aware**: report `aged-404` → backend HEADs B2 and removes any orphan from a died-mid-flip attempt → ack; abandoned PUTs drain via lifecycle, never via a *lasting* B2 write. *Test 1: event with no row → retried then orphan-acked, zero B2 objects. Test 2: kill the worker between B2 PUT and flip, then delete the row → no B2 orphan remains after the aged-404 path runs.*
+- **I7 — user-delete wins:** deletes go to both stores (`deleteEverywhere`); flip on a deleted row → 410 + backend deletes the B2 orphan; the aged-404 path (I6) covers the copy-completed-but-never-flipped variant. *Test: delete row mid-copy → no orphan in either store after grace.*
 - **I8 — double-flip race:** CAS (`updateMany where storageLocation:'r2'`) makes the loser a no-op 200. *Test: concurrent flips → exactly one transition, both 2xx.*
-- **I9 — reconciliation closes the loop:** sweep re-enqueues rows stuck `r2` >1 h (skipping `failed`), alerts >24 h; covers event loss, DLQ drops, and Postgres-restore desync. *Test: fabricate stuck rows → repaired; `failed` rows skipped.*
+- **I9 — reconciliation closes the loop:** sweep re-enqueues rows stuck `r2` >1 h, alerts >24 h, emits the backlog gauge every cycle, and re-alerts recurringly on `failed` rows (excluded from re-enqueue, never from alerting); covers event loss, DLQ drops, and Postgres-restore desync (the consumer's `'gone'` path then auto-heals or terminal-fails). *Test: fabricate stuck rows → repaired; `failed` rows re-alert but are not re-enqueued.*
+- **I10 — no transient poisoning:** only a backend-confirmed short/corrupt/missing B2 object may set `failed`; a transient verification error returns 503 and leaves the row `r2`. *Test: flip during a simulated B2 HEAD outage → 503, row stays `r2`, message retries, eventual flip succeeds.*
 
 ### Failure-mode table
 
 | Failure | System behavior | Data at risk | Recovery |
 |---|---|---|---|
 | R2→Queue event never generated (guarantees undocumented) | Row stays `r2`; downloads presign from R2 — user-invisible | none | sweep re-enqueues ≥1 h; Sentry >24 h (I9) |
-| Event-before-row race (normal, seconds) | Precheck 404 → backoff retry 30 s→10 min | none | automatic (I6) |
-| Row never created (client died between PUT and `POST /uploads`) | 404 persists → orphan-ack at eventTime>24 h; nothing copied | none (orphan bytes) | R2 lifecycle @7 d (I6) |
-| B2 down 48 h | In-queue backoff 30 s→3 h over 25 retries ≈ 52 h coverage; stragglers → DLQ alert-and-ack | none (R2 holds bytes ≤7 d) | retries self-heal; sweep regenerates acked work |
-| Consumer down 48 h (bad deploy / CF incident) | Backlog grows (~35k msgs ≪ 25 GB cap); retention 14 d | none | autoscaled drain on recovery; 24 h alert fires |
+| Event-before-row race (normal, seconds) | Precheck 404 → backoff retry 30 s→2 h cap | none | automatic (I6) |
+| Row never created (client died between PUT and `POST /uploads`) | 404 persists → aged-404 at >24 h: backend HEADs B2, removes any orphan, worker acks | none (orphan bytes) | R2 lifecycle @7 d (I6) |
+| Worker dies between B2 PUT and flip, row later deleted | Redelivery hits 404 → aged-404 path finds the B2 object → backend `deleteEverywhere` | GDPR exposure if unhandled | I6 test 2 / I7 |
+| Transient B2 HEAD failure at flip | 503 → row stays `r2`, message retries | none | automatic (I10) |
+| B2 down 48 h | **Uploads keep succeeding** — every client falls back to R2; replication queue backs off 30 s→3 h over 25 retries ≈ 52 h coverage; stragglers → DLQ alert-and-ack | none (R2 holds bytes ≤7 d) | retries self-heal; sweep regenerates acked work; this failover is the design's headline win |
+| Consumer down 48 h (bad deploy / CF incident) | Backlog grows (~35k msgs ≪ 25 GB cap); retention 14 d; backlog gauge warns within hours | none | autoscaled drain on recovery; graduated alerts (I9) |
 | Duplicate delivery / client re-PUT pre-flip | Precheck `b2`→ack; mid-copy duplicate overwrites same key with identical bytes; CAS idempotent | none | by design (I4/I5/I8) |
-| Mid-stream B2 failure / truncation | `FixedLengthStream` errors locally, or B2 rejects Content-MD5 → whole-object retry (streams not seekable) | none | retry w/ backoff |
-| Flip integrity mismatch (B2 shorter than row size) | 409 → CAS `r2→failed` + Sentry; downloads keep serving from R2 | none | human-gated redrive |
-| HMAC secret drift/rotation skew | 401s → long-delay retries; copies keep succeeding; flips stall; downloads unaffected (rows still `r2`) | none | dual-secret acceptance; DLQ depth = pager |
+| Mid-stream B2 failure / truncation | `FixedLengthStream` errors locally, or B2 rejects Content-MD5 → whole-object retry (streams not seekable; `aws4fetch retries: 0` so the queue owns the retry) | none | retry w/ backoff |
+| Flip integrity mismatch (backend-confirmed short/corrupt B2 copy) | 409 → CAS `r2→failed` + **recurring** Sentry alerts; downloads keep serving from R2 | none while alerts are actioned | human-gated redrive before the lifecycle fuse; recurring alerts make silent expiry impossible |
+| HMAC secret drift/rotation skew | 401s → long-delay retries; copies keep succeeding; flips stall; downloads unaffected (rows still `r2`) | none | dual-secret acceptance; backlog gauge = early pager |
 | User deletes mid-copy | Flip 410 → backend `deleteEverywhere` removes B2 orphan | GDPR exposure if unhandled | I7 |
 | Flip ok but grace-delete message lost | R2 object lingers ≤7 d | none (B2 verified) | lifecycle backstop |
 | Grace delete fires against a bad state | Delete consumer re-verifies row==`b2` + B2 HEAD before the only destructive op | none | I2 |
-| Uncopied object reaches lifecycle day 7 | **The one true data-loss path** — requires ~6 days of ignored Sentry alerts | loss | I3 + alerting SLA (D3) |
-| Postgres restored to older snapshot (row says `b2`, delete already ran / row says `r2`, object gone) | desync | possible dangling pointers | sweep spot-checks + I3 margin; document RPO in runbook |
+| Uncopied (or `failed`) object reaches lifecycle day 7 | **The true data-loss path** — requires ~6 days of ignored alerts (stuck-`r2` gauge, >24 h page, and recurring `failed` alerts all firing) | loss | I3 + I9/I10 + alerting SLA (D3) |
+| Postgres restored to older snapshot (row says `r2`, staging object gone) | Sweep re-enqueues → consumer `'gone'` path: HEADs B2 → auto-flips if the durable copy exists, else CAS→`failed` + alert | dangling pointers until healed | auto-heal via `'gone'` path; I3 margin; document RPO in runbook |
 
 ---
 
@@ -422,16 +469,16 @@ Worker key compromise blast radius (why no-delete matters): confidentiality is E
 |---|---|---|---|---|
 | 1 | Workers outbound `fetch()` buffers the streamed body → 100 MB copy impossible in 128 MB isolate | L-M × H | **P2** (150 MB case is decisive); contingency: B2 multipart in ~20 MB buffered parts — pipeline-only change | worker |
 | 2 | MV2 extension PUT to R2 blocked (CORS/Origin behavior) | M × H | **P1**; fallback Origin-strip twin + manifest permission in same add-on release | client |
-| 3 | Presigned bearer URLs leaking to Sentry (happening **today** with B2) | H × M-H | WS1 scrubbing, ship before the R2-staging design; replay-policy audit | client + backend |
+| 3 | Presigned bearer URLs reaching telemetry (breadcrumbs, tracing spans, session replay) | H × M-H | WS1 scrubbing ships first (incl. `beforeSendTransaction` — spans are the easily-missed leg); Sentry server-side scrub as stopgap; replay-policy audit (D9) | client + backend |
 | 4 | Pulumi v5→v6 upgrade produces destructive diff on prod DNS CNAMEs | M × H | `pulumi preview --diff` gate on ci/stage; `pulumi.Alias`; Plan B (wrangler provisioning / separate project) | infra |
-| 5 | Copy-pipeline data loss (flip-before-verify, premature delete, lifecycle vs outage) | M × H | invariants I1–I3, I9 with tests; delete gated on double verification | worker + backend |
+| 5 | Copy-pipeline data loss (flip-before-verify, premature delete, transient-poisoned `failed` rows, lifecycle vs outage) | M × H | invariants I1–I3, I9, I10 with tests; delete gated on double verification; transient/terminal split at the flip; recurring `failed` alerts | worker + backend |
 | 6 | CSP dual-source drift (csp.config.js vs pulumi yaml) silently blocks gated users' PUTs | M × H | single PR touching both; stage e2e; 1–5% initial rollout + kill switch | client + infra |
 | 7 | B2 write-path surprises when replacing tweedegolf native API with aws-sdk S3 (`WHEN_REQUIRED` lore; stale 2024 comment) | M × M | cred-gated live B2 test suite must pass before tweedegolf removal; keep `WHEN_REQUIRED` (no-op if fixed) | backend |
 | 8 | HMAC secret drift between Worker (GH secret) and backend (Pulumi/SM) → silent flip stall | M × M | dual-secret acceptance; stage canary exercising callback after each worker deploy; DLQ-depth alert | infra |
 | 9 | R2 event generation loss / undocumented delivery guarantees | L × M | sweep is the correctness mechanism (not an optimization); 24 h alert; P1 measures real lag | backend |
 | 10 | Worker B2 key compromise corrupts served objects | L × H | key has no `deleteFiles`/`listFiles`, bucket-scoped; B2 file versioning retained as undo; E2E encryption preserves confidentiality regardless | infra |
 
-Honorable mentions: quota evasion via unsigned Content-Length (pre-existing; fixed by WS4, enforcement mechanism gated on P1(d)); event-before-row DLQ noise (L×H likelihood but zero-cost by design); Queues delaySeconds cap ambiguity (resolved — verified 24 h; 6 h grace is safe).
+Honorable mentions: Content-Length pinning enforcement gated on P1(d) (with the exact-size `createUpload` check as fallback); event-before-row DLQ noise (eliminated by the 2 h retry cap + aged-404 ack path); Queues delaySeconds cap ambiguity (resolved — verified 24 h; 1 h grace is safe); `COPIER_HMAC_SECRET` custody (§2.5 blast radius).
 
 ---
 
@@ -441,34 +488,37 @@ Honorable mentions: quota evasion via unsigned Content-Length (pre-existing; fix
 |---|---|---|---|
 | **D1** | **EU jurisdiction for the staging bucket** (immutable at creation; changes endpoint to `<acct>.eu.r2.cloudflarestorage.com`, CSP string, all IaC `jurisdiction` params; legal posture for a GDPR-sensitive product) | Recommend `eu` from day one (B2 is eu-central-003). Note: Queues/Workers are global — object bytes transit the Worker; state this in the privacy review | **WS6, and ideally P1/P2** (prototype against the real endpoint) |
 | **D2** | **Pulumi v6 in-place upgrade vs wrangler-provisioned Cloudflare surface** (two angles disagreed) | Recommend attempting v6 gated on a clean `preview --diff`; fall back to wrangler-in-CI. Either way the Worker deploys via wrangler | **WS6** |
-| **D3** | **Lifecycle fuse N + grace period** | Decided defaults: N=7 d, grace 6 h. Security angle argued N=28 d (> 14 d queue retention + backup-restore window; ~+$175→ balance vs cost at 50 TB/mo). Ops must pair N=7 with a committed 24 h-alert response SLA, or pick 28 | WS6 config only |
+| **D3** | **Lifecycle fuse N + grace period** | Decided defaults: N=7 d fuse (orphans only — normal residency is minutes, per #959 maintainer direction), grace 1 h (= presigned-GET expiry floor). A longer fuse (28 d) was argued for restore-window margin; N=7 keeps orphan cost/residency low but REQUIRES the committed 24 h-alert response SLA | WS6 config only |
 | **D4** | Cloudflare DPA / subprocessor list / privacy-policy update (Cloudflare transiently holds E2E-encrypted content ≤N days; metadata = uuid keys, sizes, timestamps) | Legal/MZLA; engineering not blocked but **prod rollout (WS12) is** | WS12 |
 | **D5** | One Cloudflare account for stage+prod? Workers Paid enabled? (bucket names are account-global; Queues free tier can't cover the 50 TB tier) | Confirm before WS6 naming | WS6 |
-| **D6** | Rollout gate default when `UPLOADS_R2_ROLLOUT_PERCENT` unset (design: 100, behind kill switch) + rollout schedule | Ops preference | WS12 |
-| **D7** | Flip-409 policy: `failed` enum state + Sentry (decided) — does ops also want quarantine/suspicious-file marking or an attempts/lastError column? | Default: enum only | none |
-| **D8** | DLQ/stuck-row alerting surface: Cloudflare-side queue-depth alerting is a new monitoring surface (no CloudWatch equivalent in `tb_pulumi.cloudwatch`); plus who owns weekly DLQ triage | Ops runbook decision | WS12 |
+| **D6** | Rollout: `gatePct` default when the percent env is unset (design: 100, behind the `UPLOADS_R2_MODE` switch), ramp schedule, and the criteria for ever widening `fallback` → `all` (region cohorts?) | Ops preference | WS12 |
+| **D7** | Flip-409 policy: `failed` enum + recurring alerts + redrive runbook (decided) — does ops also want quarantine/suspicious-file marking or an attempts/lastError column? | Default: enum + recurring alerts only | none |
+| **D8** | DLQ alerting surface: Cloudflare-side queue-depth alerting is a new monitoring surface (no CloudWatch equivalent in `tb_pulumi.cloudwatch`); the sweep's backlog gauge (WS13) covers B2-degradation early warning, so this decision narrows to where DLQ-depth alerts live + who owns triage | Ops runbook decision | WS12/WS13 |
 | **D9** | Sentry session replay on upload/download screens at all (signed URLs in network activity)? | Recommend disabling replay network capture for storage hosts | WS1 scope |
-| **D10** | Close pre-existing gaps opportunistically? (a) unauthenticated direct-stream `GET /api/download/:id` skipping the suspicious-file check (ticket #101) — the registry refactor touches this file anyway; (b) repo-wide absence of rate limiting (the R2-staging design adds it only on the internal router) | Recommend yes to (a) | none |
+| **D10** | Adjacent hardening items discovered during this design are tracked in the **private issue tracker**; the registry refactor touches `download.ts` anyway — schedule them opportunistically with WS3/WS5? | Recommend yes where the file is already open | none |
 | **D11** | R2 S3-credential automation: attempt `cloudflare.ApiToken`-based generation (EU permission-group naming under-documented) vs documented one-time dashboard token per env (like the existing manual B2 key step, `pulumi/README.md:54-55`) | Recommend manual + runbook now, automate later | WS6 (minor) |
 
 ---
 
-## 7. Appendix — fact-check ledger
+## 7. Appendix — evidence ledger
 
-### Corrected claims (design uses the corrected reality)
+Every load-bearing platform claim in this note was checked against official documentation (2026-07-06). The first table records claims where the commonly-repeated version is weaker or wrong — the design uses the verified reality; the second table lists claims that cannot be settled on paper and are therefore prototype-gated.
 
-| Claim as originally made | Correction |
+### Verified realities behind commonly-misstated claims
+
+| Commonly-repeated / weaker claim | Verified reality this design uses |
 |---|---|
-| Backblaze's `cloudflare-b2` sample sets `UNSIGNED-PAYLOAD` unconditionally | It's the *default path* (only when the header isn't in ALLOWED_HEADERS). B2's acceptance of UNSIGNED-PAYLOAD is sample-code-grade evidence → P2 asserts it |
+| Backblaze's `cloudflare-b2` sample proves B2 accepts `UNSIGNED-PAYLOAD` | The sample is GET/HEAD-only — weak evidence for PUT. The strong evidence is production itself: `@aws-sdk/s3-request-presigner` presigned PUTs use `X-Amz-Content-Sha256=UNSIGNED-PAYLOAD` (query form), and Send's presigned uploads to B2 have run in prod since 2024. P2 still asserts the *header* form the Worker uses |
 | B2 S3 docs show Content-MD5 support/enforcement | The s3-put-object page never mentions Content-MD5; enforcement is field-evidence-grade (Object Lock runtime error, sftpgo #1336) → **P2 assertion 5 (wrong-MD5 → 400) is mandatory, not optional** |
 | `WHEN_REQUIRED` fix documented in pingvin-share #798 | #798 documents only the breakage. Cite AWS's official reference: `docs.aws.amazon.com/sdkref/latest/guide/feature-dataintegrity.html` (+ v3.729.0 release notes) |
 | v6 has `WorkersForPlatformsScriptSecret` for Worker secrets | **Refuted:** v6.17.0 ships *no* secret resource of any kind (v5's `WorkersSecret` was removed). Alternatives: `WorkersScript.secret_text` inline binding (value in Pulumi state; drift behavior untested) or wrangler — design uses wrangler |
 | Queues requires Workers Paid | Stale: free tier exists (10k ops/day hard cap) — insufficient at the 50 TB tier (~52k ops/day at ~3 ops/message), so Paid remains the planning assumption; dev/stage could run free |
 | workers-sdk #5514 (EU event notifications) needs wrangler v4+ | Fixed **platform-side** Nov 2024 (aligned with the 2024-10-21 R2 release note); no wrangler version requirement — and the rule is IaC-configured anyway |
 | Only Logpush excluded on jurisdiction buckets | Super Slurper is also excluded (neither is used) |
-| Queues delaySeconds cap 12 h (older docs) | Verified **24 h** — 6 h grace delete is comfortably legal |
+| Queues delaySeconds cap 12 h (older docs) | Verified **24 h** — the 1 h grace delete is comfortably legal |
 | Consumer concurrency "GA'd Sep 2024" | Conflated: Sep 2024 was Queues' own GA (raised concurrency to 250, throughput to 5,000 msg/s). Net capability as claimed |
-| `signQuery` signs only host by default | aws4fetch-specific; the repo presigns with `@aws-sdk/s3-request-presigner`, which signs headers set on the command (Content-Type is signed today, `s3b2.ts:32-41`) |
+| "The current presign signs Content-Type" | It signs **neither** Content-Type nor Content-Length: `s3b2.ts` passes no `signableHeaders`, and the SDK excludes `content-type` from signing by default (aws-sdk-js-v3 #3497). WS4 adds both via `signableHeaders` |
+| `AwsClient` is a thin signer | It defaults to **10 internal retries**, which re-send an already-consumed `ReadableStream` — must be constructed with `retries: 0` in the Worker (§2.1) |
 | At-least-once cited from batching-retries page | Lives at `queues/reference/delivery-guarantees/` (facts correct) |
 
 ### Unverifiable-on-paper claims → prototype gates
@@ -490,4 +540,4 @@ Honorable mentions: quota evasion via unsigned Content-Length (pre-existing; fix
 
 ### Implementation footnotes surfaced by verification (easy to lose, all incorporated above)
 
-Queues HTTP publish addresses queues by **UUID**, not name (sweep config). DLQ 4-day persistence applies only without an active consumer (ours has one). R2 delete events omit `size`/`eTag`; create events may include `copySource` (defensive parsing). Multipart-uploaded R2 objects have **no** `checksums.md5` (two-pass fallback is first-class). Queue-consumer CPU default is 30 s — `cpu_ms` raised explicitly. `R2BucketEventNotification` does not support `pulumi import`. Free-plan Queues retention is fixed at 24 h (irrelevant on Paid).
+Queues HTTP publish addresses queues by **UUID**, not name (sweep config). DLQ 4-day persistence applies only without an active consumer (ours has one). R2 delete events omit `size`/`eTag`; create events may include `copySource` (defensive parsing). Multipart-uploaded R2 objects have **no** `checksums.md5` (two-pass fallback is first-class). Queue-consumer CPU default is 30 s — `cpu_ms` raised explicitly (queue consumers share the standard Worker CPU ceiling; the 15-minute figure is **wall-clock**, not CPU). `R2BucketEventNotification` does not support `pulumi import`. Free-plan Queues retention is fixed at 24 h (irrelevant on Paid).


### PR DESCRIPTION
## Summary

Design-first deliverable for #959 — **no production code changes**. Two notes in `packages/send/docs/` (following the `ResumableUploadDesign.md` precedent):

- **`R2StagingFeasibility.md`** — evaluates the four feasibility caveats (background-job infra, replication byte-path cost, client rollout, storage-layer refactor), prices three architecture bundles at 1/10/50 TB-uploaded/month, and recommends the Cloudflare Worker replication path. Core finding: any AWS-resident replicator pays ~$0.09/GB egress out of eu-central-1 (~$922/mo at 10 TB), while a Worker moves the same bytes for ~$5–15/mo flat — R2 egress is free and Cloudflare bills storage on peak-per-day, so minutes-level staging residency costs near-zero.
- **`R2StagingReplicationDesign.md`** — the implementation blueprint: B2-first upload with R2 fallback, the copier-Worker pipeline, R2-event→Queues plumbing, backend integration points down to `file:line`, IaC/CI/secrets, a failure-mode table with testable data-loss invariants (I1–I10), a delivery plan (14 workstreams) gated on three Phase 0 prototypes, and the open decisions needing human sign-off.

All platform/pricing claims were verified against official vendor docs (2026-07-06); claims unverifiable on paper are marked ⚠ and gated on the Phase 0 prototypes (design note §7).

## Incorporates maintainer feedback from #959

- **B2-first, R2-on-fallback** (`UPLOADS_R2_MODE=off|fallback|all`): clients PUT to B2 as today and only fall back to R2 after the retry budget exhausts. This makes every fallback a same-file/same-client A/B proof that R2 resolves B2 failures, and collapses R2 cost/volume to the failing fraction.
- **Minutes-level Cloudflare residency**: push-based replication via R2 events; grace-delete cut to 1 h; the multi-day lifecycle rule is an orphan fuse, not the normal path.
- **Prototype P2 now asserts throughput + a clean Cloudflare billing panel** (the "does R2→B2 via a Worker actually work, with no surprise charges" question), plus a P0 region-reliability canary that tests the premise before committing.
- Trimmed the earlier draft's AI-isms / process jargon.

## Review notes

This went through a multi-lens review before publishing; two substantive fixes are already folded in: a transient-vs-terminal split at the flip endpoint (a momentary B2 blip could otherwise poison a fully-copied file into a lifecycle-deletable `failed` state), and B2-aware orphan handling (no permanent B2 orphan of a user-deleted file; no reconciliation livelock).

Suggested review focus:
1. Open-decisions table (design note §6) — several block IaC (D1 EU jurisdiction, D2 Pulumi v6-vs-wrangler).
2. Phase 0 prototype specs (§3) — cheap, and they de-risk everything downstream.
3. The B2-first fallback routing and the `r2 | b2 | failed` pointer states.

A few pre-existing, unrelated hardening items surfaced during the investigation (telemetry hygiene, upload-size enforcement, rate limiting) are tracked separately in the private issue tracker rather than here.

Informs #959; closes nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
