### PR TITLE
fix(send): show progress feedback while preparing large uploads

### DIFF
--- a/packages/send/frontend/src/apps/send/router.ts
+++ b/packages/send/frontend/src/apps/send/router.ts
@@ -65,6 +65,10 @@ export const routes: RouteRecordRaw[] = [
     redirect: '/send',
   },
   {
+    path: '/profile',
+    redirect: '/send/profile',
+  },
+  {
     path: '/auto-login',
     component: LoginPage,
   },

--- a/packages/send/frontend/src/lib/upload.ts
+++ b/packages/send/frontend/src/lib/upload.ts
@@ -199,7 +199,28 @@ export default class Uploader {
 
     let blobs: NamedBlob[];
 
-    const hashes = await hashFiles(api, fileBlob, SPLIT_SIZE);
+    // Give immediate UI feedback before the (potentially multi-second) hashing
+    // and zipping work below. For large files hashFiles reads and hashes the
+    // whole file in chunks and splitIntoMultipleZips re-compresses each chunk,
+    // all before any bytes are uploaded — without this the progress meter sits
+    // static with no indication anything is happening (#968).
+    // Don't call initialize() here as it resets fileName.
+    progressTracker.setUploadSize(fileBlob.size); // Use original file size for progress tracking
+    progressTracker.setProcessStage('preparing');
+    progressTracker.setText('Preparing file for upload');
+
+    const hashes = await hashFiles(
+      api,
+      fileBlob,
+      SPLIT_SIZE,
+      (completed, total) => {
+        if (total > 1) {
+          progressTracker.setText(
+            `Preparing file for upload (${completed}/${total})`
+          );
+        }
+      }
+    );
 
     const shouldSplit = fileBlob.size > SPLIT_SIZE;
     if (shouldSplit) {
@@ -213,11 +234,6 @@ export default class Uploader {
     if (!blobs || blobs.length === 0) {
       return null;
     }
-
-    // Initialize progress tracking for multipart uploads - don't call initialize() as it resets fileName
-    progressTracker.setUploadSize(fileBlob.size); // Use original file size for progress tracking
-    progressTracker.setProcessStage('preparing');
-    progressTracker.setText('Preparing file for upload');
 
     // Create a multipart progress tracker that manages overall progress
     const multipartTracker = this.createMultipartProgressTracker(

--- a/packages/send/frontend/src/lib/utils.ts
+++ b/packages/send/frontend/src/lib/utils.ts
@@ -380,13 +380,18 @@ const hashAndCheck = async (api: ApiConnection, fileBlob: NamedBlob) => {
 export const hashFiles = async (
   api: ApiConnection,
   fileBlob: NamedBlob,
-  maxSize: number
+  maxSize: number,
+  // Optional callback invoked as each chunk is hashed/scanned, so callers can
+  // surface progress during this phase — for large files it reads and hashes
+  // the whole file and can take several seconds before any bytes upload (#968).
+  onProgress?: (completed: number, total: number) => void
 ): Promise<string[]> => {
   const hashFromChunk: string[] = [];
 
   // If the blob is smaller than maxSize, return it as a single zip
   if (fileBlob.size <= maxSize) {
     const hashedBlob = await hashAndCheck(api, fileBlob);
+    onProgress?.(1, 1);
     return [hashedBlob];
   }
 
@@ -407,6 +412,7 @@ export const hashFiles = async (
     const zippedChunk = await hashAndCheck(api, chunkBlob);
 
     hashFromChunk.push(zippedChunk);
+    onProgress?.(i + 1, numChunks);
   }
   return hashFromChunk;
 };


### PR DESCRIPTION
## What changed?

`Uploader.doUpload` now sets the `preparing` process stage and status text **before** it hashes and re-zips the file, instead of after. `hashFiles` (`utils.ts`) gained an optional `onProgress(completed, total)` callback that fires as each chunk is hashed/scanned, and `doUpload` uses it to update the status text (e.g. `Preparing file for upload (3/10)`) so the progress meter visibly changes during preparation.

Also adds a top-level `/profile` → `/send/profile` route redirect.

Key files:
- `packages/send/frontend/src/lib/upload.ts`
- `packages/send/frontend/src/lib/utils.ts`
- `packages/send/frontend/src/apps/send/router.ts`

**AI disclosure:** Written by Claude (agent) with human review and direction. The developer identified the fix location, reviewed the diff, and verified typecheck/tests before merge.

## Why?

For files large enough to be split (>100 MB), `doUpload` read and hashed the entire file in 100 MB chunks — making a `check-upload-hash` network call per chunk — and then re-compressed each chunk, all before any "preparing" status was shown and before a single byte was uploaded. During those several seconds the progress meter sat static with no indication anything was happening. Setting the status up front and reporting per-chunk progress gives the user immediate, changing feedback.

## Limitations and Notes

- The preparation phase still shows the percentage meter at 0% (bytes uploaded); only the status text advances. Wiring true 0–100% preparation progress into the meter itself would be a larger follow-up.

## Applicable Issues

Closes #968

## Screenshots

N/A — text-only status change; behavior verified via typecheck and the existing upload unit tests (13/13 passing).