### PR TITLE
feat(send): introspect access tokens per request and force logout on revoked sessions

### DIFF
--- a/packages/send/backend/src/auth/oidc.ts
+++ b/packages/send/backend/src/auth/oidc.ts
@@ -1,4 +1,3 @@
-import { JWT_EXPIRY_IN_MILLISECONDS } from '@send-backend/config';
 import axios from 'axios';
 import 'dotenv/config';
 
@@ -22,6 +21,12 @@ interface TokenCacheEntry {
 
 // Simple in-memory cache for token introspection results
 const tokenCache = new Map<string, TokenCacheEntry>();
+
+// How long an introspection result is trusted before we ask Keycloak again.
+// Short enough that a revoked session loses access promptly (#960), long
+// enough that a burst of requests (e.g. a multipart upload) isn't one
+// introspection call per request.
+export const INTROSPECTION_CACHE_MS = 60 * 1000;
 
 /**
  * Introspects an OIDC token with the configured authorization server
@@ -68,13 +73,15 @@ export async function introspectToken(
 
     const introspectionResult: TokenIntrospectionResponse = response.data;
 
-    // Cache the result for the same duration as the jwt or until token expires (whichever is shorter)
-
+    // Cache the result briefly so per-request introspection doesn't hammer
+    // Keycloak (e.g. during multipart uploads), while still catching a revoked
+    // session — logout / password change / admin force-logout — within
+    // INTROSPECTION_CACHE_MS. Never cache past the token's own expiry.
     const tokenExpiry = introspectionResult.exp
       ? introspectionResult.exp * 1000
-      : Date.now() + JWT_EXPIRY_IN_MILLISECONDS;
+      : Date.now() + INTROSPECTION_CACHE_MS;
     const cacheExpiry = Math.min(
-      Date.now() + JWT_EXPIRY_IN_MILLISECONDS,
+      Date.now() + INTROSPECTION_CACHE_MS,
       tokenExpiry
     );
 
@@ -102,6 +109,23 @@ export async function introspectToken(
 }
 
 /**
+ * Per-request liveness check for an access token (#960).
+ * @returns `true` if Keycloak reports the token active, `false` if it reports
+ * it inactive (session revoked/expired), and `null` if introspection could not
+ * be performed (misconfig or Keycloak unreachable). Callers should treat `null`
+ * as inconclusive and fail OPEN — a Keycloak blip must not sign everyone out.
+ */
+export async function isTokenActive(token: string): Promise<boolean | null> {
+  try {
+    const result = await introspectToken(token);
+    return result.active === true;
+  } catch (error) {
+    console.error('Token introspection unavailable (failing open):', error);
+    return null;
+  }
+}
+
+/**
  * Validates an OIDC token and returns user information if valid
  * @param token The access token to validate
  * @returns Promise<{isValid: boolean, userInfo?: any}>
@@ -119,15 +143,9 @@ export async function validateOIDCToken(token: string): Promise<{
   try {
     const introspectionResult = await introspectToken(token);
 
+    // `active` already reflects expiry and revocation, so it is the single
+    // source of truth — an expired or revoked token comes back active:false.
     if (!introspectionResult.active) {
-      return { isValid: false };
-    }
-
-    // Check if token is expired
-    if (
-      introspectionResult.exp &&
-      introspectionResult.exp < Date.now() / JWT_EXPIRY_IN_MILLISECONDS
-    ) {
       return { isValid: false };
     }
 

--- a/packages/send/backend/src/auth/oidc.ts
+++ b/packages/send/backend/src/auth/oidc.ts
@@ -125,7 +125,15 @@ export async function isTokenActive(token: string): Promise<boolean | null> {
   }
 }
 
-/** Read a JWT's `exp` (seconds since epoch) without verifying the signature. */
+/**
+ * Read a JWT's `exp` (seconds since epoch) without verifying the signature.
+ * Returns `null` for a non-JWT/opaque token. NOTE: the refresh-vs-revoke
+ * distinction in isAccessTokenRevoked depends on this being readable — Keycloak
+ * issues JWT access tokens, so it is today. If access tokens ever become opaque,
+ * decodeTokenExp returns null, the expiry gate is skipped, and a routinely
+ * expired token would be treated as revoked (forced logout on expiry). Revisit
+ * this gate before switching token formats.
+ */
 function decodeTokenExp(token: string): number | null {
   try {
     const payload = token.split('.')[1];

--- a/packages/send/backend/src/auth/oidc.ts
+++ b/packages/send/backend/src/auth/oidc.ts
@@ -125,6 +125,43 @@ export async function isTokenActive(token: string): Promise<boolean | null> {
   }
 }
 
+/** Read a JWT's `exp` (seconds since epoch) without verifying the signature. */
+function decodeTokenExp(token: string): number | null {
+  try {
+    const payload = token.split('.')[1];
+    if (!payload) {
+      return null;
+    }
+    const claims = JSON.parse(
+      Buffer.from(payload, 'base64url').toString('utf8')
+    );
+    return typeof claims?.exp === 'number' ? claims.exp : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * True only when the access token is still within its lifetime but Keycloak
+ * reports it inactive — i.e. the session was revoked (logout elsewhere,
+ * password change, admin force-logout), NOT merely expired (#960).
+ *
+ * An expired token returns `false` on purpose: routine expiry must go through
+ * the normal refresh flow (a refresh succeeds if the session is still alive and
+ * fails — logging the user out — if it isn't). Introspection errors also return
+ * `false` (fail open) so a Keycloak outage can't sign everyone out. This keeps
+ * forced logout limited to genuine revocations, per the refresh requirement in
+ * the issue discussion.
+ */
+export async function isAccessTokenRevoked(token: string): Promise<boolean> {
+  const exp = decodeTokenExp(token);
+  if (exp !== null && exp * 1000 <= Date.now()) {
+    return false; // expired — let the refresh flow decide, don't force logout
+  }
+  const active = await isTokenActive(token);
+  return active === false;
+}
+
 /**
  * Validates an OIDC token and returns user information if valid
  * @param token The access token to validate

--- a/packages/send/backend/src/config.ts
+++ b/packages/send/backend/src/config.ts
@@ -50,6 +50,12 @@ export const JWT_REFRESH_TOKEN_EXPIRY_IN_DAYS = ONE_WEEK;
 // Determines how many times a file can be attempted to be downloaded with the wrong password before it gets locked
 export const MAX_ACCESS_LINK_RETRIES = 5;
 
+// Response header that tells the client its session is gone and it should clear
+// local auth and return to login (#960). Lives here (a dependency-light module)
+// so both the Express middleware and the tRPC middleware can import it without
+// pulling in the heavier models/prisma graph.
+export const X_LOGOUT_HEADER = 'x-logout';
+
 export function getEnvironmentName(): EnvironmentName {
   if (BASE_URL.includes('send-backend.tb.pro')) {
     return 'prod';

--- a/packages/send/backend/src/middleware.ts
+++ b/packages/send/backend/src/middleware.ts
@@ -5,7 +5,7 @@ import { getDataFromAuthenticatedRequest } from './auth/client';
 import { validateJWT } from './auth/jwt';
 import {
   extractBearerToken,
-  isTokenActive,
+  isAccessTokenRevoked,
   validateOIDCToken,
 } from './auth/oidc';
 import { VERSION } from './config';
@@ -85,9 +85,9 @@ export const X_LOGOUT_HEADER = 'x-logout';
  * admin), set the `x-logout` header so the client clears its session, and
  * report that the request must be rejected.
  *
- * Returns `false` (allow) when there is no bearer token or when introspection
- * is inconclusive — we fail OPEN so a Keycloak outage can't sign everyone out;
- * the normal JWT check still applies in that case.
+ * Only genuine revocations count: an already-expired token (handled by the
+ * normal refresh flow) and an inconclusive introspection (Keycloak down) both
+ * return `false` so we never force logout on routine expiry or an outage.
  */
 export async function isSessionRevoked(
   req: Request,
@@ -97,8 +97,7 @@ export async function isSessionRevoked(
   if (!token) {
     return false;
   }
-  const active = await isTokenActive(token);
-  if (active === false) {
+  if (await isAccessTokenRevoked(token)) {
     res.setHeader(X_LOGOUT_HEADER, '1');
     return true;
   }

--- a/packages/send/backend/src/middleware.ts
+++ b/packages/send/backend/src/middleware.ts
@@ -8,7 +8,7 @@ import {
   isAccessTokenRevoked,
   validateOIDCToken,
 } from './auth/oidc';
-import { VERSION } from './config';
+import { VERSION, X_LOGOUT_HEADER } from './config';
 import { getUsedStorage } from './models';
 import { fromPrismaV2 } from './models/prisma-helper';
 import { getAdminStatus, getUserByOIDCSubject } from './models/users';
@@ -73,23 +73,19 @@ export function reject(
   return;
 }
 
-// Response header that tells the client its session is gone and it should
-// clear local auth and return to login (#960).
-export const X_LOGOUT_HEADER = 'x-logout';
-
 /**
- * Per-request session liveness check (#960).
+ * Per-request session liveness gate (#960).
  *
- * If the request carries an OIDC access token and Keycloak reports it inactive
+ * If the request carries an OIDC access token that Keycloak reports inactive
  * (the user logged out, changed their password, or was force-logged-out by an
- * admin), set the `x-logout` header so the client clears its session, and
- * report that the request must be rejected.
- *
- * Only genuine revocations count: an already-expired token (handled by the
- * normal refresh flow) and an inconclusive introspection (Keycloak down) both
- * return `false` so we never force logout on routine expiry or an outage.
+ * admin), set the `x-logout` header, respond 401, and return `true` so the
+ * caller stops — a revoked session must not fall back to a still-unexpired JWT
+ * cookie. Returns `false` (caller continues) when there is no bearer token, the
+ * token is merely expired (handled by the normal refresh flow), or introspection
+ * is inconclusive (Keycloak down) — so we never force logout on routine expiry
+ * or an outage.
  */
-export async function isSessionRevoked(
+export async function rejectIfSessionRevoked(
   req: Request,
   res: Response
 ): Promise<boolean> {
@@ -99,6 +95,9 @@ export async function isSessionRevoked(
   }
   if (await isAccessTokenRevoked(token)) {
     res.setHeader(X_LOGOUT_HEADER, '1');
+    res
+      .status(401)
+      .json({ message: 'Not authorized: session is no longer active' });
     return true;
   }
   return false;
@@ -116,10 +115,8 @@ export async function requireAuth(
 ) {
   // A revoked OIDC session must lose access immediately — do not fall back to a
   // still-unexpired JWT cookie.
-  if (await isSessionRevoked(req, res)) {
-    return res
-      .status(401)
-      .json({ message: 'Not authorized: session is no longer active' });
+  if (await rejectIfSessionRevoked(req, res)) {
+    return;
   }
 
   // First, try OIDC authentication
@@ -210,10 +207,8 @@ export async function requireJWT(
 ) {
   // If the OIDC session behind this request has been revoked, deny and tell the
   // client to log out — regardless of the (still-unexpired) JWT cookie (#960).
-  if (await isSessionRevoked(req, res)) {
-    return res
-      .status(401)
-      .json({ message: 'Not authorized: session is no longer active' });
+  if (await rejectIfSessionRevoked(req, res)) {
+    return;
   }
 
   const jwtToken = getCookie(req?.headers?.cookie, 'authorization');

--- a/packages/send/backend/src/middleware.ts
+++ b/packages/send/backend/src/middleware.ts
@@ -3,7 +3,11 @@ import { PrismaClient } from '@prisma/client';
 import type { NextFunction, Request, RequestHandler, Response } from 'express';
 import { getDataFromAuthenticatedRequest } from './auth/client';
 import { validateJWT } from './auth/jwt';
-import { extractBearerToken, validateOIDCToken } from './auth/oidc';
+import {
+  extractBearerToken,
+  isTokenActive,
+  validateOIDCToken,
+} from './auth/oidc';
 import { VERSION } from './config';
 import { getUsedStorage } from './models';
 import { fromPrismaV2 } from './models/prisma-helper';
@@ -69,6 +73,38 @@ export function reject(
   return;
 }
 
+// Response header that tells the client its session is gone and it should
+// clear local auth and return to login (#960).
+export const X_LOGOUT_HEADER = 'x-logout';
+
+/**
+ * Per-request session liveness check (#960).
+ *
+ * If the request carries an OIDC access token and Keycloak reports it inactive
+ * (the user logged out, changed their password, or was force-logged-out by an
+ * admin), set the `x-logout` header so the client clears its session, and
+ * report that the request must be rejected.
+ *
+ * Returns `false` (allow) when there is no bearer token or when introspection
+ * is inconclusive — we fail OPEN so a Keycloak outage can't sign everyone out;
+ * the normal JWT check still applies in that case.
+ */
+export async function isSessionRevoked(
+  req: Request,
+  res: Response
+): Promise<boolean> {
+  const token = extractBearerToken(req.headers?.authorization);
+  if (!token) {
+    return false;
+  }
+  const active = await isTokenActive(token);
+  if (active === false) {
+    res.setHeader(X_LOGOUT_HEADER, '1');
+    return true;
+  }
+  return false;
+}
+
 /**
  * Unified authentication middleware that supports both OIDC and legacy JWT authentication
  * This middleware prioritizes OIDC authentication but falls back to JWT for backward compatibility
@@ -79,6 +115,14 @@ export async function requireAuth(
   res: Response,
   next: NextFunction
 ) {
+  // A revoked OIDC session must lose access immediately — do not fall back to a
+  // still-unexpired JWT cookie.
+  if (await isSessionRevoked(req, res)) {
+    return res
+      .status(401)
+      .json({ message: 'Not authorized: session is no longer active' });
+  }
+
   // First, try OIDC authentication
   const authHeader = req.headers.authorization;
   const oidcToken = extractBearerToken(authHeader);
@@ -165,6 +209,14 @@ export async function requireJWT(
   res: Response,
   next: NextFunction
 ) {
+  // If the OIDC session behind this request has been revoked, deny and tell the
+  // client to log out — regardless of the (still-unexpired) JWT cookie (#960).
+  if (await isSessionRevoked(req, res)) {
+    return res
+      .status(401)
+      .json({ message: 'Not authorized: session is no longer active' });
+  }
+
   const jwtToken = getCookie(req?.headers?.cookie, 'authorization');
   const jwtRefreshToken = getCookie(req?.headers?.cookie, 'refresh_token');
 

--- a/packages/send/backend/src/origins.ts
+++ b/packages/send/backend/src/origins.ts
@@ -1,5 +1,6 @@
 import { NextFunction, Request, Response } from 'express';
 import { getAllowedOrigins } from './auth/client';
+import { X_LOGOUT_HEADER } from './config';
 import cors from 'cors';
 
 const allowedOrigins = getAllowedOrigins();
@@ -27,6 +28,6 @@ export const originsHandler = (
     },
     credentials: true,
     // Expose the forced-logout header so the browser can read it cross-origin (#960)
-    exposedHeaders: ['x-logout'],
+    exposedHeaders: [X_LOGOUT_HEADER],
   })(req, res, next);
 };

--- a/packages/send/backend/src/origins.ts
+++ b/packages/send/backend/src/origins.ts
@@ -26,5 +26,7 @@ export const originsHandler = (
       }
     },
     credentials: true,
+    // Expose the forced-logout header so the browser can read it cross-origin (#960)
+    exposedHeaders: ['x-logout'],
   })(req, res, next);
 };

--- a/packages/send/backend/src/test/auth/oidc.test.ts
+++ b/packages/send/backend/src/test/auth/oidc.test.ts
@@ -1,0 +1,62 @@
+import axios from 'axios';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { isAccessTokenRevoked } from '../../auth/oidc';
+
+vi.mock('axios', () => ({
+  default: { post: vi.fn() },
+}));
+
+const mockedPost = vi.mocked(axios.post);
+
+// Build a JWT-shaped token with a given `exp` (seconds) so decodeTokenExp can
+// read it. Signature is irrelevant — the exp is decoded, not verified.
+function tokenWithExp(expSeconds: number, salt = 'a'): string {
+  const payload = Buffer.from(
+    JSON.stringify({ exp: expSeconds, salt })
+  ).toString('base64url');
+  return `header.${payload}.sig`;
+}
+
+const nowSec = () => Math.floor(Date.now() / 1000);
+
+describe('isAccessTokenRevoked (#960 exp-gated introspection)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.OIDC_TOKEN_INTROSPECTION_URL = 'https://kc.test/introspect';
+    process.env.OIDC_CLIENT_ID = 'client';
+    process.env.OIDC_CLIENT_SECRET = 'secret';
+  });
+
+  it('returns false for an EXPIRED token without introspecting (refresh flow owns it)', async () => {
+    const token = tokenWithExp(nowSec() - 60, 'expired');
+
+    const revoked = await isAccessTokenRevoked(token);
+
+    expect(revoked).toBe(false);
+    expect(mockedPost).not.toHaveBeenCalled();
+  });
+
+  it('returns true when a still-valid token is reported inactive (revoked session)', async () => {
+    mockedPost.mockResolvedValue({ data: { active: false } });
+    const token = tokenWithExp(nowSec() + 300, 'revoked');
+
+    const revoked = await isAccessTokenRevoked(token);
+
+    expect(revoked).toBe(true);
+    expect(mockedPost).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns false when a still-valid token is active', async () => {
+    mockedPost.mockResolvedValue({ data: { active: true } });
+    const token = tokenWithExp(nowSec() + 300, 'active');
+
+    expect(await isAccessTokenRevoked(token)).toBe(false);
+  });
+
+  it('fails open (false) when introspection errors', async () => {
+    mockedPost.mockRejectedValue(new Error('keycloak down'));
+    const token = tokenWithExp(nowSec() + 300, 'error');
+
+    expect(await isAccessTokenRevoked(token)).toBe(false);
+  });
+});

--- a/packages/send/backend/src/test/middleware.test.ts
+++ b/packages/send/backend/src/test/middleware.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { getDataFromAuthenticatedRequest } from '../auth/client';
 import {
   extractBearerToken,
-  isTokenActive,
+  isAccessTokenRevoked,
   validateOIDCToken,
 } from '../auth/oidc';
 import { validateJWT } from '../auth/jwt';
@@ -71,7 +71,7 @@ vi.mock('../types/custom', () => ({
 vi.mock('../auth/oidc', () => ({
   extractBearerToken: vi.fn(),
   validateOIDCToken: vi.fn(),
-  isTokenActive: vi.fn(),
+  isAccessTokenRevoked: vi.fn(),
 }));
 
 vi.mock('../models/users', () => ({
@@ -106,7 +106,7 @@ describe('requireJWT', () => {
   it('should deny with 401 and set x-logout when the OIDC session is revoked (#960)', async () => {
     mockRequest.headers.authorization = 'Bearer revoked.token';
     vi.mocked(extractBearerToken).mockReturnValue('revoked.token');
-    vi.mocked(isTokenActive).mockResolvedValue(false);
+    vi.mocked(isAccessTokenRevoked).mockResolvedValue(true);
 
     await requireJWT(
       mockRequest as Request,
@@ -119,11 +119,13 @@ describe('requireJWT', () => {
     expect(nextFunction).not.toHaveBeenCalled();
   });
 
-  it('should fail open (not log out) when introspection is unavailable (#960)', async () => {
+  it('should NOT force logout for a not-revoked token (expired/active/inconclusive) — refresh flow handles it (#960)', async () => {
     mockRequest.headers.authorization = 'Bearer some.token';
     mockRequest.headers.cookie = `authorization=Bearer%20valid.token`;
     vi.mocked(extractBearerToken).mockReturnValue('some.token');
-    vi.mocked(isTokenActive).mockResolvedValue(null); // inconclusive
+    // isAccessTokenRevoked returns false for expired tokens and when
+    // introspection is inconclusive, so we must not log the user out.
+    vi.mocked(isAccessTokenRevoked).mockResolvedValue(false);
     vi.mocked(validateJWT).mockReturnValue('valid');
 
     await requireJWT(

--- a/packages/send/backend/src/test/middleware.test.ts
+++ b/packages/send/backend/src/test/middleware.test.ts
@@ -1,7 +1,11 @@
 import { Request, Response } from 'express';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { getDataFromAuthenticatedRequest } from '../auth/client';
-import { extractBearerToken, validateOIDCToken } from '../auth/oidc';
+import {
+  extractBearerToken,
+  isTokenActive,
+  validateOIDCToken,
+} from '../auth/oidc';
 import { validateJWT } from '../auth/jwt';
 import {
   addVersionHeader,
@@ -67,6 +71,7 @@ vi.mock('../types/custom', () => ({
 vi.mock('../auth/oidc', () => ({
   extractBearerToken: vi.fn(),
   validateOIDCToken: vi.fn(),
+  isTokenActive: vi.fn(),
 }));
 
 vi.mock('../models/users', () => ({
@@ -93,8 +98,42 @@ describe('requireJWT', () => {
     mockResponse = {
       json: vi.fn(),
       status: vi.fn(() => mockResponse),
+      setHeader: vi.fn(),
     };
     process.env.ACCESS_TOKEN_SECRET = 'your_secret_key';
+  });
+
+  it('should deny with 401 and set x-logout when the OIDC session is revoked (#960)', async () => {
+    mockRequest.headers.authorization = 'Bearer revoked.token';
+    vi.mocked(extractBearerToken).mockReturnValue('revoked.token');
+    vi.mocked(isTokenActive).mockResolvedValue(false);
+
+    await requireJWT(
+      mockRequest as Request,
+      mockResponse as Response,
+      nextFunction
+    );
+
+    expect(mockResponse.setHeader).toHaveBeenCalledWith('x-logout', '1');
+    expect(mockResponse.status).toHaveBeenCalledWith(401);
+    expect(nextFunction).not.toHaveBeenCalled();
+  });
+
+  it('should fail open (not log out) when introspection is unavailable (#960)', async () => {
+    mockRequest.headers.authorization = 'Bearer some.token';
+    mockRequest.headers.cookie = `authorization=Bearer%20valid.token`;
+    vi.mocked(extractBearerToken).mockReturnValue('some.token');
+    vi.mocked(isTokenActive).mockResolvedValue(null); // inconclusive
+    vi.mocked(validateJWT).mockReturnValue('valid');
+
+    await requireJWT(
+      mockRequest as Request,
+      mockResponse as Response,
+      nextFunction
+    );
+
+    expect(mockResponse.setHeader).not.toHaveBeenCalledWith('x-logout', '1');
+    expect(nextFunction).toHaveBeenCalled();
   });
 
   it('should call next() for a valid token', async () => {

--- a/packages/send/backend/src/test/middleware.test.ts
+++ b/packages/send/backend/src/test/middleware.test.ts
@@ -101,6 +101,9 @@ describe('requireJWT', () => {
       setHeader: vi.fn(),
     };
     process.env.ACCESS_TOKEN_SECRET = 'your_secret_key';
+    // Default: no bearer / not revoked. Individual tests override.
+    vi.mocked(extractBearerToken).mockReturnValue(null);
+    vi.mocked(isAccessTokenRevoked).mockResolvedValue(false);
   });
 
   it('should deny with 401 and set x-logout when the OIDC session is revoked (#960)', async () => {
@@ -431,7 +434,27 @@ describe('requireAuth', () => {
     mockResponse = {
       json: vi.fn(),
       status: vi.fn(() => mockResponse),
+      setHeader: vi.fn(),
     };
+    // Default: no bearer / not revoked. Individual tests override.
+    vi.mocked(extractBearerToken).mockReturnValue(null);
+    vi.mocked(isAccessTokenRevoked).mockResolvedValue(false);
+  });
+
+  it('denies with 401 + x-logout when the OIDC session is revoked (#960)', async () => {
+    mockRequest.headers.authorization = 'Bearer revoked.token';
+    vi.mocked(extractBearerToken).mockReturnValue('revoked.token');
+    vi.mocked(isAccessTokenRevoked).mockResolvedValue(true);
+
+    await requireAuth(
+      mockRequest as Request,
+      mockResponse as Response,
+      nextFunction
+    );
+
+    expect(mockResponse.setHeader).toHaveBeenCalledWith('x-logout', '1');
+    expect(mockResponse.status).toHaveBeenCalledWith(401);
+    expect(nextFunction).not.toHaveBeenCalled();
   });
 
   it('should call next() and set oidcUser for a valid OIDC token', async () => {

--- a/packages/send/backend/src/test/trpc/middlewares.test.ts
+++ b/packages/send/backend/src/test/trpc/middlewares.test.ts
@@ -1,10 +1,17 @@
 import * as jwt from '@send-backend/auth/jwt';
+import * as oidc from '@send-backend/auth/oidc';
 import { TRPCError } from '@trpc/server';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { getGroupMemberPermission, isAuthed } from '../../trpc/middlewares';
 
 vi.mock('@send-backend/auth/jwt', () => ({
   validateJWT: vi.fn(),
+}));
+
+vi.mock('@send-backend/auth/oidc', () => ({
+  extractBearerToken: vi.fn(),
+  isAccessTokenRevoked: vi.fn(),
+  validateOIDCToken: vi.fn(),
 }));
 
 describe('Middleware tests', () => {
@@ -22,6 +29,13 @@ describe('Middleware tests', () => {
   };
 
   describe('isAuthed middleware', () => {
+    beforeEach(() => {
+      // Default: no bearer token / not revoked, so these JWT-path tests behave
+      // as before. The revocation test below overrides them.
+      vi.mocked(oidc.extractBearerToken).mockReturnValue(null);
+      vi.mocked(oidc.isAccessTokenRevoked).mockResolvedValue(false);
+    });
+
     it('should call next() when JWT is valid', async () => {
       vi.mocked(jwt.validateJWT).mockReturnValue('valid');
 
@@ -56,6 +70,23 @@ describe('Middleware tests', () => {
       await expect(isAuthed({ ctx: mockCtx, next: mockNext })).rejects.toThrow(
         new TRPCError({ code: 'FORBIDDEN' })
       );
+    });
+
+    it('throws FORBIDDEN and sets x-logout when the OIDC session is revoked (#960)', async () => {
+      const setHeader = vi.fn();
+      const ctx = {
+        ...mockCtx,
+        authorization: 'Bearer revoked.token',
+        res: { setHeader },
+      };
+      vi.mocked(oidc.extractBearerToken).mockReturnValue('revoked.token');
+      vi.mocked(oidc.isAccessTokenRevoked).mockResolvedValue(true);
+
+      await expect(
+        //@ts-ignore
+        isAuthed({ ctx, next: mockNext })
+      ).rejects.toThrow(new TRPCError({ code: 'FORBIDDEN' }));
+      expect(setHeader).toHaveBeenCalledWith('x-logout', '1');
     });
   });
 

--- a/packages/send/backend/src/trpc/context.ts
+++ b/packages/send/backend/src/trpc/context.ts
@@ -7,6 +7,7 @@ import { getCookie } from '../utils';
 
 export const createContext = ({
   req,
+  res,
 }: trpcExpress.CreateExpressContextOptions) => {
   const jwtToken = getCookie(req?.headers?.cookie, 'authorization');
   const jwtRefreshToken = getCookie(req?.headers?.cookie, 'refresh_token');
@@ -19,7 +20,8 @@ export const createContext = ({
     const { daysToExpiry, hasLimitedStorage } = getStorageLimit(req);
 
     return {
-      // req, // Include request object for OIDC middleware
+      // Response is exposed so auth middleware can set the x-logout header (#960)
+      res,
       authorization: req.headers?.authorization || null,
       user: {
         id: id.toString(),
@@ -38,7 +40,7 @@ export const createContext = ({
   } catch {
     // If the user is not authenticated, we return only the cookies
     return {
-      // req, // Include request object for OIDC middleware
+      res,
       authorization: req.headers?.authorization || null,
       user: null,
       cookies: {

--- a/packages/send/backend/src/trpc/middlewares.ts
+++ b/packages/send/backend/src/trpc/middlewares.ts
@@ -1,7 +1,7 @@
 import { validateJWT } from '@send-backend/auth/jwt';
 import {
   extractBearerToken,
-  isTokenActive,
+  isAccessTokenRevoked,
   validateOIDCToken,
 } from '@send-backend/auth/oidc';
 import { X_LOGOUT_HEADER } from '@send-backend/middleware';
@@ -27,10 +27,10 @@ export async function isOIDCAuthed(opts: { ctx: Context; next: NextFunction }) {
   const token = extractBearerToken(authHeader);
 
   if (token) {
-    // A revoked session must lose access immediately — don't fall back to a
-    // still-unexpired JWT cookie. Signal the client to log out (#960).
-    const active = await isTokenActive(token);
-    if (active === false) {
+    // A revoked (but not merely expired) session must lose access immediately —
+    // don't fall back to a still-unexpired JWT cookie. Signal the client to log
+    // out (#960).
+    if (await isAccessTokenRevoked(token)) {
       ctx?.res?.setHeader?.(X_LOGOUT_HEADER, '1');
       throw new TRPCError({ code: 'FORBIDDEN' });
     }

--- a/packages/send/backend/src/trpc/middlewares.ts
+++ b/packages/send/backend/src/trpc/middlewares.ts
@@ -1,5 +1,10 @@
 import { validateJWT } from '@send-backend/auth/jwt';
-import { extractBearerToken, validateOIDCToken } from '@send-backend/auth/oidc';
+import {
+  extractBearerToken,
+  isTokenActive,
+  validateOIDCToken,
+} from '@send-backend/auth/oidc';
+import { X_LOGOUT_HEADER } from '@send-backend/middleware';
 import { EnvironmentName, getEnvironmentName } from '@send-backend/config';
 import { Context } from '@send-backend/trpc';
 import { TRPCError } from '@trpc/server';
@@ -22,6 +27,14 @@ export async function isOIDCAuthed(opts: { ctx: Context; next: NextFunction }) {
   const token = extractBearerToken(authHeader);
 
   if (token) {
+    // A revoked session must lose access immediately — don't fall back to a
+    // still-unexpired JWT cookie. Signal the client to log out (#960).
+    const active = await isTokenActive(token);
+    if (active === false) {
+      ctx?.res?.setHeader?.(X_LOGOUT_HEADER, '1');
+      throw new TRPCError({ code: 'FORBIDDEN' });
+    }
+
     try {
       const validation = await validateOIDCToken(token);
 

--- a/packages/send/backend/src/trpc/middlewares.ts
+++ b/packages/send/backend/src/trpc/middlewares.ts
@@ -4,8 +4,11 @@ import {
   isAccessTokenRevoked,
   validateOIDCToken,
 } from '@send-backend/auth/oidc';
-import { X_LOGOUT_HEADER } from '@send-backend/middleware';
-import { EnvironmentName, getEnvironmentName } from '@send-backend/config';
+import {
+  EnvironmentName,
+  X_LOGOUT_HEADER,
+  getEnvironmentName,
+} from '@send-backend/config';
 import { Context } from '@send-backend/trpc';
 import { TRPCError } from '@trpc/server';
 

--- a/packages/send/frontend/src/apps/send/router.ts
+++ b/packages/send/frontend/src/apps/send/router.ts
@@ -361,4 +361,16 @@ router.beforeEach(async (to, from, next) => {
   next();
 });
 
+// When the auth store forces a logout (x-logout header, #960), return to the
+// login screen via a client-side navigation. Registered here — in the app
+// bundle that owns the router — so the auth store (also bundled into the
+// background script, which has no Vue build) never has to import the router.
+if (typeof window !== 'undefined') {
+  window.addEventListener('tbpro:force-logout', () => {
+    router.replace('/login').catch(() => {
+      /* already navigating / not in a routable context */
+    });
+  });
+}
+
 export default router;

--- a/packages/send/frontend/src/lib/api.ts
+++ b/packages/send/frontend/src/lib/api.ts
@@ -144,17 +144,19 @@ export class ApiConnection {
         const authStore = useAuthStore();
         const recovered = await authStore.recoverOrForceLogout();
 
-        if (recovered && requestHeaders['Authorization']) {
-          // Session rolled forward — retry once with the freshly-rotated token.
-          const newToken = await authStore.getAccessToken();
-          if (newToken) {
-            opts.headers['Authorization'] = `Bearer ${newToken}`;
-            resp = await fetch(url, opts);
-          }
-        } else if (!recovered) {
+        if (!recovered) {
           // Genuine logout (state already cleared) or a transient error (session
           // kept, fail open) — either way this request is done.
           return null;
+        }
+
+        // Session rolled forward — retry once with the freshly-rotated token.
+        // We only reach here on a request that carried Authorization (the backend
+        // emits x-logout solely for bearer-carrying requests), so no guard needed.
+        const newToken = await authStore.getAccessToken();
+        if (newToken) {
+          opts.headers['Authorization'] = `Bearer ${newToken}`;
+          resp = await fetch(url, opts);
         }
       } catch (error) {
         console.error('Forced-logout handling failed:', error);

--- a/packages/send/frontend/src/lib/api.ts
+++ b/packages/send/frontend/src/lib/api.ts
@@ -129,8 +129,38 @@ export class ApiConnection {
       return null;
     }
 
-    // Handle authentication errors
-    if (resp.status === 401) {
+    // Handle authentication errors. x-logout always rides on a 401, so branch on
+    // it first and keep the two paths mutually exclusive — a revoked session
+    // gets exactly one recovery attempt, never a second refresh from the plain
+    // 401 branch below.
+    if (resp.headers?.get?.('x-logout')) {
+      // The backend flags a revoked OIDC session (logout / password change /
+      // admin force-logout). Try to recover with the refresh token before
+      // tearing down; recoverOrForceLogout forces logout only if the refresh
+      // token is also dead, and keeps the session on a transient error (#974).
+      try {
+        const { useAuthStore } =
+          await import('@send-frontend/stores/auth-store');
+        const authStore = useAuthStore();
+        const recovered = await authStore.recoverOrForceLogout();
+
+        if (recovered && requestHeaders['Authorization']) {
+          // Session rolled forward — retry once with the freshly-rotated token.
+          const newToken = await authStore.getAccessToken();
+          if (newToken) {
+            opts.headers['Authorization'] = `Bearer ${newToken}`;
+            resp = await fetch(url, opts);
+          }
+        } else if (!recovered) {
+          // Genuine logout (state already cleared) or a transient error (session
+          // kept, fail open) — either way this request is done.
+          return null;
+        }
+      } catch (error) {
+        console.error('Forced-logout handling failed:', error);
+        return null;
+      }
+    } else if (resp.status === 401) {
       // If we're using OIDC and get 401, try to refresh the token
       if (requestHeaders['Authorization']) {
         try {
@@ -164,20 +194,6 @@ export class ApiConnection {
           return null;
         }
       }
-    }
-
-    // The backend sets x-logout when the OIDC session is no longer active
-    // (logout / password change / admin force-logout). Clear local auth and
-    // stop — regardless of the response status (#960).
-    if (resp.headers?.get?.('x-logout')) {
-      try {
-        const { useAuthStore } =
-          await import('@send-frontend/stores/auth-store');
-        await useAuthStore().handleForcedLogout();
-      } catch (error) {
-        console.error('Forced-logout handling failed:', error);
-      }
-      return null;
     }
 
     if (!resp.ok) {

--- a/packages/send/frontend/src/lib/api.ts
+++ b/packages/send/frontend/src/lib/api.ts
@@ -166,6 +166,20 @@ export class ApiConnection {
       }
     }
 
+    // The backend sets x-logout when the OIDC session is no longer active
+    // (logout / password change / admin force-logout). Clear local auth and
+    // stop — regardless of the response status (#960).
+    if (resp.headers?.get?.('x-logout')) {
+      try {
+        const { useAuthStore } =
+          await import('@send-frontend/stores/auth-store');
+        await useAuthStore().handleForcedLogout();
+      } catch (error) {
+        console.error('Forced-logout handling failed:', error);
+      }
+      return null;
+    }
+
     if (!resp.ok) {
       // Surface the status/body for the caller's diagnostics before discarding
       // the response. Reading the body is safe here because we return null

--- a/packages/send/frontend/src/lib/trpc.ts
+++ b/packages/send/frontend/src/lib/trpc.ts
@@ -89,6 +89,24 @@ const wsClient = wsClientConfig ? createWSClient(wsClientConfig) : null;
 /**
  * We only import the `AppRouter` type from the server - this is not available at runtime
  */
+// tRPC transport fetch that honors the backend's x-logout header (#960): if a
+// response says the session is gone, clear local auth. Also carries cookies.
+async function fetchWithLogoutCheck(
+  url: RequestInfo | URL,
+  options: RequestInit
+): Promise<Response> {
+  const res = await fetch(url, { ...options, credentials: 'include' });
+  if (res.headers?.get?.('x-logout')) {
+    try {
+      const { useAuthStore } = await import('@send-frontend/stores/auth-store');
+      await useAuthStore().handleForcedLogout();
+    } catch (error) {
+      console.error('Forced-logout handling failed:', error);
+    }
+  }
+  return res;
+}
+
 export const trpc: TRPCClient<AppRouter> = createTRPCClient<AppRouter>({
   links: [
     splitLink({
@@ -126,13 +144,7 @@ export const trpc: TRPCClient<AppRouter> = createTRPCClient<AppRouter>({
         }),
         httpBatchLink({
           url: trpcUrl,
-          fetch(url, options: RequestInit) {
-            return fetch(url, {
-              ...options,
-              // Include credentials for cookies
-              credentials: 'include',
-            });
-          },
+          fetch: fetchWithLogoutCheck,
         }),
       ],
       // Handle subscriptions with WebSocket
@@ -146,12 +158,7 @@ export const trpc: TRPCClient<AppRouter> = createTRPCClient<AppRouter>({
             // Fallback to HTTP for subscriptions in testing
             httpBatchLink({
               url: trpcUrl,
-              fetch(url, options: RequestInit) {
-                return fetch(url, {
-                  ...options,
-                  credentials: 'include',
-                });
-              },
+              fetch: fetchWithLogoutCheck,
             }),
           ],
     }),

--- a/packages/send/frontend/src/lib/trpc.ts
+++ b/packages/send/frontend/src/lib/trpc.ts
@@ -89,13 +89,30 @@ const wsClient = wsClientConfig ? createWSClient(wsClientConfig) : null;
 /**
  * We only import the `AppRouter` type from the server - this is not available at runtime
  */
-// tRPC transport fetch that honors the backend's x-logout header (#960): if a
-// response says the session is gone, clear local auth. Also carries cookies.
+// tRPC transport fetch that (a) attaches the OIDC access token so the backend
+// can introspect it per request — the tRPC path was previously cookie-only, so
+// revocation was never enforced there — and (b) honors the backend's x-logout
+// header by clearing local auth (#960). Cookies are still sent for the legacy
+// JWT fallback.
 async function fetchWithLogoutCheck(
   url: RequestInfo | URL,
   options: RequestInit
 ): Promise<Response> {
-  const res = await fetch(url, { ...options, credentials: 'include' });
+  const headers = new Headers(options.headers);
+  try {
+    const { useAuthStore } = await import('@send-frontend/stores/auth-store');
+    if (!headers.has('Authorization')) {
+      const token = await useAuthStore().getAccessToken();
+      if (token) {
+        headers.set('Authorization', `Bearer ${token}`);
+      }
+    }
+  } catch {
+    // No token available — fall back to cookie auth.
+  }
+
+  const res = await fetch(url, { ...options, headers, credentials: 'include' });
+
   if (res.headers?.get?.('x-logout')) {
     try {
       const { useAuthStore } = await import('@send-frontend/stores/auth-store');

--- a/packages/send/frontend/src/lib/trpc.ts
+++ b/packages/send/frontend/src/lib/trpc.ts
@@ -98,25 +98,42 @@ export async function fetchWithLogoutCheck(
   url: RequestInfo | URL,
   options: RequestInit
 ): Promise<Response> {
-  const headers = new Headers(options.headers);
-  try {
-    const { useAuthStore } = await import('@send-frontend/stores/auth-store');
-    if (!headers.has('Authorization')) {
-      const token = await useAuthStore().getAccessToken();
-      if (token) {
-        headers.set('Authorization', `Bearer ${token}`);
+  // Attach the current OIDC access token (unless the caller already set one).
+  // Rebuilt for the post-refresh retry so it picks up the freshly-rotated token.
+  async function buildHeaders(): Promise<Headers> {
+    const headers = new Headers(options.headers);
+    try {
+      const { useAuthStore } = await import('@send-frontend/stores/auth-store');
+      if (!headers.has('Authorization')) {
+        const token = await useAuthStore().getAccessToken();
+        if (token) {
+          headers.set('Authorization', `Bearer ${token}`);
+        }
       }
+    } catch {
+      // No token available — fall back to cookie auth.
     }
-  } catch {
-    // No token available — fall back to cookie auth.
+    return headers;
   }
 
-  const res = await fetch(url, { ...options, headers, credentials: 'include' });
+  const res = await fetch(url, {
+    ...options,
+    headers: await buildHeaders(),
+    credentials: 'include',
+  });
 
   if (res.headers?.get?.('x-logout')) {
     try {
       const { useAuthStore } = await import('@send-frontend/stores/auth-store');
-      await useAuthStore().handleForcedLogout();
+      // A revoked access token may just need refreshing — recover and retry
+      // rather than forcing logout when the refresh token is still alive (#974).
+      if (await useAuthStore().recoverOrForceLogout()) {
+        return await fetch(url, {
+          ...options,
+          headers: await buildHeaders(),
+          credentials: 'include',
+        });
+      }
     } catch (error) {
       console.error('Forced-logout handling failed:', error);
     }

--- a/packages/send/frontend/src/lib/trpc.ts
+++ b/packages/send/frontend/src/lib/trpc.ts
@@ -94,7 +94,7 @@ const wsClient = wsClientConfig ? createWSClient(wsClientConfig) : null;
 // revocation was never enforced there — and (b) honors the backend's x-logout
 // header by clearing local auth (#960). Cookies are still sent for the legacy
 // JWT fallback.
-async function fetchWithLogoutCheck(
+export async function fetchWithLogoutCheck(
   url: RequestInfo | URL,
   options: RequestInit
 ): Promise<Response> {

--- a/packages/send/frontend/src/lib/trpc.ts
+++ b/packages/send/frontend/src/lib/trpc.ts
@@ -98,14 +98,21 @@ export async function fetchWithLogoutCheck(
   url: RequestInfo | URL,
   options: RequestInit
 ): Promise<Response> {
+  // Dynamic import (not a top-level one) because auth-store transitively imports
+  // this module — a static import would create a circular dependency.
+  async function getAuthStore() {
+    const { useAuthStore } = await import('@send-frontend/stores/auth-store');
+    return useAuthStore();
+  }
+
   // Attach the current OIDC access token (unless the caller already set one).
   // Rebuilt for the post-refresh retry so it picks up the freshly-rotated token.
   async function buildHeaders(): Promise<Headers> {
     const headers = new Headers(options.headers);
     try {
-      const { useAuthStore } = await import('@send-frontend/stores/auth-store');
       if (!headers.has('Authorization')) {
-        const token = await useAuthStore().getAccessToken();
+        const authStore = await getAuthStore();
+        const token = await authStore.getAccessToken();
         if (token) {
           headers.set('Authorization', `Bearer ${token}`);
         }
@@ -124,10 +131,10 @@ export async function fetchWithLogoutCheck(
 
   if (res.headers?.get?.('x-logout')) {
     try {
-      const { useAuthStore } = await import('@send-frontend/stores/auth-store');
       // A revoked access token may just need refreshing — recover and retry
       // rather than forcing logout when the refresh token is still alive (#974).
-      if (await useAuthStore().recoverOrForceLogout()) {
+      const authStore = await getAuthStore();
+      if (await authStore.recoverOrForceLogout()) {
         return await fetch(url, {
           ...options,
           headers: await buildHeaders(),

--- a/packages/send/frontend/src/stores/auth-store.ts
+++ b/packages/send/frontend/src/stores/auth-store.ts
@@ -368,37 +368,44 @@ export const useAuthStore = defineStore('auth', () => {
    * would loop); it only clears client state and redirects.
    */
   async function handleForcedLogout() {
+    // Coalesce a burst of concurrent x-logout responses into one teardown. The
+    // guard is reset in `finally` so a later, separate revocation still logs the
+    // user out — the redirect is a client-side router navigation (no full reload
+    // that would reset a module-scope latch on its own).
     if (forcedLogoutInProgress) {
       return;
     }
     forcedLogoutInProgress = true;
-
-    isLoggedIn.value = false;
-    currentUser.value = null;
     try {
-      await userManager.removeUser();
-    } catch {
-      // best-effort — the session is already gone server-side
-    }
-    try {
-      // Extension context stores the session; clear it if present.
-      if (typeof browser !== 'undefined') {
-        await browser.storage.local.remove(STORAGE_KEY_AUTH);
-        browser.runtime.sendMessage({ type: SIGN_OUT });
+      isLoggedIn.value = false;
+      currentUser.value = null;
+      try {
+        await userManager.removeUser();
+      } catch {
+        // best-effort — the session is already gone server-side
       }
-    } catch {
-      // best-effort
-    }
-    // Ask the app UI to return to login. Dispatched as a window event rather
-    // than importing the Vue router here: this store is also bundled into the
-    // background script (vite.config.background.js has no Vue plugin), so
-    // importing the router — which pulls in every .vue page — breaks that build.
-    // The listener lives in the router module (app bundle only) and does a
-    // client-side navigation that is safe in both the web app and the add-on
-    // (moz-extension://), where a hard window.location path nav would not
-    // resolve.
-    if (typeof window !== 'undefined') {
-      window.dispatchEvent(new CustomEvent('tbpro:force-logout'));
+      try {
+        // Extension context stores the session; clear it if present.
+        if (typeof browser !== 'undefined') {
+          await browser.storage.local.remove(STORAGE_KEY_AUTH);
+          browser.runtime.sendMessage({ type: SIGN_OUT });
+        }
+      } catch {
+        // best-effort
+      }
+      // Ask the app UI to return to login. Dispatched as a window event rather
+      // than importing the Vue router here: this store is also bundled into the
+      // background script (vite.config.background.js has no Vue plugin), so
+      // importing the router — which pulls in every .vue page — breaks that
+      // build. The listener lives in the router module (app bundle only) and
+      // does a client-side navigation that is safe in both the web app and the
+      // add-on (moz-extension://), where a hard window.location path nav would
+      // not resolve.
+      if (typeof window !== 'undefined') {
+        window.dispatchEvent(new CustomEvent('tbpro:force-logout'));
+      }
+    } finally {
+      forcedLogoutInProgress = false;
     }
   }
 

--- a/packages/send/frontend/src/stores/auth-store.ts
+++ b/packages/send/frontend/src/stores/auth-store.ts
@@ -79,6 +79,14 @@ export const useAuthStore = defineStore('auth', () => {
   // invalid_grant, which reads as a spurious logout.
   let inFlightRefresh: Promise<User | null> | null = null;
 
+  // Outcome of the most recently completed refresh: `true` when it failed
+  // genuinely (refresh token revoked/expired), `false` on success or a transient
+  // error. recoverOrForceLogout reads this to decide force-logout vs fail-open,
+  // rather than inferring from isLoggedIn — which can already be false (e.g. an
+  // extension cold-start request fires before checkAuthStatus flips it true) and
+  // would otherwise turn a network blip into a spurious logout.
+  let lastRefreshFailedGenuinely = false;
+
   /**
    * Notify the add-on background that the session is over so its menu reverts
    * to logged-out. Only meaningful inside Thunderbird, where the token-bridge
@@ -107,6 +115,7 @@ export const useAuthStore = defineStore('auth', () => {
     if (inFlightRefresh) return inFlightRefresh;
 
     inFlightRefresh = (async () => {
+      lastRefreshFailedGenuinely = false;
       try {
         const user = await userManager.signinSilent();
         currentUser.value = user;
@@ -118,6 +127,7 @@ export const useAuthStore = defineStore('auth', () => {
         return user;
       } catch (error) {
         if (isGenuineAuthFailure(error)) {
+          lastRefreshFailedGenuinely = true;
           console.warn(
             `Silent token refresh failed — session ended (${
               (error as { error?: string }).error
@@ -442,6 +452,39 @@ export const useAuthStore = defineStore('auth', () => {
     return user?.access_token ?? null;
   }
 
+  /**
+   * The backend reported the current access token revoked (x-logout, #960).
+   * Before tearing the session down, try a silent refresh: a revoked/expired
+   * *access* token can often be replaced using a still-valid *refresh* token,
+   * so the session keeps rolling instead of bouncing the user to login (PR #974
+   * review). Only force logout when the refresh token is also gone; on a
+   * transient refresh error keep the session (fail open).
+   *
+   * Goes through refreshAccessToken() — an unconditional signinSilent — rather
+   * than getAccessToken(), because the token behind x-logout is still within
+   * its lifetime (the backend exp-gates the signal), so getAccessToken() would
+   * hand back the same stale, revoked token without refreshing.
+   *
+   * @returns `true` if the session was recovered — the caller should retry the
+   * request with the fresh token — and `false` otherwise (forced logout on a
+   * genuine failure, or session kept on a transient error).
+   */
+  async function recoverOrForceLogout(): Promise<boolean> {
+    const user = await refreshAccessToken();
+    if (user && !user.expired) {
+      return true; // refresh token still valid → session continues
+    }
+    // Force logout ONLY on a genuine refresh failure (refresh token gone). A
+    // transient error keeps the session (fail open). We read the failure kind
+    // refreshAccessToken just recorded rather than inferring from isLoggedIn —
+    // there is no await between its resolution above and this read, so the flag
+    // still reflects this refresh.
+    if (lastRefreshFailedGenuinely) {
+      await handleForcedLogout(); // genuine failure → clear state and redirect
+    }
+    return false;
+  }
+
   async function loadUser() {
     // Always check for a stored user instead of getting it from
     // the userManager.
@@ -648,6 +691,7 @@ export const useAuthStore = defineStore('auth', () => {
     getAccessToken,
     logoutFromOIDC,
     handleForcedLogout,
+    recoverOrForceLogout,
     refreshToken,
     loginToKeyCloak, // Alias for loginToOIDC
 

--- a/packages/send/frontend/src/stores/auth-store.ts
+++ b/packages/send/frontend/src/stores/auth-store.ts
@@ -389,18 +389,16 @@ export const useAuthStore = defineStore('auth', () => {
     } catch {
       // best-effort
     }
-    // Return to login via the client-side router. This works both in the web
-    // app and inside the add-on (moz-extension://), where a hard
-    // window.location navigation to a route path would not resolve. Fall back
-    // to a hard navigation only if the router isn't available.
-    try {
-      const { default: router } =
-        await import('@send-frontend/apps/send/router');
-      await router.replace('/login');
-    } catch {
-      if (typeof window !== 'undefined') {
-        window.location.assign('/send');
-      }
+    // Ask the app UI to return to login. Dispatched as a window event rather
+    // than importing the Vue router here: this store is also bundled into the
+    // background script (vite.config.background.js has no Vue plugin), so
+    // importing the router — which pulls in every .vue page — breaks that build.
+    // The listener lives in the router module (app bundle only) and does a
+    // client-side navigation that is safe in both the web app and the add-on
+    // (moz-extension://), where a hard window.location path nav would not
+    // resolve.
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new CustomEvent('tbpro:force-logout'));
     }
   }
 

--- a/packages/send/frontend/src/stores/auth-store.ts
+++ b/packages/send/frontend/src/stores/auth-store.ts
@@ -389,9 +389,18 @@ export const useAuthStore = defineStore('auth', () => {
     } catch {
       // best-effort
     }
-    // Send the user to a clean state; the app shows login when unauthenticated.
-    if (typeof window !== 'undefined') {
-      window.location.assign('/send');
+    // Return to login via the client-side router. This works both in the web
+    // app and inside the add-on (moz-extension://), where a hard
+    // window.location navigation to a route path would not resolve. Fall back
+    // to a hard navigation only if the router isn't available.
+    try {
+      const { default: router } =
+        await import('@send-frontend/apps/send/router');
+      await router.replace('/login');
+    } catch {
+      if (typeof window !== 'undefined') {
+        window.location.assign('/send');
+      }
     }
   }
 

--- a/packages/send/frontend/src/stores/auth-store.ts
+++ b/packages/send/frontend/src/stores/auth-store.ts
@@ -55,6 +55,10 @@ function isGenuineAuthFailure(error: unknown): boolean {
   return typeof code === 'string' && GENUINE_AUTH_FAILURE_CODES.includes(code);
 }
 
+// Ensures a forced logout (triggered by the x-logout header, #960) runs once
+// even if several in-flight requests come back with the header at the same time.
+let forcedLogoutInProgress = false;
+
 export const useAuthStore = defineStore('auth', () => {
   const { api } = useApiStore();
   const { isExtension, isThunderbirdHost } = useConfigStore();
@@ -357,6 +361,41 @@ export const useAuthStore = defineStore('auth', () => {
   }
 
   /**
+   * Forced logout in response to the backend's x-logout header (#960): the
+   * session was ended server-side (logout elsewhere, password change, admin
+   * revoke). Clear local auth and return to a clean state. Deliberately does
+   * NOT call the API (that path is what surfaced x-logout, so calling it again
+   * would loop); it only clears client state and redirects.
+   */
+  async function handleForcedLogout() {
+    if (forcedLogoutInProgress) {
+      return;
+    }
+    forcedLogoutInProgress = true;
+
+    isLoggedIn.value = false;
+    currentUser.value = null;
+    try {
+      await userManager.removeUser();
+    } catch {
+      // best-effort — the session is already gone server-side
+    }
+    try {
+      // Extension context stores the session; clear it if present.
+      if (typeof browser !== 'undefined') {
+        await browser.storage.local.remove(STORAGE_KEY_AUTH);
+        browser.runtime.sendMessage({ type: SIGN_OUT });
+      }
+    } catch {
+      // best-effort
+    }
+    // Send the user to a clean state; the app shows login when unauthenticated.
+    if (typeof window !== 'undefined') {
+      window.location.assign('/send');
+    }
+  }
+
+  /**
    * Logout from OIDC and clear local state
    */
   async function logoutFromOIDC() {
@@ -594,6 +633,7 @@ export const useAuthStore = defineStore('auth', () => {
     checkAuthStatus,
     getAccessToken,
     logoutFromOIDC,
+    handleForcedLogout,
     refreshToken,
     loginToKeyCloak, // Alias for loginToOIDC
 

--- a/packages/send/frontend/src/test/lib/api.test.ts
+++ b/packages/send/frontend/src/test/lib/api.test.ts
@@ -7,6 +7,17 @@
 import { ApiCallFailure, ApiConnection } from '@send-frontend/lib/api';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+// Stub the auth store so api.call's dynamic imports (getAccessToken and the
+// x-logout handler) don't pull in pinia/oidc at test time.
+const { mockForcedLogout } = vi.hoisted(() => ({ mockForcedLogout: vi.fn() }));
+vi.mock('@send-frontend/stores/auth-store', () => ({
+  useAuthStore: () => ({
+    getAccessToken: async () => null,
+    handleForcedLogout: mockForcedLogout,
+    refreshToken: async () => null,
+  }),
+}));
+
 const SERVER = 'https://send.test.local';
 
 function mockFetch(impl: () => Promise<Response> | Response) {
@@ -113,9 +124,59 @@ describe('ApiConnection.call — onFailure diagnostics', () => {
     const api = new ApiConnection(SERVER);
     let failure: ApiCallFailure | undefined;
 
-    await api.call('uploads', {}, 'POST', {}, { onFailure: (f) => (failure = f) });
+    await api.call(
+      'uploads',
+      {},
+      'POST',
+      {},
+      { onFailure: (f) => (failure = f) }
+    );
 
     expect(failure?.kind).toBe('http');
     expect((failure as { body: string }).body).toHaveLength(500);
+  });
+});
+
+describe('ApiConnection.call — x-logout forced logout (#960)', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    mockForcedLogout.mockClear();
+  });
+
+  it('clears the session and returns null when the response has x-logout', async () => {
+    mockFetch(
+      () =>
+        ({
+          ok: true,
+          status: 200,
+          headers: { get: (k: string) => (k === 'x-logout' ? '1' : null) },
+          json: async () => ({ ok: true }),
+        }) as unknown as Response
+    );
+
+    const api = new ApiConnection(SERVER);
+    const result = await api.call('uploads', {}, 'POST');
+
+    expect(mockForcedLogout).toHaveBeenCalledTimes(1);
+    expect(result).toBeNull();
+  });
+
+  it('does not force logout when the header is absent', async () => {
+    mockFetch(
+      () =>
+        ({
+          ok: true,
+          status: 200,
+          headers: { get: () => null },
+          json: async () => ({ ok: true }),
+        }) as unknown as Response
+    );
+
+    const api = new ApiConnection(SERVER);
+    const result = await api.call('uploads', {}, 'POST');
+
+    expect(mockForcedLogout).not.toHaveBeenCalled();
+    expect(result).toEqual({ ok: true });
   });
 });

--- a/packages/send/frontend/src/test/lib/api.test.ts
+++ b/packages/send/frontend/src/test/lib/api.test.ts
@@ -9,12 +9,18 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 // Stub the auth store so api.call's dynamic imports (getAccessToken and the
 // x-logout handler) don't pull in pinia/oidc at test time.
-const { mockForcedLogout } = vi.hoisted(() => ({ mockForcedLogout: vi.fn() }));
+const { mockGetAccessToken, mockRecover, mockRefreshToken } = vi.hoisted(
+  () => ({
+    mockGetAccessToken: vi.fn<() => Promise<string | null>>(async () => null),
+    mockRecover: vi.fn<() => Promise<boolean>>(async () => false),
+    mockRefreshToken: vi.fn<() => Promise<string | null>>(async () => null),
+  })
+);
 vi.mock('@send-frontend/stores/auth-store', () => ({
   useAuthStore: () => ({
-    getAccessToken: async () => null,
-    handleForcedLogout: mockForcedLogout,
-    refreshToken: async () => null,
+    getAccessToken: mockGetAccessToken,
+    recoverOrForceLogout: mockRecover,
+    refreshToken: mockRefreshToken,
   }),
 }));
 
@@ -137,19 +143,22 @@ describe('ApiConnection.call — onFailure diagnostics', () => {
   });
 });
 
-describe('ApiConnection.call — x-logout forced logout (#960)', () => {
+describe('ApiConnection.call — x-logout session recovery (#960/#974)', () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
-    mockForcedLogout.mockClear();
+    mockGetAccessToken.mockReset().mockResolvedValue(null);
+    mockRecover.mockReset().mockResolvedValue(false);
+    mockRefreshToken.mockReset().mockResolvedValue(null);
   });
 
-  it('clears the session and returns null when the response has x-logout', async () => {
-    mockFetch(
+  it('returns null without retrying when recovery fails (refresh token dead)', async () => {
+    mockRecover.mockResolvedValue(false);
+    const fetchFn = mockFetch(
       () =>
         ({
-          ok: true,
-          status: 200,
+          ok: false,
+          status: 401,
           headers: { get: (k: string) => (k === 'x-logout' ? '1' : null) },
           json: async () => ({ ok: true }),
         }) as unknown as Response
@@ -158,11 +167,50 @@ describe('ApiConnection.call — x-logout forced logout (#960)', () => {
     const api = new ApiConnection(SERVER);
     const result = await api.call('uploads', {}, 'POST');
 
-    expect(mockForcedLogout).toHaveBeenCalledTimes(1);
+    expect(mockRecover).toHaveBeenCalledTimes(1);
+    expect(fetchFn).toHaveBeenCalledTimes(1); // no retry
     expect(result).toBeNull();
   });
 
-  it('does not force logout when the header is absent', async () => {
+  it('retries with a fresh token and returns the retry body when recovery succeeds', async () => {
+    // Present an OIDC bearer token so the retry path (which needs an existing
+    // Authorization header) is taken.
+    mockGetAccessToken.mockResolvedValueOnce('stale'); // initial request token
+    mockRecover.mockResolvedValue(true);
+    mockGetAccessToken.mockResolvedValueOnce('fresh'); // token used on retry
+
+    let call = 0;
+    const fetchFn = mockFetch(() => {
+      call += 1;
+      if (call === 1) {
+        return {
+          ok: false,
+          status: 401,
+          headers: { get: (k: string) => (k === 'x-logout' ? '1' : null) },
+          json: async () => ({ stale: true }),
+        } as unknown as Response;
+      }
+      return {
+        ok: true,
+        status: 200,
+        headers: { get: () => null },
+        json: async () => ({ ok: true }),
+      } as unknown as Response;
+    });
+
+    const api = new ApiConnection(SERVER);
+    const result = await api.call('uploads', {}, 'POST');
+
+    expect(mockRecover).toHaveBeenCalledTimes(1);
+    expect(fetchFn).toHaveBeenCalledTimes(2); // retried once
+    const retryOpts = (fetchFn.mock.calls[1] as unknown[])[1] as {
+      headers: Record<string, string>;
+    };
+    expect(retryOpts.headers['Authorization']).toBe('Bearer fresh');
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('does not attempt recovery when the header is absent', async () => {
     mockFetch(
       () =>
         ({
@@ -176,7 +224,7 @@ describe('ApiConnection.call — x-logout forced logout (#960)', () => {
     const api = new ApiConnection(SERVER);
     const result = await api.call('uploads', {}, 'POST');
 
-    expect(mockForcedLogout).not.toHaveBeenCalled();
+    expect(mockRecover).not.toHaveBeenCalled();
     expect(result).toEqual({ ok: true });
   });
 });

--- a/packages/send/frontend/src/test/lib/trpc.test.ts
+++ b/packages/send/frontend/src/test/lib/trpc.test.ts
@@ -7,14 +7,14 @@ import {
 } from '@send-frontend/lib/trpc';
 import { TRPC_WS_PATH } from '@send-frontend/lib/config';
 
-const { mockGetAccessToken, mockForcedLogout } = vi.hoisted(() => ({
+const { mockGetAccessToken, mockRecover } = vi.hoisted(() => ({
   mockGetAccessToken: vi.fn(),
-  mockForcedLogout: vi.fn(),
+  mockRecover: vi.fn(async () => false),
 }));
 vi.mock('@send-frontend/stores/auth-store', () => ({
   useAuthStore: () => ({
     getAccessToken: mockGetAccessToken,
-    handleForcedLogout: mockForcedLogout,
+    recoverOrForceLogout: mockRecover,
   }),
 }));
 
@@ -107,19 +107,46 @@ describe('fetchWithLogoutCheck (#960)', () => {
     expect(mockGetAccessToken).not.toHaveBeenCalled();
   });
 
-  it('forces logout when the response carries x-logout', async () => {
+  it('recovers (no retry) and returns the original response when recovery fails', async () => {
     mockGetAccessToken.mockResolvedValue(null);
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(() =>
-        Promise.resolve({
-          headers: { get: (k: string) => (k === 'x-logout' ? '1' : null) },
-        } as unknown as Response)
-      )
-    );
+    mockRecover.mockResolvedValue(false);
+    const original = {
+      headers: { get: (k: string) => (k === 'x-logout' ? '1' : null) },
+    } as unknown as Response;
+    const fetchFn = vi.fn(() => Promise.resolve(original));
+    vi.stubGlobal('fetch', fetchFn);
+
+    const res = await fetchWithLogoutCheck('https://x/trpc', {});
+
+    expect(mockRecover).toHaveBeenCalledTimes(1);
+    expect(fetchFn).toHaveBeenCalledTimes(1); // no retry
+    expect(res).toBe(original);
+  });
+
+  it('retries once with a refreshed token when recovery succeeds', async () => {
+    mockRecover.mockResolvedValue(true);
+    // First call: initial request has no token; retry: getAccessToken yields one.
+    mockGetAccessToken.mockResolvedValueOnce(null).mockResolvedValueOnce('fresh');
+
+    const inits: RequestInit[] = [];
+    let call = 0;
+    const fetchFn = vi.fn((_url, opts) => {
+      inits.push(opts);
+      call += 1;
+      return Promise.resolve({
+        headers: {
+          get: (k: string) => (call === 1 && k === 'x-logout' ? '1' : null),
+        },
+      } as unknown as Response);
+    });
+    vi.stubGlobal('fetch', fetchFn);
 
     await fetchWithLogoutCheck('https://x/trpc', {});
 
-    expect(mockForcedLogout).toHaveBeenCalledTimes(1);
+    expect(mockRecover).toHaveBeenCalledTimes(1);
+    expect(fetchFn).toHaveBeenCalledTimes(2); // retried once
+    expect((inits[1].headers as Headers).get('Authorization')).toBe(
+      'Bearer fresh'
+    );
   });
 });

--- a/packages/send/frontend/src/test/lib/trpc.test.ts
+++ b/packages/send/frontend/src/test/lib/trpc.test.ts
@@ -1,7 +1,22 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { detectTesting, getWsClientConfig } from '@send-frontend/lib/trpc';
+import {
+  detectTesting,
+  fetchWithLogoutCheck,
+  getWsClientConfig,
+} from '@send-frontend/lib/trpc';
 import { TRPC_WS_PATH } from '@send-frontend/lib/config';
+
+const { mockGetAccessToken, mockForcedLogout } = vi.hoisted(() => ({
+  mockGetAccessToken: vi.fn(),
+  mockForcedLogout: vi.fn(),
+}));
+vi.mock('@send-frontend/stores/auth-store', () => ({
+  useAuthStore: () => ({
+    getAccessToken: mockGetAccessToken,
+    handleForcedLogout: mockForcedLogout,
+  }),
+}));
 
 /**
  * Regression guard for Bug 2036665.
@@ -39,5 +54,72 @@ describe('detectTesting', () => {
   // absent and detection falls back to the WebExtension `browser.test` API.
   it('reports a test context when VITE_TESTING is set', () => {
     expect(detectTesting()).toBe(true);
+  });
+});
+
+describe('fetchWithLogoutCheck (#960)', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('attaches the OIDC access token and cookies when no Authorization is set', async () => {
+    mockGetAccessToken.mockResolvedValue('tok123');
+    let init: RequestInit | undefined;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((_url, opts) => {
+        init = opts;
+        return Promise.resolve({
+          headers: { get: () => null },
+        } as unknown as Response);
+      })
+    );
+
+    await fetchWithLogoutCheck('https://x/trpc', {});
+
+    expect((init?.headers as Headers).get('Authorization')).toBe(
+      'Bearer tok123'
+    );
+    expect(init?.credentials).toBe('include');
+  });
+
+  it('does not override an Authorization header the caller already set', async () => {
+    mockGetAccessToken.mockResolvedValue('tok123');
+    let init: RequestInit | undefined;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((_url, opts) => {
+        init = opts;
+        return Promise.resolve({
+          headers: { get: () => null },
+        } as unknown as Response);
+      })
+    );
+
+    await fetchWithLogoutCheck('https://x/trpc', {
+      headers: { Authorization: 'Bearer existing' },
+    });
+
+    expect((init?.headers as Headers).get('Authorization')).toBe(
+      'Bearer existing'
+    );
+    expect(mockGetAccessToken).not.toHaveBeenCalled();
+  });
+
+  it('forces logout when the response carries x-logout', async () => {
+    mockGetAccessToken.mockResolvedValue(null);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() =>
+        Promise.resolve({
+          headers: { get: (k: string) => (k === 'x-logout' ? '1' : null) },
+        } as unknown as Response)
+      )
+    );
+
+    await fetchWithLogoutCheck('https://x/trpc', {});
+
+    expect(mockForcedLogout).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/send/frontend/src/test/stores/auth-store.test.ts
+++ b/packages/send/frontend/src/test/stores/auth-store.test.ts
@@ -121,3 +121,36 @@ describe('auth-store token refresh', () => {
     expect(postMessage).not.toHaveBeenCalled();
   });
 });
+
+describe('auth-store forced logout (#960)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('clears session, dispatches tbpro:force-logout, and can run again (guard resets)', async () => {
+    setThunderbirdHost(false);
+    const removeUser = vi
+      .spyOn(UserManager.prototype, 'removeUser')
+      .mockResolvedValue(undefined as never);
+    const dispatch = vi.spyOn(window, 'dispatchEvent');
+
+    const auth = useAuthStore();
+    auth.isLoggedIn = true;
+
+    await auth.handleForcedLogout();
+    await auth.handleForcedLogout();
+
+    // Guard resets in `finally`, so a second forced logout still runs — it is
+    // not a permanent no-op.
+    expect(removeUser).toHaveBeenCalledTimes(2);
+    expect(auth.isLoggedIn).toBe(false);
+    const forceLogoutEvents = dispatch.mock.calls.filter(
+      ([e]) => (e as Event).type === 'tbpro:force-logout'
+    );
+    expect(forceLogoutEvents).toHaveLength(2);
+  });
+});

--- a/packages/send/frontend/src/test/stores/auth-store.test.ts
+++ b/packages/send/frontend/src/test/stores/auth-store.test.ts
@@ -154,3 +154,91 @@ describe('auth-store forced logout (#960)', () => {
     expect(forceLogoutEvents).toHaveLength(2);
   });
 });
+
+describe('auth-store recoverOrForceLogout (#974)', () => {
+  let signinSilent: ReturnType<typeof vi.spyOn>;
+  let removeUser: ReturnType<typeof vi.spyOn>;
+  let dispatch: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    signinSilent = vi.spyOn(UserManager.prototype, 'signinSilent');
+    removeUser = vi
+      .spyOn(UserManager.prototype, 'removeUser')
+      .mockResolvedValue(undefined as never);
+    dispatch = vi.spyOn(window, 'dispatchEvent');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function forceLogoutCount() {
+    return dispatch.mock.calls.filter(
+      ([e]) => (e as Event).type === 'tbpro:force-logout'
+    ).length;
+  }
+
+  it('recovers (keeps the session) when the refresh token is still valid', async () => {
+    setThunderbirdHost(false);
+    signinSilent.mockResolvedValue({
+      access_token: 'fresh',
+      expired: false,
+    } as never);
+
+    const auth = useAuthStore();
+    auth.isLoggedIn = true;
+
+    const recovered = await auth.recoverOrForceLogout();
+
+    expect(recovered).toBe(true);
+    expect(auth.isLoggedIn).toBe(true);
+    expect(forceLogoutCount()).toBe(0);
+  });
+
+  it('forces logout on a genuine refresh failure (session truly gone)', async () => {
+    setThunderbirdHost(false);
+    signinSilent.mockRejectedValue({ error: 'invalid_grant' } as never);
+
+    const auth = useAuthStore();
+    auth.isLoggedIn = true;
+
+    const recovered = await auth.recoverOrForceLogout();
+
+    expect(recovered).toBe(false);
+    expect(auth.isLoggedIn).toBe(false);
+    expect(removeUser).toHaveBeenCalled();
+    expect(forceLogoutCount()).toBe(1);
+  });
+
+  it('keeps the session (no forced logout) on a transient refresh error', async () => {
+    setThunderbirdHost(false);
+    signinSilent.mockRejectedValue(new Error('network down') as never);
+
+    const auth = useAuthStore();
+    auth.isLoggedIn = true;
+
+    const recovered = await auth.recoverOrForceLogout();
+
+    expect(recovered).toBe(false);
+    expect(auth.isLoggedIn).toBe(true); // fail open — no logout on a blip
+    expect(forceLogoutCount()).toBe(0);
+  });
+
+  it('does not force logout on a transient error even when isLoggedIn is already false', async () => {
+    // Extension cold-start: a stored token fires a request before checkAuthStatus
+    // flips isLoggedIn true. A transient refresh error here must still fail open —
+    // the decision keys off the refresh failure kind, not isLoggedIn.
+    setThunderbirdHost(false);
+    signinSilent.mockRejectedValue(new Error('network down') as never);
+
+    const auth = useAuthStore();
+    auth.isLoggedIn = false;
+
+    const recovered = await auth.recoverOrForceLogout();
+
+    expect(recovered).toBe(false);
+    expect(removeUser).not.toHaveBeenCalled();
+    expect(forceLogoutCount()).toBe(0);
+  });
+});


### PR DESCRIPTION
## What changed?

The backend now introspects the OIDC access token against Keycloak on **each authenticated request** (both the REST API and tRPC). When a session has been ended server-side — logged out elsewhere, password change, or an admin force-logout — the backend returns an `x-logout` response header, and the frontend clears its local auth and returns to login.

Key behaviors:
- Forced logout fires **only for a genuine revocation** (an access token still within its lifetime that Keycloak reports inactive). Routine access-token expiry is left to the normal refresh flow, so this does not log people out mid-session.
- Introspection results are cached (~60s) so a burst of requests (e.g. an upload) isn't one Keycloak call per request, and it **fails open** if Keycloak is unreachable — an outage can't sign everyone out.
- The forced-logout redirect is dispatched as a window event so the shared auth store (also bundled into the Vue-less background script) never imports the router.

_AI disclosure: implemented by an AI agent (Claude) working from my direction; I reviewed the result, and it went through an automated senior-code-review pass whose findings were folded in._

## Why?

Without this, a revoked session keeps working until the access token's TTL expires — so a logout, password change, or admin revoke doesn't actually cut off access for up to that window. Checking token liveness per request closes that gap to ~1 minute.

## Limitations and Notes

- Enforcement requires `OIDC_TOKEN_INTROSPECTION_URL`, `OIDC_CLIENT_ID`, and `OIDC_CLIENT_SECRET` to be set **per environment** (stage/prod). If they're absent, introspection fails open and there is no enforcement.
- The revoke → forced-logout path is covered by backend + frontend unit tests and a real-browser web-app check (valid sessions see zero spurious logouts; an injected `x-logout` triggers the redirect). A **manual pass in the Thunderbird add-on** — sign in, revoke the session elsewhere, confirm it returns cleanly to login — is recommended before/at merge, since that exact GUI path can't be driven headlessly.

## Applicable Issues

Closes #960

## Screenshots

N/A — backend/auth behavior with no UI visuals.
