### PR TITLE
fix(addon): strip sourcemaps from the shipped system add-on (#971)

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -490,6 +490,17 @@ jobs:
           mkdir -p /tmp/system-addon-unpack
           unzip "packages/addon/$PROD_XPI" -d /tmp/system-addon-unpack
           bun run packages/addon/scripts/set-system-id.ts /tmp/system-addon-unpack/manifest.json
+
+          # Strip sourcemaps from the shipped system add-on: delete standalone
+          # *.map files and remove the sourceMappingURL comments (the background
+          # bundle inlines its map as a data: URI, so it has no separate file).
+          # The maps were already uploaded to Sentry during the addon build
+          # above, so crash symbolication is unaffected — we only stop shipping
+          # them into comm-central.
+          find /tmp/system-addon-unpack -type f -name '*.map' -delete
+          find /tmp/system-addon-unpack -type f \( -name '*.js' -o -name '*.mjs' -o -name '*.css' \) \
+            -exec perl -ni -e 'print unless m{^\s*(//|/\*)# sourceMappingURL=}' {} +
+
           cd /tmp/system-addon-unpack
           zip -r "$GITHUB_WORKSPACE/packages/addon/$SYSTEM_XPI" .
 

--- a/packages/addon/scripts/sync-to-builtin.sh
+++ b/packages/addon/scripts/sync-to-builtin.sh
@@ -57,8 +57,26 @@ if ! grep -q "tbpro-system-add-on@thunderbird.net" "$DIST/manifest.json"; then
   exit 1
 fi
 
+# Remove every sourcemap from a directory tree: delete standalone *.map files and
+# strip the trailing sourceMappingURL comments from JS/CSS (the background bundle
+# uses an inline `sourcemap: 'inline'` data: URI, so it has no separate .map to
+# delete). The system add-on ships to users via comm-central and must not carry
+# sourcemaps; Sentry symbolication is unaffected because the maps are uploaded to
+# Sentry during the vite build, before this sync runs.
+strip_sourcemaps() {
+  local dir="$1"
+  find "$dir" -type f -name '*.map' -delete
+  find "$dir" -type f \( -name '*.js' -o -name '*.mjs' -o -name '*.css' \) \
+    -exec perl -ni -e 'print unless m{^\s*(//|/\*)# sourceMappingURL=}' {} +
+}
+
 echo "Syncing $DIST/ -> $DEST/"
 # --delete so files removed from the build don't linger in the vendored copy.
-rsync -a --delete "$DIST/" "$DEST/"
+# --exclude='*.map' keeps sourcemaps out of the vendored copy (see strip_sourcemaps).
+rsync -a --delete --exclude='*.map' "$DIST/" "$DEST/"
 
-echo "Synced. Now: cd \"\$TB_COMM_SRC\" && ./mach build faster && ./mach run --temp-profile"
+# rsync's --exclude can't touch the inline background sourcemap or clean stale
+# .map files already in $DEST (they're protected by the exclude), so scrub $DEST.
+strip_sourcemaps "$DEST"
+
+echo "Synced (sourcemaps stripped). Now: cd \"\$TB_COMM_SRC\" && ./mach build faster && ./mach run --temp-profile"


### PR DESCRIPTION
## What changed?

Stopped shipping sourcemaps in the system add-on vendored into comm-central (`thundermail`) and in the CI production system XPI.

- `packages/addon/scripts/sync-to-builtin.sh` now excludes `*.map` from the rsync and runs a `strip_sourcemaps` pass over the synced copy that deletes any `*.map` and removes `sourceMappingURL` comments — this also handles the background bundle, whose sourcemap is inlined as a `data:` URI (no separate file), and cleans any stale maps already in the destination.
- `.github/workflows/merge.yml` — the prod "Build system-add-on XPI" repack step deletes `*.map` and strips `sourceMappingURL` comments before re-zipping.

Scope is limited to the comm-central / system add-on. The standalone web (S3) build and the regular add-on `.xpi` are unchanged.

_AI disclosure: implemented with Claude Code (an AI agent) under my direction; I reviewed the diff and verification. The change touches two files — a shell script and one GitHub Actions step._

## Why?

Now that we ship a built-in **system** add-on, sourcemaps don't need to be bundled into comm-central. Removing them keeps the vendored tree lean and avoids shipping source to end users. Sentry crash symbolication is preserved: the maps are still generated and uploaded to Sentry during the vite build — we only stop copying them into the shipped bundle. Stripping at the **copy step** (rather than disabling sourcemaps at build time) is deliberate so the Sentry upload, which runs earlier, is unaffected.

## Limitations and Notes

- The background bundle inlines its sourcemap as a `data:` URI, so it's handled by stripping the `sourceMappingURL` comment rather than deleting a `.map` file.
- Verified locally: unit-tested the strip logic (including a no-trailing-newline edge case) and ran the real `sync-to-builtin.sh` against a synthetic build + fake comm-central tree — no `.map` files or `sourceMappingURL` comments remain and code content is intact. Shell (`bash -n`) and YAML syntax validated.
- The CI repack path was not executed on a live prod run, but uses the identical `find … -delete` / `perl` strip commands proven above.

## Applicable Issues

Closes #971

## Screenshots

N/A — build/CI change.