### PR TITLE
fix(send): mobile file info panel — dismissable & non-blocking (reviewed) (#977)

### DIFF
--- a/packages/send/e2e/.gitignore
+++ b/packages/send/e2e/.gitignore
@@ -8,3 +8,6 @@
 
 # BrowserStack logging
 /log
+
+# Local visual artifacts from the #977 mobile suite
+screenshots977/

--- a/packages/send/e2e/playwright.config.mobile977.ts
+++ b/packages/send/e2e/playwright.config.mobile977.ts
@@ -1,0 +1,44 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const THREE_MINUTES = 3 * 60 * 1000;
+
+/**
+ * Dedicated config for the mobile "file info panel" repro/visual suite (issue #977).
+ * Runs against a local dev stack (default the #977 worktree stack on :5573).
+ *
+ * Uses Firefox at a Pixel-sized (412x915) viewport. #977 is a width-breakpoint
+ * layout bug (the info panel column overlaps the file list below Tailwind's `md`
+ * breakpoint), so a narrow viewport reproduces it. Firefox is used because it
+ * restores the (encrypted-at-rest) keychain from storage reliably, whereas
+ * chromium's emulated device could not, blocking the upload step.
+ *
+ * Screenshots are written to ./screenshots977 so you can eyeball the UI.
+ */
+export default defineConfig({
+  testDir: "./tests/mobile/dev",
+  outputDir: "./playwright-test-results",
+  timeout: THREE_MINUTES,
+  fullyParallel: false,
+  workers: 1,
+  reporter: [["html", { outputFolder: "./playwright-report" }], ["list"]],
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL || "http://localhost:5573",
+    trace: "retain-on-failure",
+    actionTimeout: 15_000,
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+    ignoreHTTPSErrors: true,
+    acceptDownloads: true,
+    serviceWorkers: "block",
+    bypassCSP: true,
+  },
+  projects: [
+    {
+      name: "mobile-firefox",
+      use: {
+        ...devices["Desktop Firefox"],
+        viewport: { width: 412, height: 915 },
+      },
+    },
+  ],
+});

