### PR TITLE
fix(send): idempotent create-entry + cleanup endpoint for failed uploads

### DIFF
--- a/packages/send/backend/src/models.ts
+++ b/packages/send/backend/src/models.ts
@@ -330,6 +330,68 @@ export async function deleteUpload(id: string) {
   });
 }
 
+/**
+ * Best-effort cleanup of uploads by id, used when a (multipart) upload fails
+ * partway and the client wants to remove any parts it already wrote to storage.
+ *
+ * Removes the stored bytes (keyed by upload id) and, when present, the DB
+ * `Upload` row.
+ *
+ * Trust boundary: an upload's bytes are keyed by a server-generated UUID that is
+ * only ever returned to the client that requested the presigned URL, so the ids
+ * are effectively unguessable. When a DB `Upload` row exists we additionally
+ * require the requester to be its owner and refuse otherwise. Storage-only
+ * orphans — a PUT that landed bytes but never created a row — have no owner to
+ * check and are removed by id.
+ */
+export async function deleteUploadsByIds(ids: string[], requesterId: string) {
+  const rows = await prisma.upload.findMany({
+    where: { id: { in: ids } },
+    select: { id: true, ownerId: true },
+  });
+  const ownerById = new Map(rows.map(({ id, ownerId }) => [id, ownerId]));
+
+  const deleted: string[] = [];
+  const skipped: string[] = [];
+  const errors: string[] = [];
+
+  // Deduplicate so a repeated id isn't processed twice.
+  await Promise.all(
+    [...new Set(ids)].map(async (id) => {
+      const owner = ownerById.get(id);
+
+      // A row exists but belongs to someone else — refuse to touch it.
+      if (owner !== undefined && owner !== requesterId) {
+        skipped.push(id);
+        return;
+      }
+
+      // Remove bytes first. Absent bytes (e.g. a part whose PUT never landed)
+      // are fine — the goal is idempotent "make sure it's gone".
+      try {
+        await storage.del(id);
+      } catch (e) {
+        console.warn(`[deleteUploadsByIds] storage.del(${id}) failed`, e);
+      }
+
+      // Only remove a DB row we actually found.
+      if (owner !== undefined) {
+        try {
+          await deleteUpload(id);
+        } catch (e) {
+          console.error(`[deleteUploadsByIds] deleteUpload(${id}) failed`, e);
+          errors.push(id);
+          return;
+        }
+      }
+
+      deleted.push(id);
+    })
+  );
+
+  return { deleted, skipped, errors };
+}
+
 export async function getContainersOwnedByUser(id: string) {
   return await prisma.container.findMany({
     where: {

--- a/packages/send/backend/src/models/uploads.ts
+++ b/packages/send/backend/src/models/uploads.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@prisma/client';
+import { Prisma, PrismaClient } from '@prisma/client';
 import storage from '../storage';
 import { fromPrismaV2 } from './prisma-helper';
 const prisma = new PrismaClient();
@@ -47,6 +47,24 @@ export async function createUpload(
       },
     });
   } catch (error) {
+    // Create-entry is retried by the client with the SAME server-minted id
+    // (the id is generated once at /uploads/signed and reused across retries).
+    // So a retry after the row already committed hits a unique-constraint
+    // violation (Prisma P2002). That is not a failure — the row exists exactly
+    // as we'd create it — so return it and let item-creation proceed, instead
+    // of throwing forever and dooming the whole (multipart) upload. Only treat
+    // it as success when the existing row belongs to the SAME owner, so a
+    // (vanishingly unlikely) id collision across users can never hand back
+    // another user's upload.
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === 'P2002'
+    ) {
+      const existing = await prisma.upload.findUnique({ where: { id } });
+      if (existing && existing.ownerId === ownerId) {
+        return existing;
+      }
+    }
     console.error('ERROR creating upload:', error);
     throw new BaseError(UPLOAD_NOT_CREATED);
   }

--- a/packages/send/backend/src/routes/uploads.ts
+++ b/packages/send/backend/src/routes/uploads.ts
@@ -22,7 +22,7 @@ import {
 } from '../models/uploads';
 
 import { getDataFromAuthenticatedRequest } from '@send-backend/auth/client';
-import { reportUpload } from '@send-backend/models';
+import { deleteUploadsByIds, reportUpload } from '@send-backend/models';
 import storage from '@send-backend/storage';
 import { useMetrics } from '../metrics';
 import {
@@ -176,6 +176,64 @@ router.post(
     }
   })
 );
