### PR TITLE
Potential fix for code scanning alert no. 43: Server-side request forgery

### DIFF
--- a/packages/send/frontend/src/lib/api.ts
+++ b/packages/send/frontend/src/lib/api.ts
@@ -11,6 +11,30 @@ export class ApiConnection {
   serverUrl: string;
   isBucketStorage: boolean;
 
+  private normalizeApiPath(path: string): string {
+    const trimmed = (path ?? '').trim();
+    if (!trimmed) {
+      throw new Error('Invalid API path');
+    }
+
+    // Block absolute/protocol-relative URL injection attempts.
+    if (/^(?:[a-zA-Z][a-zA-Z\d+\-.]*:)?\/\//.test(trimmed)) {
+      throw new Error('Invalid API path');
+    }
+
+    const normalized = trimmed.replace(/^\/+/, '');
+    const segments = normalized.split('/');
+    if (
+      segments.some(
+        (segment) => !segment || !/^[A-Za-z0-9._-]+$/.test(segment)
+      )
+    ) {
+      throw new Error('Invalid API path');
+    }
+
+    return segments.map((segment) => encodeURIComponent(segment)).join('/');
+  }
+
   constructor(serverUrl: string) {
     if (!serverUrl) {
       throw Error('No Server URL provided.');
@@ -82,8 +106,12 @@ export class ApiConnection {
     headers: Record<string, any> = {},
     options?: Options
   ): Promise<Response | T | null> {
-    const url = `${this.serverUrl}/api/${path}`;
-    const refreshTokenUrl = `${this.serverUrl}/api/auth/refresh`;
+    const safePath = this.normalizeApiPath(path);
+    const url = new URL(`/api/${safePath}`, this.serverUrl).toString();
+    const refreshTokenUrl = new URL(
+      '/api/auth/refresh',
+      this.serverUrl
+    ).toString();
 
     // Try to get OIDC access token and add to headers if available
     const requestHeaders = { ...headers };

--- a/packages/send/frontend/src/lib/api.ts
+++ b/packages/send/frontend/src/lib/api.ts
@@ -7,33 +7,48 @@ export type AsyncJsonResponse<T = { [key: string]: any }> = Promise<
   JsonResponse<T>
 > | null;
 
+/**
+ * Build an absolute `/api/...` request URL from a caller-supplied, possibly
+ * user-derived `path`, pinned to `serverUrl`'s origin.
+ *
+ * Guards against server-side request forgery (code-scanning alert #43): a `path`
+ * containing a scheme or authority (`http://evil`, `//evil`) is rejected, and
+ * the resulting URL's origin is asserted to equal the configured server origin
+ * before it is ever used. Legitimate paths — including query strings
+ * (`.../links?type=file`), trailing slashes and non-ASCII-safe segments such as
+ * email addresses (`users/lookup/a@b.com/`) — are preserved unchanged.
+ */
+export function buildApiUrl(serverUrl: string, path: string): string {
+  const trimmed = (path ?? '').trim();
+  if (!trimmed) {
+    throw new Error('Invalid API path');
+  }
+
+  // Reject absolute/protocol-relative paths up front. The `/api/` prefix below
+  // already de-fangs these (they resolve into the path, not the authority), so
+  // this is not what pins the host — it just fails loudly on a clearly bad path
+  // instead of silently building `/api/http://evil.com`.
+  if (/^(?:[a-zA-Z][a-zA-Z\d+\-.]*:)?\/\//.test(trimmed)) {
+    throw new Error('Invalid API path');
+  }
+
+  // Stripping leading slashes and prepending the constant `/api/` makes the
+  // path an absolute-*path* reference, which can never carry an authority, so
+  // the origin is always `serverUrl`'s. The origin assertion is therefore
+  // unreachable at runtime; it is kept as the explicit host-allowlist barrier
+  // CodeQL's request-forgery query recognizes, and as defense in depth.
+  const relativePath = trimmed.replace(/^\/+/, '');
+  const url = new URL(`/api/${relativePath}`, serverUrl);
+  if (url.origin !== new URL(serverUrl).origin) {
+    throw new Error('Invalid API path');
+  }
+
+  return url.toString();
+}
+
 export class ApiConnection {
   serverUrl: string;
   isBucketStorage: boolean;
-
-  private normalizeApiPath(path: string): string {
-    const trimmed = (path ?? '').trim();
-    if (!trimmed) {
-      throw new Error('Invalid API path');
-    }
-
-    // Block absolute/protocol-relative URL injection attempts.
-    if (/^(?:[a-zA-Z][a-zA-Z\d+\-.]*:)?\/\//.test(trimmed)) {
-      throw new Error('Invalid API path');
-    }
-
-    const normalized = trimmed.replace(/^\/+/, '');
-    const segments = normalized.split('/');
-    if (
-      segments.some(
-        (segment) => !segment || !/^[A-Za-z0-9._-]+$/.test(segment)
-      )
-    ) {
-      throw new Error('Invalid API path');
-    }
-
-    return segments.map((segment) => encodeURIComponent(segment)).join('/');
-  }
 
   constructor(serverUrl: string) {
     if (!serverUrl) {
@@ -81,6 +96,7 @@ export class ApiConnection {
    * @param {string} method - The HTTP Request method.
    * @param {Record<string, any>} headers - Optional Request headers to include.
    * @returns {AsyncJsonResponse<T>} Returns a Promise that resolves to the response data (or null).
+   * @throws If `path` is empty or an absolute/protocol-relative URL (see {@link buildApiUrl}).
    *
    */
   // `fullResponse: true` returns the raw Response (required, so an omitted
@@ -106,12 +122,8 @@ export class ApiConnection {
     headers: Record<string, any> = {},
     options?: Options
   ): Promise<Response | T | null> {
-    const safePath = this.normalizeApiPath(path);
-    const url = new URL(`/api/${safePath}`, this.serverUrl).toString();
-    const refreshTokenUrl = new URL(
-      '/api/auth/refresh',
-      this.serverUrl
-    ).toString();
+    const url = buildApiUrl(this.serverUrl, path);
+    const refreshTokenUrl = buildApiUrl(this.serverUrl, 'auth/refresh');
 
     // Try to get OIDC access token and add to headers if available
     const requestHeaders = { ...headers };

--- a/packages/send/frontend/src/lib/api.ts
+++ b/packages/send/frontend/src/lib/api.ts
@@ -12,11 +12,16 @@ export type AsyncJsonResponse<T = { [key: string]: any }> = Promise<
  * user-derived `path`, pinned to `serverUrl`'s origin.
  *
  * Guards against server-side request forgery (code-scanning alert #43): a `path`
- * containing a scheme or authority (`http://evil`, `//evil`) is rejected, and
- * the resulting URL's origin is asserted to equal the configured server origin
- * before it is ever used. Legitimate paths — including query strings
- * (`.../links?type=file`), trailing slashes and non-ASCII-safe segments such as
- * email addresses (`users/lookup/a@b.com/`) — are preserved unchanged.
+ * containing a scheme or authority (`http://evil`, `//evil`) is rejected, a
+ * `path` containing a backslash (which URL parsing may treat as a path
+ * separator) is rejected, and dot-segments (`.`/`..`) — which `new URL()` would
+ * normalize and could use to climb out of the `/api/` prefix (e.g. `../admin`
+ * → `/admin`) — are rejected. After construction the resulting URL's origin is
+ * asserted to equal the configured server origin, and its pathname is asserted
+ * to still live under `/api/`, before it is ever used. Legitimate paths —
+ * including query strings (`.../links?type=file`), trailing slashes and
+ * non-ASCII-safe segments such as email addresses (`users/lookup/a@b.com/`) —
+ * are preserved unchanged.
  */
 export function buildApiUrl(serverUrl: string, path: string): string {
   const trimmed = (path ?? '').trim();
@@ -32,14 +37,39 @@ export function buildApiUrl(serverUrl: string, path: string): string {
     throw new Error('Invalid API path');
   }
 
+  // Reject backslashes: URL parsing can treat `\` as a path separator, so
+  // `..\admin` or `\\evil` would otherwise smuggle traversal/authority past the
+  // forward-slash checks below.
+  if (trimmed.includes('\\')) {
+    throw new Error('Invalid API path');
+  }
+
+  // Reject dot-segments. `new URL()` normalizes `.`/`..`, so a path like
+  // `../admin` would resolve to `/admin` and escape the intended `/api/`
+  // prefix. Splitting on `/` and rejecting any segment that is exactly `.` or
+  // `..` blocks traversal while still preserving dots *inside* a segment (e.g.
+  // `a@b.com`, `file.txt`).
+  const relativePath = trimmed.replace(/^\/+/, '');
+  const segments = relativePath.split('/');
+  if (segments.some((segment) => segment === '.' || segment === '..')) {
+    throw new Error('Invalid API path');
+  }
+
   // Stripping leading slashes and prepending the constant `/api/` makes the
   // path an absolute-*path* reference, which can never carry an authority, so
   // the origin is always `serverUrl`'s. The origin assertion is therefore
   // unreachable at runtime; it is kept as the explicit host-allowlist barrier
   // CodeQL's request-forgery query recognizes, and as defense in depth.
-  const relativePath = trimmed.replace(/^\/+/, '');
   const url = new URL(`/api/${relativePath}`, serverUrl);
   if (url.origin !== new URL(serverUrl).origin) {
+    throw new Error('Invalid API path');
+  }
+
+  // Defense in depth against dot-segment normalization escaping the prefix: the
+  // resulting pathname must still live under `/api/`. If it does not, the path
+  // climbed out (e.g. via traversal that slipped past the segment check) and we
+  // fail loudly rather than issue a request to an unintended path.
+  if (!url.pathname.startsWith('/api/')) {
     throw new Error('Invalid API path');
   }
 

--- a/packages/send/frontend/src/test/lib/api.test.ts
+++ b/packages/send/frontend/src/test/lib/api.test.ts
@@ -4,16 +4,110 @@
  * network-vs-HTTP distinction and the status code; `onFailure` recovers it for
  * observability without changing the return value.
  */
-import { ApiCallFailure, ApiConnection } from '@send-frontend/lib/api';
+import {
+  ApiCallFailure,
+  ApiConnection,
+  buildApiUrl,
+} from '@send-frontend/lib/api';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const SERVER = 'https://send.test.local';
+
+describe('buildApiUrl — path pinning (SSRF alert #43)', () => {
+  it('pins the request to the server origin under /api/', () => {
+    expect(buildApiUrl(SERVER, 'uploads/can-upload')).toBe(
+      'https://send.test.local/api/uploads/can-upload'
+    );
+  });
+
+  it('preserves query strings, trailing slashes, and email segments', () => {
+    // These are all real call sites that a naive per-segment allowlist breaks.
+    expect(buildApiUrl(SERVER, 'sharing/abc123/links?type=file')).toBe(
+      'https://send.test.local/api/sharing/abc123/links?type=file'
+    );
+    expect(buildApiUrl(SERVER, 'users/invitations/')).toBe(
+      'https://send.test.local/api/users/invitations/'
+    );
+    expect(buildApiUrl(SERVER, 'users/lookup/a@b.com/')).toBe(
+      'https://send.test.local/api/users/lookup/a@b.com/'
+    );
+    expect(buildApiUrl(SERVER, 'auth/login?state=xyz')).toBe(
+      'https://send.test.local/api/auth/login?state=xyz'
+    );
+  });
+
+  it('strips leading slashes rather than escaping the /api prefix', () => {
+    expect(buildApiUrl(SERVER, '/uploads')).toBe(
+      'https://send.test.local/api/uploads'
+    );
+  });
+
+  it('rejects absolute and protocol-relative paths', () => {
+    expect(() => buildApiUrl(SERVER, 'http://evil.example/steal')).toThrow(
+      'Invalid API path'
+    );
+    expect(() => buildApiUrl(SERVER, 'https://evil.example')).toThrow(
+      'Invalid API path'
+    );
+    expect(() => buildApiUrl(SERVER, '//evil.example/steal')).toThrow(
+      'Invalid API path'
+    );
+  });
+
+  it('rejects an empty path', () => {
+    expect(() => buildApiUrl(SERVER, '')).toThrow('Invalid API path');
+    expect(() => buildApiUrl(SERVER, '   ')).toThrow('Invalid API path');
+  });
+});
 
 function mockFetch(impl: () => Promise<Response> | Response) {
   const fn = vi.fn(impl);
   vi.stubGlobal('fetch', fn);
   return fn;
 }
+
+describe('ApiConnection.call — URL building', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('fetches the pinned /api/ URL, preserving the query string', async () => {
+    const fetchFn = mockFetch(
+      () =>
+        ({
+          ok: true,
+          status: 200,
+          json: async () => ({}),
+        }) as unknown as Response
+    );
+
+    const api = new ApiConnection(SERVER);
+    await api.call('sharing/abc123/links?type=file');
+
+    expect(fetchFn).toHaveBeenCalledWith(
+      'https://send.test.local/api/sharing/abc123/links?type=file',
+      expect.any(Object)
+    );
+  });
+
+  it('rejects an absolute path before making any request', async () => {
+    const fetchFn = mockFetch(
+      () =>
+        ({
+          ok: true,
+          status: 200,
+          json: async () => ({}),
+        }) as unknown as Response
+    );
+
+    const api = new ApiConnection(SERVER);
+    await expect(api.call('http://evil.example/steal')).rejects.toThrow(
+      'Invalid API path'
+    );
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+});
 
 describe('ApiConnection.call — onFailure diagnostics', () => {
   afterEach(() => {
@@ -113,7 +207,13 @@ describe('ApiConnection.call — onFailure diagnostics', () => {
     const api = new ApiConnection(SERVER);
     let failure: ApiCallFailure | undefined;
 
-    await api.call('uploads', {}, 'POST', {}, { onFailure: (f) => (failure = f) });
+    await api.call(
+      'uploads',
+      {},
+      'POST',
+      {},
+      { onFailure: (f) => (failure = f) }
+    );
 
     expect(failure?.kind).toBe('http');
     expect((failure as { body: string }).body).toHaveLength(500);

--- a/packages/send/frontend/src/test/lib/api.test.ts
+++ b/packages/send/frontend/src/test/lib/api.test.ts
@@ -58,6 +58,45 @@ describe('buildApiUrl — path pinning (SSRF alert #43)', () => {
     expect(() => buildApiUrl(SERVER, '')).toThrow('Invalid API path');
     expect(() => buildApiUrl(SERVER, '   ')).toThrow('Invalid API path');
   });
+
+  it('rejects dot-segment traversal that would escape the /api/ prefix', () => {
+    // `new URL()` normalizes `..`, so without an explicit guard `../admin`
+    // would resolve to `/admin` and climb out of `/api/`.
+    expect(() => buildApiUrl(SERVER, '../admin')).toThrow('Invalid API path');
+    expect(() => buildApiUrl(SERVER, '../../admin')).toThrow(
+      'Invalid API path'
+    );
+    expect(() => buildApiUrl(SERVER, 'uploads/../../admin')).toThrow(
+      'Invalid API path'
+    );
+    expect(() => buildApiUrl(SERVER, '/../admin')).toThrow('Invalid API path');
+    // A single `.` segment is also normalized away and is rejected.
+    expect(() => buildApiUrl(SERVER, './admin')).toThrow('Invalid API path');
+    expect(() => buildApiUrl(SERVER, 'uploads/./stat')).toThrow(
+      'Invalid API path'
+    );
+  });
+
+  it('rejects backslashes, which URL parsing may treat as separators', () => {
+    expect(() => buildApiUrl(SERVER, '..\\admin')).toThrow('Invalid API path');
+    expect(() => buildApiUrl(SERVER, '\\\\evil.example/steal')).toThrow(
+      'Invalid API path'
+    );
+    expect(() => buildApiUrl(SERVER, 'uploads\\..\\admin')).toThrow(
+      'Invalid API path'
+    );
+  });
+
+  it('preserves dots inside a segment (not treated as traversal)', () => {
+    // Dots *within* a segment are legitimate (emails, filenames) and must
+    // survive; only segments that are exactly `.` or `..` are rejected.
+    expect(buildApiUrl(SERVER, 'users/lookup/a..b@example.com')).toBe(
+      'https://send.test.local/api/users/lookup/a..b@example.com'
+    );
+    expect(buildApiUrl(SERVER, 'uploads/file.name.txt/stat')).toBe(
+      'https://send.test.local/api/uploads/file.name.txt/stat'
+    );
+  });
 });
 
 function mockFetch(impl: () => Promise<Response> | Response) {


### PR DESCRIPTION
Potential fix for [https://github.com/thunderbird/tbpro-add-on/security/code-scanning/43](https://github.com/thunderbird/tbpro-add-on/security/code-scanning/43)

## Approach (updated)

> **Note:** This PR intentionally differs from the original Copilot Autofix proposal below. The autofix suggested a per-segment allowlist + `URL`-encoding `normalizeApiPath` method. That approach breaks legitimate real call sites — e.g. email segments like `users/lookup/a@b.com/`, query strings like `.../links?type=file`, and trailing slashes — because `@`, `?`, and empty trailing segments are not in a conservative allowlist and get encoded/stripped. Instead, this PR implements an exported **`buildApiUrl(serverUrl, path)`** helper that pins every request under the server's origin and the constant `/api/` prefix while preserving valid paths verbatim.

### Implemented threat model — `buildApiUrl(serverUrl, path)` in `packages/send/frontend/src/lib/api.ts`

`buildApiUrl` builds an absolute `/api/...` URL from a caller-supplied, possibly user-derived `path`, pinned to `serverUrl`'s origin. It rejects hostile input and preserves legitimate paths:

1. **Reject empty paths** (`''`, whitespace-only).
2. **Reject absolute / protocol-relative paths** — anything matching `scheme://` or starting with `//` (`http://evil`, `https://evil`, `//evil`). The `/api/` prefix already de-fangs these (they resolve into the path, not the authority), so this just fails loudly on clearly bad input.
3. **Reject backslashes** — `\` is rejected because URL parsing may treat it as a path separator, so `..\admin` or `\\evil` could otherwise smuggle traversal/authority past the forward-slash checks.
4. **Reject dot-segment traversal** — the path is split on `/` and any segment that is *exactly* `.` or `..` is rejected. This is required because `new URL()` normalizes dot-segments (e.g. `../admin` → `/admin`, `uploads/../../admin` → `/admin`), which would climb out of the intended `/api/` prefix. Dots *inside* a segment (emails, filenames such as `a@b.com`, `file.name.txt`) are preserved.
5. **Strip leading slashes** and prepend the constant `/api/`, making the result an absolute-*path* reference that can never carry an authority — so the origin is always `serverUrl`'s.
6. **Assert the origin** of the constructed URL equals `serverUrl`'s origin (the explicit host-allowlist barrier CodeQL's request-forgery query recognizes; defense in depth).
7. **Assert the pathname still starts with `/api/`** after construction. If normalization escaped the prefix, we throw rather than issue a request to an unintended path (defense in depth against dot-segment normalization).

`ApiConnection.call(...)` uses `buildApiUrl(this.serverUrl, path)` for both the request URL and the refresh-token URL, so every network call goes through this guard.

### Preserved behavior

Valid paths pass through unchanged, including:
- `uploads/can-upload`, `uploads/${id}/stat`
- query strings — `sharing/abc123/links?type=file`, `auth/login?state=xyz`
- trailing slashes — `users/invitations/`
- email segments — `users/lookup/a@b.com/`

### Tests

`packages/send/frontend/src/test/lib/api.test.ts` covers pinning, preservation of query strings / trailing slashes / email segments, leading-slash stripping, rejection of absolute & protocol-relative paths, empty paths, **dot-segment traversal (`../admin`, `../../admin`, `uploads/../../admin`, `/../admin`, `./admin`, `uploads/./stat`)**, **backslash cases (`..\admin`, `\\evil.example/steal`, `uploads\..\admin`)**, and confirmation that dots *inside* a segment are preserved. Frontend typecheck (`tsc --noEmit`) and the api test suite both pass.

---

<details>
<summary>Original Copilot Autofix proposal (superseded — see note above)</summary>

The best fix is to **normalize and validate API paths before building the URL**, and to construct URLs via `new URL()` + pathname joining rather than raw string concatenation.

Concretely in `packages/send/frontend/src/lib/api.ts`:

1. Add a private sanitizer method on `ApiConnection` that:
   - rejects empty paths,
   - rejects absolute URLs / protocol-relative strings (`http://`, `https://`, `//`),
   - strips leading slashes,
   - splits by `/` and validates each segment with a conservative allowlist (e.g. alphanumerics, `_`, `-`, `.`),
   - URL-encodes each segment and rejoins with `/`.

2. In `call(...)`, replace raw string concatenation with `new URL()` construction using the sanitized path.

This proposal was **not** adopted as-is because the conservative per-segment allowlist + encoding breaks legitimate paths (emails, query strings, trailing slashes). The implemented `buildApiUrl` approach achieves the same SSRF protection while preserving those valid paths.

</details>

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._