--- a/packages/send/e2e/tests/mobile/dev/file-info-panel.spec.ts
+++ b/packages/send/e2e/tests/mobile/dev/file-info-panel.spec.ts
@@ -1,0 +1,125 @@
+// Mobile repro + visual suite for issue #977:
+// "File info panel covers delete button on mobile".
+//
+// Runs the whole flow in one continuous Firefox session at a Pixel-sized
+// (412px) viewport (see playwright.config.mobile977.ts): register a fresh
+// local-auth user, create a folder, upload a file, then open the file info
+// panel and verify that on a narrow/mobile viewport the panel:
+//   1. renders as an overlay that can be dismissed (has a close button),
+//   2. exposes a delete control (previously absent), and
+//   3. lets the user actually delete the file.
+// Screenshots land in ./screenshots977 so the UI can be eyeballed.
+
+import path from "path";
+import { expect, test } from "@playwright/test";
+
+import { dashboardLocators, fileLocators } from "../../../pages/dev/locators";
+import { playwrightConfig } from "../../../utils/dev/testUtils";
+
+const SHOTS = path.resolve(__dirname, "../../../screenshots977");
+
+test.describe("mobile file info panel (#977)", () => {
+  test("can delete a file and close the panel from a mobile viewport", async ({
+    page,
+  }) => {
+    const { email, password } = playwrightConfig;
+    const {
+      registerButton,
+      emailField,
+      passwordField,
+      confirmPasswordField,
+      submitButton,
+      passphraseInputOverlay,
+      backupKeysButtonOverlay,
+    } = dashboardLocators(page);
+    const { folderRowSelector, folderRowTestID, uploadButton, fileCountID } =
+      fileLocators(page);
+
+    page.on("dialog", (dialog) => dialog.accept());
+
+    // --- Register a fresh local-auth user + back up keys ---
+    await page.goto("/send");
+    await expect(page).toHaveTitle(/Thunderbird Send/);
+    await registerButton.click();
+    await emailField.fill(email);
+    await passwordField.fill(password);
+    await confirmPasswordField.fill(password);
+    await submitButton.click();
+
+    const passphrase = await passphraseInputOverlay.inputValue();
+    expect(passphrase, "expected a generated passphrase").toBeTruthy();
+    await backupKeysButtonOverlay.click();
+
+    // --- Go to Your Files via the mobile footer nav ---
+    await page.getByRole("link", { name: "Encrypted Files" }).last().click();
+    await expect(
+      page.getByRole("heading", { name: "Your Files" })
+    ).toBeVisible();
+    await page.waitForLoadState("networkidle");
+
+    // --- Create a folder and open it (root can't receive uploads) ---
+    await page.getByTestId("new-folder-button").click();
+    await page.waitForSelector(folderRowSelector);
+    await page.getByTestId(folderRowTestID).first().dblclick();
+    await page.waitForLoadState("networkidle");
+    await expect(
+      page.getByRole("heading", { name: "Your Files" })
+    ).toBeVisible();
+
+    // --- Upload a file (feed the hidden file input directly) ---
+    await page.waitForSelector("#drop-zone", { state: "attached" });
+    await page
+      .locator('input[type="file"]')
+      .first()
+      .setInputFiles(path.resolve(__dirname, "../../../test-files/test.png"));
+    await uploadButton.click();
+    await page.waitForSelector('[data-testid="file-0"]', { timeout: 90_000 });
+    await expect(page.getByTestId(fileCountID)).toHaveText("1");
+    await page.screenshot({ path: `${SHOTS}/01-your-files.png`, fullPage: true });
+
+    // --- Open the file info panel ---
+    // Click the left (icon/name) side of the row, not the right side where the
+    // row's own download/delete buttons now live (visible on mobile after the
+    // fix), so we open the info panel rather than triggering a row action.
+    await page.getByTestId("file-0").click({ position: { x: 12, y: 20 } });
+    const panelDelete = page.getByTestId("delete-file-info");
+    const panelClose = page.getByTestId("close-file-info");
+    await expect(panelClose).toBeVisible();
+    await expect(panelDelete).toBeVisible();
+    await page.screenshot({
+      path: `${SHOTS}/02-info-panel-open.png`,
+      fullPage: true,
+    });
+
+    // --- Close button dismisses the panel (previously no way to close it) ---
+    await panelClose.click();
+    await expect(page.getByTestId("delete-file-info")).toHaveCount(0);
+    await page.screenshot({
+      path: `${SHOTS}/03-panel-closed.png`,
+      fullPage: true,
+    });
+
+    // --- Re-open and delete the file from the panel (was covered / absent) ---
+    await page.getByTestId("file-0").click({ position: { x: 12, y: 20 } });
+    await expect(panelDelete).toBeVisible();
+    await panelDelete.click();
+    await page.screenshot({
+      path: `${SHOTS}/04-delete-confirm.png`,
+      fullPage: true,
+    });
+    const deleteResponse = page.waitForResponse(
+      (r) => r.request().method() === "DELETE"
+    );
+    await page.getByText("Yes, Delete").click();
+    expect((await deleteResponse).status()).toBe(202);
+    await page.waitForLoadState("networkidle");
+
+    // File is gone and the panel closed itself.
+    await expect(page.getByTestId(fileCountID)).toHaveCount(0);
+    await expect(page.getByTestId("delete-file-info")).toHaveCount(0);
+    await page.screenshot({
+      path: `${SHOTS}/05-after-delete.png`,
+      fullPage: true,
+    });
+  });
+});