+
+// Zod schema for cleaning up failed-upload parts
+const cleanupSchema = z.object({
+  ids: z.array(z.string()).min(1, 'At least one ID is required'),
+});
+
+/**
+ * @openapi
+ * /api/uploads/cleanup:
+ *   post:
+ *     summary: Delete uploaded parts of a failed upload
+ *     description: >-
+ *       Removes stored bytes (and any DB rows) for the given upload ids. Used by
+ *       the client to clean up a multipart upload that failed partway, so no
+ *       orphaned parts are left in storage. Only removes rows owned by the
+ *       authenticated user; storage-only orphans (no DB row) are removed by id.
+ *     tags: [Uploads]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               ids:
+ *                 type: array
+ *                 items:
+ *                   type: string
+ *                 minItems: 1
+ *             required:
+ *               - ids
+ *     responses:
+ *       200:
+ *         description: Cleanup completed
+ *       400:
+ *         description: Invalid request body
+ *       500:
+ *         description: Failed to clean up uploads
+ */
+router.post('/cleanup', requireJWT, async (req, res) => {
+  try {
+    const { ids } = cleanupSchema.parse(req.body);
+    const { id: requesterId } = getDataFromAuthenticatedRequest(req);
+    const result = await deleteUploadsByIds(ids, requesterId);
+    return res.status(200).json({ message: 'Cleanup complete', ...result });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return res.status(400).json({
+        message: 'Invalid request body',
+        errors: error.errors,
+      });
+    }
+    console.error('Error cleaning up uploads:', error);
+    return res.status(500).json({ message: 'Failed to clean up uploads' });
+  }
+});
 
 /**
  * @openapi

--- a/packages/send/backend/src/test/models/uploads.createentry.test.ts
+++ b/packages/send/backend/src/test/models/uploads.createentry.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Regression test for the multipart create-entry idempotency fix.
+//
+// Create-entry is retried by the client with the SAME server-minted id (minted
+// once at /uploads/signed and reused). Before the fix, a retry after the Upload
+// row already committed hit a Prisma P2002 unique-constraint violation, which
+// createUpload rethrew as UPLOAD_NOT_CREATED — permanently dooming the whole
+// multipart upload and stranding an Item-less Upload orphan. The fix treats
+// P2002 as success and returns the existing row.
+
+const h = vi.hoisted(() => {
+  // Minimal stand-in matching the shape createUpload checks:
+  // `error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002'`.
+  class PrismaClientKnownRequestError extends Error {
+    code: string;
+    constructor(message: string, opts: { code: string }) {
+      super(message);
+      this.code = opts.code;
+    }
+  }
+  return {
+    mockCreate: vi.fn(),
+    mockFindUnique: vi.fn(),
+    mockLength: vi.fn(),
+    PrismaClientKnownRequestError,
+  };
+});
+
+vi.mock('@prisma/client', () => ({
+  PrismaClient: vi.fn(function () {
+    return {
+      upload: { create: h.mockCreate, findUnique: h.mockFindUnique },
+    };
+  }),
+  Prisma: { PrismaClientKnownRequestError: h.PrismaClientKnownRequestError },
+}));
+
+// Module under test imports `storage` via '../storage'; from this test file the
+// same file resolves at '../../storage'. Only length() is exercised here.
+vi.mock('../../storage', () => ({
+  default: { length: h.mockLength },
+}));
+
+// Static import (not top-level `await import`) so tsc is happy; vi.mock() above
+// is hoisted above imports, so createUpload still sees the mocked Prisma/storage.
+import { createUpload } from '../../models/uploads';
+
+const ID = '11111111-1111-1111-1111-111111111111';
+const ARGS = [ID, 100, 'owner-1', 'MESSAGE', 1, 'hash'] as const;
+
+describe('createUpload idempotency (multipart create-entry retry)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Stored object is at least as large as the stated size, so the size check passes.
+    h.mockLength.mockResolvedValue(150);
+  });
+
+  it('returns the created row on first attempt', async () => {
+    const row = { id: ID, size: 100, part: 1 };
+    h.mockCreate.mockResolvedValue(row);
+
+    const result = await createUpload(...ARGS);
+
+    expect(result).toBe(row);
+    expect(h.mockFindUnique).not.toHaveBeenCalled();
+  });
+
+  it('returns the existing row (not throw) when the retry hits a P2002 unique violation', async () => {
+    // Same owner as ARGS (owner-1) — this is the real retry case.
+    const existing = { id: ID, size: 100, part: 1, ownerId: 'owner-1' };
+    h.mockCreate.mockRejectedValue(
+      new h.PrismaClientKnownRequestError('Unique constraint failed', {
+        code: 'P2002',
+      })
+    );
+    h.mockFindUnique.mockResolvedValue(existing);
+
+    const result = await createUpload(...ARGS);
+
+    expect(result).toBe(existing);
+    expect(h.mockFindUnique).toHaveBeenCalledWith({ where: { id: ID } });
+  });
+
+  it('throws (does not hand back a foreign row) if the P2002 id collides with another owner', async () => {
+    // Astronomically unlikely UUIDv4 collision across users: the existing row
+    // belongs to someone else, so idempotency must NOT return it.
+    h.mockCreate.mockRejectedValue(
+      new h.PrismaClientKnownRequestError('Unique constraint failed', {
+        code: 'P2002',
+      })
+    );
+    h.mockFindUnique.mockResolvedValue({
+      id: ID,
+      size: 100,
+      part: 1,
+      ownerId: 'someone-else',
+    });
+
+    await expect(createUpload(...ARGS)).rejects.toThrow();
+  });
+
+  it('still throws if P2002 fires but the row cannot be found', async () => {
+    h.mockCreate.mockRejectedValue(
+      new h.PrismaClientKnownRequestError('Unique constraint failed', {
+        code: 'P2002',
+      })
+    );
+    h.mockFindUnique.mockResolvedValue(null);
+
+    await expect(createUpload(...ARGS)).rejects.toThrow();
+  });
+
+  it('rethrows non-P2002 database errors as a create failure', async () => {
+    h.mockCreate.mockRejectedValue(new Error('connection reset'));
+
+    await expect(createUpload(...ARGS)).rejects.toThrow();
+    expect(h.mockFindUnique).not.toHaveBeenCalled();
+  });
+});

--- a/packages/send/backend/src/test/routes/uploads.cleanup.routes.test.ts
+++ b/packages/send/backend/src/test/routes/uploads.cleanup.routes.test.ts
@@ -1,0 +1,101 @@
+import express from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockDeleteUploadsByIds, mockAuthenticatedRequest } = vi.hoisted(() => ({
+  mockDeleteUploadsByIds: vi.fn(),
+  mockAuthenticatedRequest: vi.fn(),
+}));
+
+// The route only needs deleteUploadsByIds; stub the rest of the barrel so the
+// import resolves without a database.
+vi.mock('@send-backend/models', () => ({
+  deleteUploadsByIds: mockDeleteUploadsByIds,
+  reportUpload: vi.fn(),
+}));
+
+// Avoid the real storage client (Backblaze token timer + AWS SDK) at import.
+vi.mock('@send-backend/storage', () => ({
+  default: { del: vi.fn() },
+}));
+
+vi.mock('@send-backend/auth/client', () => ({
+  getDataFromAuthenticatedRequest: mockAuthenticatedRequest,
+}));
+
+// All middleware becomes a pass-through so we exercise the handler directly.
+vi.mock('../../middleware', () => {
+  const passthrough = (_req, _res, next) => next();
+  return {
+    requireJWT: passthrough,
+    checkStorageLimit: passthrough,
+    getGroupMemberPermissions: passthrough,
+    requireWritePermission: passthrough,
+  };
+});
+
+// vi.mock() calls above are hoisted above imports, so this router picks up the
+// stubs. (Static import instead of top-level `await import` to keep tsc happy.)
+import router from '../../routes/uploads';
+
+const app = express();
+app.use(express.json());
+app.use('/api/uploads', router);
+
+describe('POST /api/uploads/cleanup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuthenticatedRequest.mockReturnValue({ id: 'user-1' });
+  });
+
+  it('deletes the given uploads on behalf of the authenticated user', async () => {
+    mockDeleteUploadsByIds.mockResolvedValue({
+      deleted: ['a', 'b'],
+      skipped: [],
+      errors: [],
+    });
+
+    const response = await request(app)
+      .post('/api/uploads/cleanup')
+      .send({ ids: ['a', 'b'] })
+      .set('Content-Type', 'application/json');
+
+    expect(response.status).toBe(200);
+    expect(mockDeleteUploadsByIds).toHaveBeenCalledWith(['a', 'b'], 'user-1');
+    expect(response.body).toMatchObject({
+      message: 'Cleanup complete',
+      deleted: ['a', 'b'],
+    });
+  });
+
+  it('rejects an empty id list with 400 and does not touch storage', async () => {
+    const response = await request(app)
+      .post('/api/uploads/cleanup')
+      .send({ ids: [] })
+      .set('Content-Type', 'application/json');
+
+    expect(response.status).toBe(400);
+    expect(mockDeleteUploadsByIds).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing ids field with 400', async () => {
+    const response = await request(app)
+      .post('/api/uploads/cleanup')
+      .send({})
+      .set('Content-Type', 'application/json');
+
+    expect(response.status).toBe(400);
+    expect(mockDeleteUploadsByIds).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 when cleanup throws', async () => {
+    mockDeleteUploadsByIds.mockRejectedValue(new Error('db down'));
+
+    const response = await request(app)
+      .post('/api/uploads/cleanup')
+      .send({ ids: ['a'] })
+      .set('Content-Type', 'application/json');
+
+    expect(response.status).toBe(500);
+  });
+});


### PR DESCRIPTION
## What changed?

Two backend changes that stop partially-failed uploads from leaving storage behind:

- **Create-entry is now idempotent** — if the same owner retries with an upload id that already exists, it succeeds instead of erroring. Previously a retry could fail permanently and strand an upload.
- **A cleanup endpoint** lets the client remove the parts a failed upload already wrote, with helpers to identify orphaned uploads.

_AI disclosure: developed with AI assistance (Claude) and reviewed by me._

## Why?

Multipart uploads that fail partway — or whose create-entry step is retried — could leave uploaded parts in storage that count against the user's quota but never appear in the UI. Making create-entry idempotent removes one orphan source, and the cleanup endpoint gives the client a way to reclaim what a failed attempt wrote.

## Limitations and Notes

This is the backend half; the frontend that calls the cleanup endpoint (including cleanup on tab-close) is in a follow-up PR. A scheduled server-side sweeper for already-orphaned data is tracked separately in #117.

## Applicable Issues

Addresses #887
