### PR TITLE
feat(send): reliable multipart uploads with bounded concurrency and cleanup

### DIFF
--- a/packages/send/frontend/src/lib/const.ts
+++ b/packages/send/frontend/src/lib/const.ts
@@ -31,6 +31,14 @@ export const MAX_ACCESS_LINK_RETRIES = 5;
 const SPLIT_SIZE_IN_MB: number = import.meta.env.VITE_SPLIT_SIZE_IN_MB || 100; // Default to 100 MB if not set
 export const SPLIT_SIZE = SPLIT_SIZE_IN_MB * ONE_MB_IN_BYTES;
 
+// Maximum number of parts of a multipart upload that are uploaded concurrently.
+// Parts are run through a bounded pool (not fixed sequential batches), so a slow
+// or failing part never blocks unrelated parts from starting.
+// Tuned to 4: uploads are bandwidth-bound (aggregate throughput is flat from 2
+// to 8 concurrent parts), so 4 keeps the pipe saturated without buffering more
+// ciphertext in memory than necessary. See docs/UploadReliabilityOptimizations.md.
+export const MAX_CONCURRENT_PARTS = 4;
+
 // Cache durations
 const ONE_MINUTE_IN_MILLISECONDS = 60 * 1000;
 export const FIFTEEN_MINUTES = 15 * ONE_MINUTE_IN_MILLISECONDS; // 15 minutes in milliseconds

--- a/packages/send/frontend/src/lib/filesync.ts
+++ b/packages/send/frontend/src/lib/filesync.ts
@@ -129,13 +129,24 @@ export async function getBlob(
   }
 }
 
+export type SendBlobOptions = {
+  // Cancels the in-flight PUT (and blocks retries) when a sibling part fails.
+  signal?: AbortSignal;
+  // Invoked with the storage upload id as soon as it is known — before the PUT
+  // for bucket storage — so the caller can track every part it has begun writing
+  // and clean them up if the overall upload later fails.
+  onUploadId?: (id: string) => void;
+};
+
 export async function sendBlob(
   blob: Blob,
   aesKey: CryptoKey,
   api: ApiConnection,
   progressTracker: ProgressTracker,
-  isBucketStorage = true
+  isBucketStorage = true,
+  options: SendBlobOptions = {}
 ): Promise<string> {
+  const { signal, onUploadId } = options;
   const stream = blobStream(blob);
   if (!isBucketStorage) {
     const encryptedSize = calculateEncryptedSize(blob.size);
@@ -144,11 +155,9 @@ export async function sendBlob(
     });
 
     // Using a type guard since a JsonResponse can be a single object or an array
-    if (Array.isArray(result)) {
-      return result[0].id;
-    } else {
-      return result.id;
-    }
+    const id = Array.isArray(result) ? result[0].id : result.id;
+    onUploadId?.(id);
+    return id;
   }
 
   try {
@@ -160,6 +169,10 @@ export async function sendBlob(
       },
       'POST'
     );
+
+    // Record the id now — the bytes may land at this key even if the PUT below
+    // fails partway, so the caller must be able to clean it up.
+    onUploadId?.(id);
 
     progressTracker.setProcessStage('encrypting');
     progressTracker.setText('Encrypting file');
