### PR TITLE
fix(addon): harden token bridge and deliver the passphrase to the add-on (#953)

### DIFF
--- a/packages/addon/public/manifest.json
+++ b/packages/addon/public/manifest.json
@@ -129,7 +129,9 @@
   "content_scripts": [
     {
       "matches": [
-        "<all_urls>"
+        "https://send.tb.pro/*",
+        "https://send-stage.tb.pro/*",
+        "http://localhost/*"
       ],
       "js": [
         "token-bridge.js"

--- a/packages/addon/public/token-bridge.js
+++ b/packages/addon/public/token-bridge.js
@@ -22,21 +22,6 @@ const PENDING_ADDON_TOKEN_RESPONSE = 'TB/PENDING_ADDON_TOKEN_RESPONSE';
 window.postMessage({ type: BRIDGE_READY }, window.location.origin);
 console.log(`[🌉 token-bridge] the token bridge has loaded.`);
 
-// Visual cue, make sure to remove.
-const tag = document.createElement('div');
-tag.textContent = '✅ Content script injected';
-Object.assign(tag.style, {
-  position: 'fixed',
-  zIndex: 999999,
-  inset: '8px auto auto 8px',
-  padding: '6px 10px',
-  background: 'lime',
-  color: 'black',
-  fontFamily: 'monospace',
-  boxShadow: '0 2px 8px rgba(0,0,0,.25)',
-});
-// document.documentElement.appendChild(tag);
-
 // Initial message to the background
 browser.runtime.sendMessage({
   type: PING,
@@ -44,9 +29,17 @@ browser.runtime.sendMessage({
 });
 
 window.addEventListener('message', (e) => {
-  // if (e.origin !== APP_ORIGIN) return;   // security: only trust your app
-  // if (e.source !== window) return;       // same-page messages only
-  // if (!e.data || e.data.type !== "TB_PING") return;
+  // Security: this bridge forwards messages straight to the privileged add-on
+  // background (OIDC tokens, the encryption passphrase, sign-in/out). Only trust
+  // messages the app page posted to itself:
+  //   • e.source !== window  → came from an embedded/cross-origin frame or
+  //     another window, not the top app page. Reject.
+  //   • e.origin !== window.location.origin → not same-origin. Reject.
+  // Combined with the scoped content_scripts `matches` in the manifest (the
+  // bridge is only injected on the Send app's own origins), this keeps a
+  // third-party page or frame from driving the add-on.
+  if (e.source !== window) return;
+  if (e.origin !== window.location.origin) return;
 
   // ----- Web to add-on: Step 6b — refresh token → background (Thundermail) -----
   // handleOIDCCallback() posts OIDC_TOKEN with the refresh_token so that

--- a/packages/addon/scripts/build.sh
+++ b/packages/addon/scripts/build.sh
@@ -168,6 +168,22 @@ if [ "$ADDON_VARIANT" = "system" ]; then
     bun run scripts/set-system-id.ts dist/manifest.json --allow-stage
 fi
 
+### Scope the token-bridge content script to remote app origins only for
+### production. public/manifest.json lists http://localhost/* so local dev builds
+### inject the bridge into the local Send app, but a released build must not trust
+### any localhost page: the bridge forwards messages to the privileged background
+### (OIDC tokens, encryption passphrase), and the same-origin guard in
+### token-bridge.js does not stop a hostile page that is itself served from
+### localhost. Strip it here for prod; non-prod builds keep localhost for dev.
+if [ "$NODE_ENV" = "production" ]; then
+    echo "================================================================"
+    echo "=============== prod: drop localhost bridge match =============="
+    tmp_manifest="$(mktemp)"
+    jq '(.content_scripts[].matches) |= map(select(. != "http://localhost/*"))' \
+        dist/manifest.json > "$tmp_manifest"
+    mv "$tmp_manifest" dist/manifest.json
+fi
+
 cd dist
 # Create xpi with version number
 zip -r -FS ../tbpro-addon-${VERSION}.xpi *

--- a/packages/send/frontend/src/composables/useSendConfig.ts
+++ b/packages/send/frontend/src/composables/useSendConfig.ts
@@ -1,8 +1,5 @@
-import {
-  GET_LOGIN_STATE,
-  LOGIN_STATE_RESPONSE,
-  SEND_MESSAGE_TO_BRIDGE,
-} from '@send-frontend/lib/const';
+import { GET_LOGIN_STATE, LOGIN_STATE_RESPONSE } from '@send-frontend/lib/const';
+import { pullBridgedPassphrase } from '@send-frontend/lib/bridgePassphrase';
 import { dbUserSetup } from '@send-frontend/lib/helpers';
 import init from '@send-frontend/lib/init';
 import { validateToken } from '@send-frontend/lib/validations';
@@ -31,35 +28,12 @@ export function useSendConfig() {
   const { isLoggedIn } = storeToRefs(authStore);
 
   /**
-   * Checks browser extension storage for SEND_MESSAGE_TO_BRIDGE value
-   * and transfers it to localStorage under 'lb/passphrase' key.
-   * The value is stored as an object with passPhrase property.
+   * Pulls a passphrase shared from the web app via the token bridge into the
+   * keychain (delegates to pullBridgedPassphrase). Called before the login
+   * checks in loadLogin so the passphrase is present when keys are restored.
    */
   const checkAndTransferBridgeMessage = async () => {
-    try {
-      const result = await browser.storage.local.get(SEND_MESSAGE_TO_BRIDGE);
-
-      if (result[SEND_MESSAGE_TO_BRIDGE]) {
-        const value = result[SEND_MESSAGE_TO_BRIDGE];
-        const passphraseObject = {
-          passPhrase: value,
-        };
-
-        localStorage.setItem('lb/passphrase', JSON.stringify(passphraseObject));
-        console.log('✅ Transferred bridge message to localStorage');
-
-        // Delete the value from extension storage after successful transfer
-        await browser.storage.local.remove(SEND_MESSAGE_TO_BRIDGE);
-        console.log('✅ Removed bridge message from extension storage');
-
-        return true;
-      }
-
-      return false;
-    } catch (error) {
-      console.error('Error checking bridge message:', error);
-      return false;
-    }
+    return pullBridgedPassphrase(keychain);
   };
   // Set up listener for bridge message transfer trigger
   try {
@@ -209,8 +183,8 @@ export function useSendConfig() {
      */
     useLoginQuery,
     /**
-     * Checks browser extension storage for SEND_MESSAGE_TO_BRIDGE value
-     * and transfers it to localStorage under 'lb/passphrase' key.
+     * Pulls a passphrase shared from the web app via the token bridge into the
+     * keychain (delegates to pullBridgedPassphrase).
      */
     checkAndTransferBridgeMessage,
     /**

--- a/packages/send/frontend/src/lib/bridgePassphrase.ts
+++ b/packages/send/frontend/src/lib/bridgePassphrase.ts
@@ -1,0 +1,43 @@
+import { SEND_MESSAGE_TO_BRIDGE } from '@send-frontend/lib/const';
+
+/**
+ * Pull a passphrase shared from the web app via the token bridge into the
+ * keychain.
+ *
+ * The web app (running in a browser tab) posts SEND_MESSAGE_TO_BRIDGE; the
+ * add-on background stores its value in browser.storage.local under that key
+ * (see background.ts). This moves that staged value into the keychain — i.e.
+ * localStorage['lb/passphrase'], which every moz-extension page (background,
+ * popup, management) shares — and clears the staged copy so it is consumed once.
+ *
+ * Runs only in an extension context where browser.storage.local exists; it is a
+ * no-op in a plain web page (where `browser` is undefined). Safe to call from
+ * any context that is about to restore keys, so the popup and background don't
+ * depend on the management page having run the transfer first.
+ *
+ * @returns true if a bridged passphrase was found and stored, false otherwise.
+ */
+export async function pullBridgedPassphrase(keychain: {
+  storePassPhrase: (passphrase: string) => Promise<void>;
+}): Promise<boolean> {
+  if (typeof browser === 'undefined' || !browser?.storage?.local) {
+    return false;
+  }
+
+  try {
+    const result = await browser.storage.local.get(SEND_MESSAGE_TO_BRIDGE);
+    const passphrase = result?.[SEND_MESSAGE_TO_BRIDGE];
+    if (!passphrase) {
+      return false;
+    }
+
+    await keychain.storePassPhrase(passphrase);
+    // Consume it once so a stale value can't linger in extension storage.
+    await browser.storage.local.remove(SEND_MESSAGE_TO_BRIDGE);
+    console.log('✅ Pulled bridged passphrase into the keychain');
+    return true;
+  } catch (error) {
+    console.error('Error pulling bridged passphrase:', error);
+    return false;
+  }
+}

--- a/packages/send/frontend/src/lib/keychain.ts
+++ b/packages/send/frontend/src/lib/keychain.ts
@@ -1,4 +1,5 @@
 import { Storage } from '@send-frontend/lib/storage';
+import { pullBridgedPassphrase } from '@send-frontend/lib/bridgePassphrase';
 import { Backup as BackupUserStore } from '@send-frontend/stores/user-store.types';
 
 export type JwkKeyPair = Record<'publicKey' | 'privateKey', string>;
@@ -720,6 +721,12 @@ export async function restoreKeysUsingLocalStorage(
   keychain: Keychain,
   api: ApiConnection
 ) {
+  // Pull any passphrase the web app shared via the token bridge into the
+  // keychain first. Both the popup and the background call this before
+  // restoring, so neither depends on the management page having already run the
+  // bridge→localStorage transfer (see pullBridgedPassphrase).
+  await pullBridgedPassphrase(keychain);
+
   console.log('🔑 auto restoring keys');
   if (!keychain.getPassphraseValue()) {
     console.log('Keychain passphrase is not initialized');

--- a/packages/send/frontend/src/test/lib/bridgePassphrase.test.ts
+++ b/packages/send/frontend/src/test/lib/bridgePassphrase.test.ts
@@ -1,0 +1,67 @@
+import { pullBridgedPassphrase } from '@send-frontend/lib/bridgePassphrase';
+import { SEND_MESSAGE_TO_BRIDGE } from '@send-frontend/lib/const';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// A minimal keychain stand-in: pullBridgedPassphrase only needs storePassPhrase.
+function makeKeychain(storePassPhrase = vi.fn().mockResolvedValue(undefined)) {
+  return { storePassPhrase };
+}
+
+// Install a fake `browser.storage.local` whose get() returns `stored`.
+function stubBrowser(stored: Record<string, unknown>) {
+  const get = vi.fn().mockResolvedValue(stored);
+  const remove = vi.fn().mockResolvedValue(undefined);
+  vi.stubGlobal('browser', { storage: { local: { get, remove } } });
+  return { get, remove };
+}
+
+describe('pullBridgedPassphrase', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('stores a staged passphrase in the keychain and consumes it once', async () => {
+    const { remove } = stubBrowser({ [SEND_MESSAGE_TO_BRIDGE]: 'word one two' });
+    const keychain = makeKeychain();
+
+    const result = await pullBridgedPassphrase(keychain);
+
+    expect(result).toBe(true);
+    expect(keychain.storePassPhrase).toHaveBeenCalledWith('word one two');
+    // The staged value is removed so it can only be consumed once.
+    expect(remove).toHaveBeenCalledWith(SEND_MESSAGE_TO_BRIDGE);
+  });
+
+  it('is a no-op when no passphrase is staged', async () => {
+    const { remove } = stubBrowser({});
+    const keychain = makeKeychain();
+
+    const result = await pullBridgedPassphrase(keychain);
+
+    expect(result).toBe(false);
+    expect(keychain.storePassPhrase).not.toHaveBeenCalled();
+    expect(remove).not.toHaveBeenCalled();
+  });
+
+  it('returns false outside an extension context (no browser global)', async () => {
+    vi.stubGlobal('browser', undefined);
+    const keychain = makeKeychain();
+
+    const result = await pullBridgedPassphrase(keychain);
+
+    expect(result).toBe(false);
+    expect(keychain.storePassPhrase).not.toHaveBeenCalled();
+  });
+
+  it('returns false and does not throw if storing the passphrase fails', async () => {
+    stubBrowser({ [SEND_MESSAGE_TO_BRIDGE]: 'word one two' });
+    const keychain = makeKeychain(
+      vi.fn().mockRejectedValue(new Error('storage full'))
+    );
+
+    const result = await pullBridgedPassphrase(keychain);
+
+    expect(result).toBe(false);
+  });
+});


### PR DESCRIPTION
## What changed?

Hardening of the add-on "token bridge" — the content script that relays messages from the Send web app to the privileged background (OIDC tokens, the encryption passphrase, sign-in/out).

**1. Bridge security (closes #953):**
- `token-bridge.js` forwarded `window.postMessage`s straight to the background. It ran on `<all_urls>` with its sender checks commented out. It now rejects messages unless `e.source === window` and `e.origin === window.location.origin`.
- `manifest.json` `content_scripts.matches` scoped to the app origins (`send.tb.pro`, `send-stage.tb.pro`, `localhost`); `build.sh` strips `http://localhost/*` from **production** builds so a released add-on never trusts a localhost page. Removed a dead debug block.

**2. Passphrase delivery to popup/background (see #712):**
- Only the management page pulled the bridged passphrase into the keychain, so an upload from the popup/background could find none. Extracted `pullBridgedPassphrase()` and call it inside `restoreKeysUsingLocalStorage` (which the popup and background already call), so neither depends on the management page having run the transfer.

_AI disclosure: implemented with Claude Code (an AI agent) under my direction and review; reviewed by independent agent passes._

## Why?

The bridge relayed secrets to the privileged background but trusted any page/frame and injected everywhere (#953), and the shared passphrase didn't reach the upload popup (#712).

## Scope note

Passphrase **encryption at rest** was originally bundled here but has been **split into its own PR** — it's incompatible with the dev e2e's cross-session `storageState` reuse (which can't carry the IndexedDB key) and needs a dedicated e2e rework. This PR contains only the bridge hardening + delivery, which don't change the passphrase storage format.

## Verification

Frontend unit suite green; `tsc` clean for changed files; bridge origin-scoping + `pullBridgedPassphrase` covered by unit tests and real-browser checks. e2e is unaffected by these changes (no storage-format change).

## Applicable Issues

Closes #953
Related: #712