--- a/packages/send/frontend/src/apps/send/components/FileInfo.vue
+++ b/packages/send/frontend/src/apps/send/components/FileInfo.vue
@@ -5,6 +5,8 @@ import { trpc } from '@send-frontend/lib/trpc';
 import { useMutation } from '@tanstack/vue-query';
 import { computed, ref } from 'vue';
 
+import DeleteModal from '@send-frontend/apps/common/modals/DeleteModal.vue';
+import DeleteConfirmation from '@send-frontend/apps/send/components/DeleteConfirmation.vue';
 import FileAccessLinksList from '@send-frontend/apps/send/components/FileAccessLinksList.vue';
 import Btn from '@send-frontend/apps/send/elements/BtnComponent.vue';
 import FileNameForm from '@send-frontend/apps/send/elements/FileNameForm.vue';
@@ -13,11 +15,50 @@ import {
   formatBytes,
   getExpirationDate,
 } from '@send-frontend/lib/utils';
-import { IconDownload, IconEye, IconEyeOff, IconLink } from '@tabler/icons-vue';
+import {
+  IconDownload,
+  IconEye,
+  IconEyeOff,
+  IconLink,
+  IconTrash,
+  IconX,
+} from '@tabler/icons-vue';
 import { useClipboard, useDebounceFn } from '@vueuse/core';
+import { useModal, useModalSlot } from 'vue-final-modal';
 
 const folderStore = useFolderStore();
 const sharingStore = useSharingStore();
+
+function closePanel() {
+  folderStore.clearSelection();
+}
+
+async function onDeleteConfirm() {
+  await folderStore.deleteItem(
+    folderStore.selectedFile.id,
+    folderStore.rootFolder.id
+  );
+}
+
+const { open: openDeleteModal, close: closeDeleteModal } = useModal({
+  component: DeleteModal,
+  attrs: {
+    title: 'Delete File?',
+  },
+  slots: {
+    default: useModalSlot({
+      component: DeleteConfirmation,
+      attrs: {
+        closefn: () => closeDeleteModal(),
+        confirm: onDeleteConfirm,
+        get itemName() {
+          return folderStore.selectedFile?.name || '';
+        },
+        itemType: 'file',
+      },
+    }),
+  },
+});
 
 const showRenameForm = ref(false);
 
@@ -97,6 +138,14 @@ Note about shareOnly containers.
   >
     <!-- info -->
     <header class="flex flex-col items-center">
+      <button
+        class="self-end -mt-1 -mr-1 p-1 text-gray-500 hover:text-gray-800"
+        data-testid="close-file-info"
+        aria-label="Close file info"
+        @click="closePanel"
+      >
+        <IconX class="w-5 h-5" />
+      </button>
       <img src="@send-frontend/apps/send/assets/file.svg" class="w-20 h-20" />
       <div class="font-semibold pt-4">
         <span
@@ -206,6 +255,9 @@ Note about shareOnly containers.
               )
             "
         /></Btn>
+        <Btn danger data-testid="delete-file-info" @click="openDeleteModal">
+          <IconTrash class="w-4 h-4" />
+        </Btn>
       </div>
     </footer>
   </div>

--- a/packages/send/frontend/src/apps/send/components/FileInfo.vue
+++ b/packages/send/frontend/src/apps/send/components/FileInfo.vue
@@ -29,15 +29,10 @@ import { useModal, useModalSlot } from 'vue-final-modal';
 const folderStore = useFolderStore();
 const sharingStore = useSharingStore();
 