@@ -182,6 +195,7 @@ export async function sendBlob(
       url,
       readableStream,
       progressTracker,
+      signal,
     });
     return id;
   } catch (error) {

--- a/packages/send/frontend/src/lib/helpers.retry.test.ts
+++ b/packages/send/frontend/src/lib/helpers.retry.test.ts
@@ -20,6 +20,7 @@ import {
 } from 'vitest';
 import {
   getUploadRetryDelayMs,
+  UPLOAD_ABORTED,
   UPLOAD_HTTP_RETRY_LIMIT,
   uploadWithTracker,
 } from './helpers';
@@ -180,7 +181,7 @@ describe('uploadWithTracker — HTTP-level retry', () => {
     expect(calls).toBe(2);
   });
 
-  it('retries on 4xx (verifies retry isn\'t gated on 5xx-only)', async () => {
+  it("retries on 4xx (verifies retry isn't gated on 5xx-only)", async () => {
     // Documents current behavior: any non-2xx triggers retry. This may not be
     // semantically correct (a 4xx is the client's fault and won't get better
     // on retry), but it's what the code does today.
@@ -188,7 +189,8 @@ describe('uploadWithTracker — HTTP-level retry', () => {
     server.use(
       http.put(TEST_URL, () => {
         calls++;
-        if (calls === 1) return HttpResponse.text('bad request', { status: 400 });
+        if (calls === 1)
+          return HttpResponse.text('bad request', { status: 400 });
         return HttpResponse.text('ok', { status: 200 });
       })
     );
@@ -202,6 +204,32 @@ describe('uploadWithTracker — HTTP-level retry', () => {
     ).resolves.toBeDefined();
 
     expect(calls).toBe(2);
+  });
+
+  it('does not attempt the PUT when the signal is already aborted', async () => {
+    let calls = 0;
+    server.use(
+      http.put(TEST_URL, () => {
+        calls++;
+        return HttpResponse.text('ok', { status: 200 });
+      })
+    );
+
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      uploadWithTracker({
+        url: TEST_URL,
+        readableStream: makeStream(),
+        progressTracker: mockProgressTracker,
+        signal: controller.signal,
+      })
+    ).rejects.toThrow(UPLOAD_ABORTED);
+
+    // Aborted before it started: no request, and no backoff scheduled.
+    expect(calls).toBe(0);
+    expect(scheduledDelays).toHaveLength(0);
   });
 
   it('resets progress to 0 before each retry attempt', async () => {
@@ -223,8 +251,9 @@ describe('uploadWithTracker — HTTP-level retry', () => {
     // First attempt: no setProgress(0) (attempt === 0).
     // Second attempt (retry #1): setProgress(0).
     // Third attempt (retry #2): setProgress(0).
-    const zeroResetCalls = (mockProgressTracker.setProgress as ReturnType<typeof vi.fn>).mock.calls
-      .filter((args) => args[0] === 0).length;
+    const zeroResetCalls = (
+      mockProgressTracker.setProgress as ReturnType<typeof vi.fn>
+    ).mock.calls.filter((args) => args[0] === 0).length;
     expect(zeroResetCalls).toBeGreaterThanOrEqual(2);
   });
 });

--- a/packages/send/frontend/src/lib/helpers.ts
+++ b/packages/send/frontend/src/lib/helpers.ts
@@ -262,7 +262,14 @@ type UploadOptions = {
   url: string;
   readableStream: ReadableStream;
   progressTracker: ProgressTracker;
+  // When aborted, the in-flight PUT is cancelled and no further retries run.
+  // Used to cancel sibling parts once a multipart upload is known to be doomed.
+  signal?: AbortSignal;
 };
+
+// Thrown when a PUT is cancelled via the AbortSignal. Distinct from a transient
+// failure so the retry loop knows not to retry it.
+export const UPLOAD_ABORTED = 'UPLOAD_ABORTED';
 
 // Upload PUT retry policy. The hard B2 failures seen in production
 // (Sentry SEND-SUITE-FRONTEND-24H) are multi-minute stalls, so we retry a
@@ -302,11 +309,17 @@ export const uploadWithTracker = ({
   url,
   readableStream,
   progressTracker,
+  signal,
 }: UploadOptions) => {
   const { setProgress } = progressTracker;
-  const XHR_TIMEOUT_MS = 60000;
+  const XHR_TIMEOUT_MS = 180000;
 
   const attemptPut = (blob: Blob, attempt: number): Promise<string> => {
+    // Bail out immediately if a sibling part already failed and aborted us.
+    if (signal?.aborted) {
+      return Promise.reject(new Error(UPLOAD_ABORTED));
+    }
+
     // Reset progress on retry so the UI gets a clean signal
     // rather than silently jumping backwards
     if (attempt > 0) {
@@ -319,6 +332,10 @@ export const uploadWithTracker = ({
       xhr.setRequestHeader('Content-Type', 'application/octet-stream');
       xhr.timeout = XHR_TIMEOUT_MS;
 
+      const onAbort = () => xhr.abort();
+      signal?.addEventListener('abort', onAbort, { once: true });
+      const cleanup = () => signal?.removeEventListener('abort', onAbort);
+
       xhr.upload.onprogress = (event) => {
         if (event.lengthComputable) {
           // For multipart uploads, the progress tracker will handle the proper calculation
@@ -328,6 +345,7 @@ export const uploadWithTracker = ({
       };
 
       xhr.onload = () => {
+        cleanup();
         if (xhr.status >= 200 && xhr.status < 300) {
           resolve(xhr.response);
         } else {
@@ -336,13 +354,24 @@ export const uploadWithTracker = ({
         }
       };
 
-      xhr.onerror = () => reject(new Error('XHR: UPLOAD_FAILED'));
-      xhr.ontimeout = () =>
+      xhr.onabort = () => {
+        cleanup();
+        reject(new Error(UPLOAD_ABORTED));
+      };
+      xhr.onerror = () => {
+        cleanup();
+        reject(new Error('XHR: UPLOAD_FAILED'));
+      };
+      xhr.ontimeout = () => {
+        cleanup();
         reject(new Error(`Upload timed out after ${XHR_TIMEOUT_MS / 1000}s`));
+      };
 
       xhr.send(blob);
     }).catch((error) => {
-      if (attempt < UPLOAD_HTTP_RETRY_LIMIT) {
+      // Never retry an abort — it means the whole upload has been cancelled.
+      const aborted = signal?.aborted || error?.message === UPLOAD_ABORTED;
+      if (!aborted && attempt < UPLOAD_HTTP_RETRY_LIMIT) {
         const delayMs = getUploadRetryDelayMs(attempt);
         console.warn(
           `HTTP PUT attempt ${attempt + 1} failed, retrying in ${delayMs}ms...`,

--- a/packages/send/frontend/src/lib/upload.ts
+++ b/packages/send/frontend/src/lib/upload.ts
@@ -10,7 +10,7 @@ import { NamedBlob, sendBlob } from '@send-frontend/lib/filesync';
 import { Keychain } from '@send-frontend/lib/keychain';
 import { UserType } from '@send-frontend/types';
 import * as Sentry from '@sentry/vue';
-import { SPLIT_SIZE } from './const';
+import { MAX_CONCURRENT_PARTS, SPLIT_SIZE } from './const';
 import {
   hashFiles,
   retryUntilSuccessOrTimeout,
@@ -51,6 +51,43 @@ export default class Uploader {
     // from an existing session or to populate from an initial login.
     this.keychain = keychain;
     this.api = api;
+  }
+
+  /**
+   * Asks the backend to delete every part this upload attempt wrote to storage.
+   * Called when a multipart upload fails partway so that already-uploaded (and
+   * partially-uploaded) parts don't linger as orphaned bytes in the bucket.
+   */
+  private async deleteWrittenUploads(api: ApiConnection, ids: string[]) {
+    if (ids.length === 0) {
+      return;
+    }
+    await api.call('uploads/cleanup', { ids }, 'POST');
+  }
+
+  /**
+   * Fire-and-forget cleanup for use during page teardown (pagehide), when an
+   * upload is still in flight and the normal `if (fatalError)` cleanup will
+   * never run. Uses a `keepalive` fetch so the request survives the page being
+   * torn down, and cookie auth (`credentials: 'include'`) since requireJWT reads
+   * the auth cookie — a Bearer header can't be attached reliably at unload time.
+   * Best-effort only: hard kills/crashes still rely on the server-side reaper.
+   */
+  private teardownCleanup(api: ApiConnection, ids: string[]) {
+    if (ids.length === 0) {
+      return;
+    }
+    try {
+      void fetch(`${api.serverUrl}/api/uploads/cleanup`, {
+        method: 'POST',
+        keepalive: true,
+        credentials: 'include',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ ids }),
+      });
+    } catch {
+      // best-effort; nothing we can do at teardown
+    }
   }
 
   /**
@@ -190,7 +227,13 @@ export default class Uploader {
       fileBlob.size // Pass original file size
     );
 
-    // Process all uploads concurrently for better performance
+    // When any part fails permanently we abort the in-flight PUTs of the other
+    // parts (via this signal) and clean up every storage object we started
+    // writing (tracked in `writtenUploadIds`) so no orphaned bytes are left in
+    // the bucket.
+    const abortController = new AbortController();
+    const writtenUploadIds = new Set<string>();
+
     const uploadPart = async (
       blob: NamedBlob,
       index: number
@@ -200,102 +243,129 @@ export default class Uploader {
 
       const partTracker = multipartTracker.getPartTracker(index);
 
-      // Retry the entire upload block if either the upload POST or itemObj call fail
+      // We set the part number starting from 1 to avoid problems with part 0 evaluating to false
+      const part = shouldSplit ? index + 1 : undefined;
+
+      // Encrypt + upload the part exactly once. The PUT owns its own
+      // retry/backoff (uploadWithTracker) and honors the abort signal, so we
+      // never re-encrypt or re-request a signed URL on a transient network
+      // failure. sendBlob throws once the PUT retries are exhausted.
+      const id = await sendBlob(blob, key, api, partTracker, isBucketStorage, {
+        signal: abortController.signal,
+        onUploadId: (uploadId) => writtenUploadIds.add(uploadId),
+      });
+
+      if (!id) {
+        throw new Error('Failed to send blob');
+      }
+
+      // Wait for storage to confirm the object is fully written before creating
+      // the DB entry. This is REQUIRED for bucket storage too: the object lands
+      // via the S3 presigned PUT, but the backend size-check (create-entry)
+      // reads via the native B2 API, which is not immediately read-after-write
+      // consistent. Skipping this races that lag and makes create-entry fail
+      // intermittently with UPLOAD_SIZE_ERROR (500). Poll up to 3 min.
+      await retryUntilSuccessOrTimeout(
+        async () => {
+          const { size } = await this.api.call<{ size: null | number }>(
+            `uploads/${id}/stat`
+          );
+          // Return a boolean, telling us if the size is null or not
+          return !!size;
+        },
+        2_000,
+        180_000
+      );
+
+      // Create the DB Content entry + Item. These are cheap POSTs, so we retry
+      // them independently of the (already-completed) upload — a transient API
+      // failure here must not re-drive the PUT or re-encrypt the blob.
       let uploadResult: {
         upload: UploadResponse;
         itemObj: ItemResponse;
       } | null = null;
+      // The Upload row is created once and reused across retries: if create-entry
+      // succeeds but item-creation fails, we must NOT re-POST /uploads (the id is
+      // fixed, so a re-POST would race the same row). Hold the created row here so
+      // a retry only re-attempts the step that actually failed.
+      let upload: UploadResponse | null = null;
       let retryCount = 0;
       const maxRetries = 5;
 
-      // We set the part number starting from 1 to avoid problems with part 0 evaluating to false
-      const part = shouldSplit ? index + 1 : undefined;
-
       while (retryCount < maxRetries && !uploadResult) {
+        // Stop retrying DB writes if a sibling part already doomed the upload.
+        if (abortController.signal.aborted) {
+          throw new Error('Upload aborted');
+        }
         try {
-          // Blob is encrypted as it is uploaded through a websocket connection
-          const id = await sendBlob(
-            blob,
-            key,
-            api,
-            partTracker,
-            isBucketStorage
-          );
-
-          if (!id) {
-            throw new Error('Failed to send blob');
-          }
-
-          if (!isBucketStorage) {
-            // Poll the api to check if the file is in storage
-            await retryUntilSuccessOrTimeout(async () => {
-              const { size } = await this.api.call<{ size: null | number }>(
-                `uploads/${id}/stat`
-              );
-              // Return a boolean, telling us if the size is null or not
-              return !!size;
-            });
-          }
-
-          // Create a Content entry in the database.
-          // Capture why this call fails (network vs API 4xx/5xx + status) so
-          // Sentry can break "Failed to create upload entry" down by cause and
-          // rate. Observability only (#914) — no retry/timeout change here.
-          let createEntryFailure: ApiCallFailure | undefined;
-          const result = await this.api.call<{
-            upload: UploadResponse;
-          }>(
-            'uploads',
-            {
-              id: id,
-              size: blob.size,
-              ownerId: this.user.id,
-              type: blob.type,
-              containerId,
-              part, // if the file was split into multiple zips, we add the part
-              fileHash: hashes[index],
-            },
-            'POST',
-            {},
-            {
-              onFailure: (failure) => {
-                createEntryFailure = failure;
+          if (!upload) {
+            // Create a Content entry in the database.
+            // Capture why this call fails (network vs API 4xx/5xx + status) so
+            // Sentry can break "Failed to create upload entry" down by cause and
+            // rate. Observability only (#914) — no retry/timeout change here.
+            let createEntryFailure: ApiCallFailure | undefined;
+            const result = await this.api.call<{
+              upload: UploadResponse;
+            }>(
+              'uploads',
+              {
+                id: id,
+                size: blob.size,
+                ownerId: this.user.id,
+                type: blob.type,
+                containerId,
+                part, // if the file was split into multiple zips, we add the part
+                fileHash: hashes[index],
               },
-            }
-          );
-          if (!result) {
-            const cause = createEntryFailureToCause(createEntryFailure);
-            Sentry.captureException(cause, {
-              tags: {
-                upload_stage: 'create_entry',
-                create_entry_failure_kind: createEntryFailure?.kind ?? 'unknown',
-                ...(createEntryFailure?.kind === 'http'
-                  ? { create_entry_http_status: String(createEntryFailure.status) }
-                  : {}),
-              },
-              contexts: {
-                create_entry: {
-                  kind: createEntryFailure?.kind ?? 'unknown',
-                  status:
-                    createEntryFailure?.kind === 'http'
-                      ? createEntryFailure.status
-                      : null,
-                  statusText:
-                    createEntryFailure?.kind === 'http'
-                      ? createEntryFailure.statusText
-                      : undefined,
-                  body:
-                    createEntryFailure?.kind === 'http'
-                      ? createEntryFailure.body
-                      : undefined,
+              'POST',
+              {},
+              {
+                onFailure: (failure) => {
+                  createEntryFailure = failure;
                 },
-              },
-            });
-            throw new Error('Failed to create upload entry', { cause });
+              }
+            );
+            if (!result) {
+              const cause = createEntryFailureToCause(createEntryFailure);
+              Sentry.captureException(cause, {
+                tags: {
+                  upload_stage: 'create_entry',
+                  create_entry_failure_kind:
+                    createEntryFailure?.kind ?? 'unknown',
+                  ...(createEntryFailure?.kind === 'http'
+                    ? {
+                        create_entry_http_status: String(
+                          createEntryFailure.status
+                        ),
+                      }
+                    : {}),
+                },
+                contexts: {
+                  create_entry: {
+                    kind: createEntryFailure?.kind ?? 'unknown',
+                    status:
+                      createEntryFailure?.kind === 'http'
+                        ? createEntryFailure.status
+                        : null,
+                    statusText:
+                      createEntryFailure?.kind === 'http'
+                        ? createEntryFailure.statusText
+                        : undefined,
+                    body:
+                      createEntryFailure?.kind === 'http'
+                        ? createEntryFailure.body
+                        : undefined,
+                  },
+                },
+              });
+              throw new Error('Failed to create upload entry', { cause });
+            }
+            upload = result.upload;
           }
-          const upload = result.upload;
 
-          // For the Content entry, create the corresponding Item in the Container
+          // Create the corresponding Item in the Container. This runs on every
+          // retry until it succeeds; because `upload` is created once and reused,
+          // a transient item-creation failure never re-POSTs /uploads.
           const itemObj = await this.api.call<ItemResponse>(
             `containers/${containerId}/item`,
             {
@@ -316,16 +386,13 @@ export default class Uploader {
           uploadResult = { upload, itemObj };
         } catch (error) {
           retryCount++;
-          console.error(`Upload attempt ${retryCount} failed:`, error);
+          console.error(`Create-entry attempt ${retryCount} failed:`, error);
 
           if (retryCount >= maxRetries) {
             const failureMessage =
               `Upload failed for ${fileBlob.name} after ${maxRetries} attempts` +
               (part ? ` (part ${part})` : '');
             console.error(failureMessage, error);
-            progressTracker.setProcessStage('error');
-            progressTracker.setText(failureMessage);
-            progressTracker.error = failureMessage;
             throw new Error(failureMessage);
           }
 
@@ -334,10 +401,6 @@ export default class Uploader {
             setTimeout(resolve, Math.pow(2, retryCount) * 1000)
           );
         }
-      }
-
-      if (!uploadResult) {
-        return null;
       }
 
       const { itemObj } = uploadResult;
@@ -357,35 +420,77 @@ export default class Uploader {
       return item;
     };
 
-    // Process uploads in batches of 5 for better resource management
-    const uploadResponses: Item[] = [];
-    const BATCH_SIZE = 5;
+    // Upload parts through a bounded-concurrency pool: up to
+    // MAX_CONCURRENT_PARTS run at once and, as each finishes, the next queued
+    // part starts immediately. There is no per-batch barrier, so a slow or
+    // failing part never blocks unrelated parts from starting. The first part
+    // that fails permanently records the error and aborts the rest.
+    const uploadResponses: Item[] = new Array(blobs.length);
+    let nextIndex = 0;
+    let fatalError: unknown = null;
 
-    for (let i = 0; i < blobs.length; i += BATCH_SIZE) {
-      const batch = blobs.slice(i, i + BATCH_SIZE);
-      const batchPromises = batch.map((blob, batchIndex) => {
-        const index = i + batchIndex;
-        return uploadPart(blob, index);
-      });
+    const runWorker = async (): Promise<void> => {
+      while (true) {
+        if (fatalError) {
+          return;
+        }
+        const index = nextIndex++;
+        if (index >= blobs.length) {
+          return;
+        }
+        try {
+          const item = await uploadPart(blobs[index], index);
+          if (!item) {
+            throw new Error(`Upload part ${index} returned no item`);
+          }
+          uploadResponses[index] = item;
+        } catch (error) {
+          // First failure dooms the upload: record it and cancel the in-flight
+          // PUTs of the sibling parts. Those PUTs are cancelled instead of
+          // running to completion, so no more bytes are written past this point.
+          if (!fatalError) {
+            fatalError = error;
+          }
+          abortController.abort();
+          return;
+        }
+      }
+    };
 
-      const batchResults = await Promise.all(batchPromises);
+    // If the tab is closed or navigated away while parts are still in flight,
+    // the normal failure cleanup below never runs — so strand-proof it with a
+    // teardown-time cleanup of whatever we've started writing. Registered only
+    // for the duration of the pool run and removed in the finally.
+    const onPageHide = () => this.teardownCleanup(api, [...writtenUploadIds]);
+    window.addEventListener('pagehide', onPageHide);
 
-      // Check if any uploads in this batch failed
-      if (batchResults.some((response) => response === null)) {
-        return null;
+    try {
+      const workerCount = Math.min(MAX_CONCURRENT_PARTS, blobs.length);
+      await Promise.all(Array.from({ length: workerCount }, () => runWorker()));
+
+      if (fatalError) {
+        // Best-effort cleanup so a failed multipart upload doesn't strand bytes
+        // in the bucket. Never let a cleanup failure mask the original error.
+        await this.deleteWrittenUploads(api, [...writtenUploadIds]).catch(
+          () => {}
+        );
+
+        const failureMessage =
+          fatalError instanceof Error
+            ? fatalError.message
+            : `Upload failed for ${fileBlob.name}`;
+        progressTracker.setProcessStage('error');
+        progressTracker.setText(failureMessage);
+        progressTracker.error = failureMessage;
+
+        throw fatalError instanceof Error
+          ? fatalError
+          : new Error(failureMessage);
       }
 
-      uploadResponses.push(...batchResults);
+      return uploadResponses;
+    } finally {
+      window.removeEventListener('pagehide', onPageHide);
     }
-
-    if (uploadResponses.length !== blobs.length) {
-      const failureMessage = `Upload failed for ${fileBlob.name}`;
-      progressTracker.setProcessStage('error');
-      progressTracker.setText(failureMessage);
-      progressTracker.error = failureMessage;
-      throw new Error(failureMessage);
-    }
-
-    return uploadResponses;
   }
 }

--- a/packages/send/frontend/src/test/lib/upload.test.ts
+++ b/packages/send/frontend/src/test/lib/upload.test.ts
@@ -1,10 +1,10 @@
 import { ProgressTracker } from '@send-frontend/apps/send/stores/status-store';
 import { ApiConnection } from '@send-frontend/lib/api';
-import { SPLIT_SIZE } from '@send-frontend/lib/const';
-import { NamedBlob } from '@send-frontend/lib/filesync';
+import { MAX_CONCURRENT_PARTS, SPLIT_SIZE } from '@send-frontend/lib/const';
+import { NamedBlob, sendBlob } from '@send-frontend/lib/filesync';
 import { Keychain } from '@send-frontend/lib/keychain';
 import Uploader from '@send-frontend/lib/upload';
-import { hashFiles } from '@send-frontend/lib/utils';
+import { hashFiles, splitIntoMultipleZips } from '@send-frontend/lib/utils';
 import { UserType } from '@send-frontend/types';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -369,6 +369,150 @@ describe('Uploader', () => {
       expect(mockProgressTracker.setText).toHaveBeenCalledWith(
         'Preparing file for upload'
       );
+    });
+  });
+
+  describe('doUpload concurrency & failure handling', () => {
+    // A lightweight stand-in for the source file: doUpload only reads .size /
+    // .name off it and passes it to the (mocked) splitter + hasher, so we avoid
+    // allocating a real >SPLIT_SIZE (500MB) buffer.
+    const makeSourceBlob = (): NamedBlob =>
+      ({
+        size: SPLIT_SIZE + 1000,
+        name: 'big.txt',
+        type: 'text/plain',
+      }) as unknown as NamedBlob;
+
+    const makeParts = (n: number): NamedBlob[] =>
+      Array.from({ length: n }, (_, i) =>
+        Object.assign(new Blob([`part${i}`]), { name: `big-${i}.txt` })
+      ) as NamedBlob[];
+
+    const indexFromName = (blob: Blob): number =>
+      Number((blob as NamedBlob).name.match(/big-(\d+)/)?.[1] ?? 0);
+
+    const resolveDbCalls = () =>
+      vi.fn().mockImplementation((endpoint: string) => {
+        if (endpoint === 'uploads') {
+          return Promise.resolve({ upload: { id: 'upload-db-id' } });
+        }
+        if (endpoint.includes('item')) {
+          return Promise.resolve({ id: 'item-id' });
+        }
+        // uploads/cleanup and anything else
+        return Promise.resolve({ message: 'ok' });
+      });
+
+    beforeEach(() => {
+      vi.mocked(sendBlob).mockReset().mockResolvedValue('upload-id');
+    });
+
+    it('passes an abort signal and an onUploadId reporter to each part', async () => {
+      vi.mocked(splitIntoMultipleZips).mockResolvedValueOnce(makeParts(2));
+      vi.mocked(hashFiles).mockResolvedValueOnce(['h0', 'h1']);
+      mockApi.call = resolveDbCalls();
+
+      await uploader.doUpload(
+        makeSourceBlob(),
+        'container-id',
+        mockApi,
+        mockProgressTracker
+      );
+
+      expect(sendBlob).toHaveBeenCalledTimes(2);
+      const options = vi.mocked(sendBlob).mock.calls[0][5];
+      expect(options?.signal).toBeInstanceOf(AbortSignal);
+      expect(typeof options?.onUploadId).toBe('function');
+    });
+
+    it('does not block later parts behind a stalled earlier part (no batch barrier)', async () => {
+      const partCount = MAX_CONCURRENT_PARTS + 2; // 7 parts, 5 concurrent
+      vi.mocked(splitIntoMultipleZips).mockResolvedValueOnce(
+        makeParts(partCount)
+      );
+      vi.mocked(hashFiles).mockResolvedValueOnce(
+        Array.from({ length: partCount }, (_, i) => `h${i}`)
+      );
+      mockApi.call = resolveDbCalls();
+
+      const startedIndexes: number[] = [];
+      let releasePart0: () => void = () => {};
+      const part0Gate = new Promise<void>((resolve) => {
+        releasePart0 = resolve;
+      });
+
+      vi.mocked(sendBlob).mockImplementation(
+        async (blob, _key, _api, _tracker, _isBucket, options) => {
+          const index = indexFromName(blob);
+          startedIndexes.push(index);
+          const id = `upload-${index}`;
+          options?.onUploadId?.(id);
+          // Part 0 stalls; every other part completes normally.
+          if (index === 0) {
+            await part0Gate;
+          }
+          return id;
+        }
+      );
+
+      const uploadPromise = uploader.doUpload(
+        makeSourceBlob(),
+        'container-id',
+        mockApi,
+        mockProgressTracker
+      );
+
+      // The last part must be able to start while part 0 is still stalled — a
+      // fixed batch-of-5 barrier would keep parts 5 & 6 from starting at all.
+      await vi.waitFor(() => expect(startedIndexes).toContain(partCount - 1));
+      expect(startedIndexes).toContain(MAX_CONCURRENT_PARTS); // index 5 started
+
+      releasePart0();
+      const result = await uploadPromise;
+      expect(result).toHaveLength(partCount);
+    });
+
+    it('cleans up every written part and aborts siblings when a part fails', async () => {
+      const parts = makeParts(3);
+      vi.mocked(splitIntoMultipleZips).mockResolvedValueOnce(parts);
+      vi.mocked(hashFiles).mockResolvedValueOnce(['h0', 'h1', 'h2']);
+      mockApi.call = resolveDbCalls();
+
+      let capturedSignal: AbortSignal | undefined;
+      vi.mocked(sendBlob).mockImplementation(
+        async (blob, _key, _api, _tracker, _isBucket, options) => {
+          const index = indexFromName(blob);
+          const id = `upload-${index}`;
+          // Record the id before the (possible) failure, exactly as the real
+          // sendBlob does right after obtaining the presigned URL.
+          options?.onUploadId?.(id);
+          capturedSignal = options?.signal;
+          if (index === 1) {
+            throw new Error('UPLOAD_FAILED');
+          }
+          return id;
+        }
+      );
+
+      await expect(
+        uploader.doUpload(
+          makeSourceBlob(),
+          'container-id',
+          mockApi,
+          mockProgressTracker
+        )
+      ).rejects.toThrow();
+
+      // Siblings were cancelled.
+      expect(capturedSignal?.aborted).toBe(true);
+
+      // The backend was asked to remove the parts we began writing, including
+      // the one that failed.
+      const cleanupCall = vi
+        .mocked(mockApi.call)
+        .mock.calls.find(([endpoint]) => endpoint === 'uploads/cleanup');
+      expect(cleanupCall).toBeDefined();
+      expect(cleanupCall?.[1]?.ids).toContain('upload-1');
     });
   });
 });


### PR DESCRIPTION
## What changed?

Reworks the frontend multipart upload path for reliability and to stop canceled uploads from stranding storage:

- Bounded-concurrency pool so a slow or failing part never blocks the others; the first fatal failure aborts the rest.
- Per-part PUT retries with backoff, a longer PUT timeout, and create-entry retried without re-uploading or re-encrypting the part.
- Cleans up parts already written on failure — and on tab-close via a teardown handler — so a canceled upload doesn't leave orphaned bytes.
- Concurrency tuned to 4 (uploads are bandwidth-bound, so more parts add no throughput but cost memory).

_AI disclosure: developed with AI assistance (Claude) and reviewed by me._

## Why?

Large and multipart uploads were unreliable — random failures, and a single stalled part could discard the whole upload. A canceled or interrupted upload could also leave storage allocated with nothing shown in the UI.

## Limitations and Notes

Uses the cleanup endpoint from #964, so it should merge after it. Tab-close cleanup is best-effort; a scheduled server-side sweeper for already-orphaned data is tracked in #117. Chunk size is deployment config and not part of this diff.

## Applicable Issues

Closes #887
Relates to #667, #913
Depends on #964