-function closePanel() {
-  folderStore.clearSelection();
-}
-
 async function onDeleteConfirm() {
-  await folderStore.deleteItem(
-    folderStore.selectedFile.id,
-    folderStore.rootFolder.id
-  );
+  const file = folderStore.selectedFile;
+  if (!file) return;
+  await folderStore.deleteItem(file.id, folderStore.rootFolder.id);
 }
 
 const { open: openDeleteModal, close: closeDeleteModal } = useModal({
@@ -142,7 +137,7 @@ Note about shareOnly containers.
         class="self-end -mt-1 -mr-1 p-1 text-gray-500 hover:text-gray-800"
         data-testid="close-file-info"
         aria-label="Close file info"
-        @click="closePanel"
+        @click="folderStore.clearSelection"
       >
         <IconX class="w-5 h-5" />
       </button>

--- a/packages/send/frontend/src/apps/send/components/FolderInfo.vue
+++ b/packages/send/frontend/src/apps/send/components/FolderInfo.vue
@@ -8,11 +8,16 @@ import FolderAccessLinksList from '@send-frontend/apps/send/components/FolderAcc
 import FolderNameForm from '@send-frontend/apps/send/elements/FolderNameForm.vue';
 import { formatBytes } from '@send-frontend/lib/utils';
 import { useStatusStore } from '@send-frontend/stores';
+import { IconX } from '@tabler/icons-vue';
 import { storeToRefs } from 'pinia';
 
 const folderStore = useFolderStore();
 const statusStore = useStatusStore();
 const { isRouterLoading } = storeToRefs(statusStore);
+
+function closePanel() {
+  folderStore.clearSelection();
+}
 
 // const { currentFolder } = inject('folderManager');
 // const { sharedByMe } = inject('sharingManager');
@@ -49,6 +54,14 @@ const showForm = ref(false);
     <div v-if="folderStore.selectedFolder" class="flex flex-col gap-6 h-full">
       <!-- info -->
       <header class="flex flex-col items-center gap-3 pt-6">
+        <button
+          class="self-end -mt-1 -mr-1 p-1 text-gray-500 hover:text-gray-800"
+          data-testid="close-folder-info"
+          aria-label="Close folder info"
+          @click="closePanel"
+        >
+          <IconX class="w-5 h-5" />
+        </button>
         <img
           src="@send-frontend/apps/send/assets/folder.svg"
           class="w-20 h-20"

--- a/packages/send/frontend/src/apps/send/components/FolderInfo.vue
+++ b/packages/send/frontend/src/apps/send/components/FolderInfo.vue
@@ -15,10 +15,6 @@ const folderStore = useFolderStore();
 const statusStore = useStatusStore();
 const { isRouterLoading } = storeToRefs(statusStore);
 
-function closePanel() {
-  folderStore.clearSelection();
-}
-
 // const { currentFolder } = inject('folderManager');
 // const { sharedByMe } = inject('sharingManager');
 
@@ -58,7 +54,7 @@ const showForm = ref(false);
           class="self-end -mt-1 -mr-1 p-1 text-gray-500 hover:text-gray-800"
           data-testid="close-folder-info"
           aria-label="Close folder info"
-          @click="closePanel"
+          @click="folderStore.clearSelection"
         >
           <IconX class="w-5 h-5" />
         </button>

--- a/packages/send/frontend/src/apps/send/components/FolderView.vue
+++ b/packages/send/frontend/src/apps/send/components/FolderView.vue
@@ -287,7 +287,7 @@ function handleFolderClick(uuid: string) {
             >
               <div class="flex justify-between">
                 <div
-                  class="flex gap-2 opacity-0 group-hover:!opacity-100 transition-opacity"
+                  class="flex gap-2 opacity-100 md:opacity-0 md:group-hover:!opacity-100 transition-opacity"
                   :class="{
                     '!opacity-100':
                       folder.id === folderStore.selectedFolder?.id,
@@ -341,7 +341,7 @@ function handleFolderClick(uuid: string) {
               <FolderTableRowCell>
                 <div class="flex justify-between">
                   <div
-                    class="flex gap-2 opacity-0 group-hover:!opacity-100 transition-opacity"
+                    class="flex gap-2 opacity-100 md:opacity-0 md:group-hover:!opacity-100 transition-opacity"
                   >
                     <Btn
                       v-if="!item.upload.expired"

--- a/packages/send/frontend/src/apps/send/components/FolderView.vue
+++ b/packages/send/frontend/src/apps/send/components/FolderView.vue
@@ -346,7 +346,7 @@ function handleFolderClick(uuid: string) {
                     <Btn
                       v-if="!item.upload.expired"
                       secondary
-                      @click="openModal(item)"
+                      @click.stop="openModal(item)"
                     >
                       <IconDownload class="w-4 h-4" />
                     </Btn>

--- a/packages/send/frontend/src/apps/send/stores/folder-store.ts
+++ b/packages/send/frontend/src/apps/send/stores/folder-store.ts
@@ -54,6 +54,7 @@ export interface FolderStore {
   goToRootFolder: (folderId: string) => Promise<void>;
   setSelectedFolder: (folderId: string) => void;
   setSelectedFile: (itemId: number) => Promise<void>;
+  clearSelection: () => void;
   renameFolder: (folderId: string, name: string) => Promise<Container>;
   deleteFolder: (folderId: string) => Promise<void>;
   uploadItem: (
@@ -176,6 +177,12 @@ const useFolderStore = defineStore('folderManager', () => {
   async function setSelectedFile(itemId: number): Promise<void> {
     selectedFolderId.value = null;
     selectedFileId.value = itemId;
+  }
+
+  // Clears the current file/folder selection so the info panel closes.
+  function clearSelection(): void {
+    selectedFileId.value = null;
+    selectedFolderId.value = null;
   }
 
   async function createFolder(
@@ -351,7 +358,7 @@ const useFolderStore = defineStore('folderManager', () => {
     );
     if (result) {
       if (selectedFileId.value === itemId) {
-        setSelectedFile(null);
+        clearSelection();
       }
       if (rootFolder.value?.items) {
         const deletedKey = result.wrappedKey;
@@ -705,6 +712,7 @@ const useFolderStore = defineStore('folderManager', () => {
     sync: async () => await goToRootFolder(null),
     setSelectedFolder,
     setSelectedFile,
+    clearSelection,
     createFolder,
     renameFolder,
     deleteFolder,

--- a/packages/send/frontend/src/apps/send/views/HomeView.vue
+++ b/packages/send/frontend/src/apps/send/views/HomeView.vue
@@ -47,15 +47,21 @@ const hasSelection = computed(() => {
     </main>
 
     <!--
-      Info panel. On desktop (md+) this is the original inline w-64 column. Below
-      md it becomes a full-screen overlay (z-[1000], above the app nav which is
-      z-999) with its own close control, so it no longer covers the file list's
-      action buttons or traps the user (see #977). The overlay classes are
-      `max-md:`-scoped so the desktop layout is byte-for-byte the original.
+      Info panel. On desktop (md+) this is the original always-present inline
+      w-64 column (empty until something is selected), so the desktop layout is
+      unchanged and doesn't reflow. Below md it is hidden until a file/folder is
+      selected, then shown as a full-screen overlay (z-[1000], above the app nav
+      which is z-999) with its own close control, so it no longer covers the file
+      list's action buttons or traps the user (see #977).
     -->
     <aside
-      v-if="showFileComponents && hasSelection"
-      class="w-64 border border-gray-300 bg-gray-50 p-2.5 max-md:fixed max-md:inset-0 max-md:z-[1000] max-md:w-full max-md:overflow-y-auto max-md:border-0"
+      v-if="showFileComponents"
+      class="w-64 border border-gray-300 bg-gray-50 p-2.5"
+      :class="
+        hasSelection
+          ? 'max-md:fixed max-md:inset-0 max-md:z-[1000] max-md:w-full max-md:overflow-y-auto max-md:border-0'
+          : 'max-md:hidden'
+      "
     >
       <FileInfo v-if="folderStore.selectedFile" />
       <FolderInfo v-if="folderStore.selectedFolder" />

--- a/packages/send/frontend/src/apps/send/views/HomeView.vue
+++ b/packages/send/frontend/src/apps/send/views/HomeView.vue
@@ -16,6 +16,10 @@ const { currentRoute } = useRouter();
 const showFileComponents = computed(() => {
   return currentRoute.value.path.includes('/folder');
 });
+
+const hasSelection = computed(() => {
+  return Boolean(folderStore.selectedFile || folderStore.selectedFolder);
+});
 </script>
 
 <template>
@@ -42,9 +46,16 @@ const showFileComponents = computed(() => {
       </div>
     </main>
 
+    <!--
+      Info panel. On desktop (md+) this is the original inline w-64 column. Below
+      md it becomes a full-screen overlay (z-[1000], above the app nav which is
+      z-999) with its own close control, so it no longer covers the file list's
+      action buttons or traps the user (see #977). The overlay classes are
+      `max-md:`-scoped so the desktop layout is byte-for-byte the original.
+    -->
     <aside
-      v-if="showFileComponents"
-      class="w-64 border border-gray-300 bg-gray-50 p-2.5"
+      v-if="showFileComponents && hasSelection"
+      class="w-64 border border-gray-300 bg-gray-50 p-2.5 max-md:fixed max-md:inset-0 max-md:z-[1000] max-md:w-full max-md:overflow-y-auto max-md:border-0"
     >
       <FileInfo v-if="folderStore.selectedFile" />
       <FolderInfo v-if="folderStore.selectedFolder" />


### PR DESCRIPTION
Supersedes #986. Same fix for #977, plus fixes from a senior code review.

## What changed?

Fixes the mobile behavior of the file info panel on the **Your Files** page:

- **`HomeView.vue`** — the info panel is the original **always-present** inline `w-64` column on desktop (`md+`), so desktop layout is unchanged and does not reflow on select/deselect. Below `md` it is hidden until a file/folder is selected, then shown as a **full-screen, dismissable overlay** (z above the app nav).
- **`FileInfo.vue`** — added a **close (X)** button and a **delete** button (reusing the existing `DeleteModal` + `DeleteConfirmation` flow); `onDeleteConfirm` guards against a null selection.
- **`FolderInfo.vue`** — added a matching close button (shares the overlay).
- **`FolderView.vue`** — file-row download/delete buttons are visible on mobile (were hover-only), and the download button now `@click.stop`s so tapping it doesn't also open the panel overlay on top of the download modal.
- **`folder-store.ts`** — added `clearSelection()`, used by the close controls and `deleteItem`.
- **e2e** — a Firefox mobile-viewport (412px) Playwright suite that registers, uploads, opens the panel, and verifies close + delete work and the panel dismisses.

### Review fixes applied over #986
1. Desktop info-panel column is kept always-present (no reflow); the mobile overlay is applied via conditional `max-md:` classes only when something is selected.
2. `@click.stop` added to the row download button (previously a tap opened both the download modal and the info overlay on mobile).
3. Null-guard in `onDeleteConfirm`; close buttons bound directly to `folderStore.clearSelection` (dropped trivial wrappers).

**AI disclosure:** Implemented and reviewed by Claude (agentic), with the author directing the task, running a senior-code-review pass, and approving the fixes. Verified via the new Playwright suite; ESLint and (frontend) typecheck clean on the changed files.

## Why?

Per #977, on mobile the info panel covered the file's delete button, had no delete button of its own, and could not be closed. The panel is now an overlay that doesn't cover the list, can be closed, and can delete the file itself.

## Limitations and Notes

- Desktop layout is intentionally unchanged; only sub-`md` behavior changed.
- The pre-existing desktop dev e2e suite (`--grep @dev-desktop`) is flaky (share-link/session timing, #930) and fails a few tests on a clean tree too — unrelated to this change.

## Applicable Issues

Closes #977

## Screenshots

Captured by the mobile suite: the info panel renders as a full-screen overlay with a close (X) and a red delete button; after closing, the file list and its row action buttons are fully accessible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)