### PR TITLE
Add E2E test for file upload, download, and delete via your files page (and run in BrowserStack)

### DIFF
--- a/packages/send/e2e/pages/dashboard-page.ts
+++ b/packages/send/e2e/pages/dashboard-page.ts
@@ -105,6 +105,12 @@ export class DashboardPage {
     await new EncryptedFilesPage(this.page).expectVisible();
   }
 
+  async goToEncryptedFilesFromHeader() {
+    await this.sendHdrEncryptedLink.click();
+    await this.page.waitForTimeout(TIMEOUT_1_SECOND);
+    await new EncryptedFilesPage(this.page).expectVisible();
+  }
+
   async goToSecurityAndPrivacyFromDashboard() {
     await this.encryptionKeyButton.click();
     await this.page.waitForTimeout(TIMEOUT_1_SECOND);

--- a/packages/send/e2e/pages/encrypted-files-page.ts
+++ b/packages/send/e2e/pages/encrypted-files-page.ts
@@ -1,15 +1,215 @@
 import { expect, type Locator, type Page } from '@playwright/test';
 
+import {
+  TB_ACCTS_EMAIL,
+  TIMEOUT_1_SECOND,
+  TIMEOUT_30_SECONDS,
+  TIMEOUT_5_SECONDS,
+  TIMEOUT_60_SECONDS,
+} from '../const/const';
+import {
+  dragAndDropUploadFile,
+  type UploadFixture,
+} from '../utils/upload-files';
+
 export class EncryptedFilesPage {
   readonly page: Page;
+  readonly sendHdrLogoLink: Locator;
+  readonly signedInUsername: Locator;
   readonly yourFilesHeading: Locator;
+  readonly userAvatar: Locator;
+  readonly userAvatarMenuBtn: Locator;
+  readonly userMenuButton: Locator;
+  readonly uploadDropZone: Locator;
+  readonly dropZone: Locator;
+  readonly uploadButton: Locator;
+  readonly noFilesMessage: Locator;
+  readonly fileListRows: Locator;
+  readonly fileListTable: Locator;
 
   constructor(page: Page) {
     this.page = page;
+    this.sendHdrLogoLink = this.page.locator('header img[alt="Send"]');
+    this.signedInUsername = this.page.locator('#send-page main > header span');
     this.yourFilesHeading = this.page.getByRole('heading', { name: 'Your Files' });
+    this.userAvatar = this.page.getByTestId('avatar-default');
+    this.userAvatarMenuBtn = this.page.locator('aside.avatar.regular');
+    this.userMenuButton = this.page.locator('button.user-menu');
+    this.uploadDropZone = this.page.getByRole('button', {
+      name: 'Drag and drop files here to upload, or click to select files',
+    });
+    this.dropZone = this.page.getByTestId('drop-zone');
+    this.uploadButton = this.page.getByTestId('upload-button');
+    this.noFilesMessage = this.page.getByText('No files', { exact: true });
+    this.fileListRows = this.page.locator(
+      '[data-testid="folder-row"], tr[data-testid^="file-"]'
+    );
+    this.fileListTable = this.page.locator('table');
   }
 
   async expectVisible() {
     await expect(this.yourFilesHeading).toBeVisible();
+  }
+
+  async expectBasicUiVisible() {
+    await expect(this.sendHdrLogoLink).toBeVisible();
+    await expect(this.signedInUsername).toHaveText(TB_ACCTS_EMAIL, {
+      timeout: TIMEOUT_30_SECONDS,
+    });
+    await expect(this.yourFilesHeading).toBeVisible();
+    await this.expectUserMenuVisible();
+    await expect(this.uploadDropZone).toBeVisible();
+    await this.expectEmptyOrPopulatedFileState();
+  }
+
+  async expectUserMenuVisible() {
+    const avatarLocators = [
+      this.userAvatar,
+      this.userAvatarMenuBtn,
+      this.userMenuButton,
+    ];
+
+    for (const avatarLocator of avatarLocators) {
+      try {
+        const locator = avatarLocator.first();
+        if ((await locator.count()) === 0) {
+          continue;
+        }
+
+        await expect(locator).toBeVisible({ timeout: TIMEOUT_5_SECONDS });
+        return;
+      } catch {
+        // The avatar markup comes from services-ui and can differ by platform.
+      }
+    }
+
+    throw new Error('Unable to find any known user menu avatar locator');
+  }
+
+  async expectEmptyOrPopulatedFileState() {
+    await expect
+      .poll(
+        async () =>
+          (await this.noFilesMessage.isVisible()) ||
+          (await this.fileListRows.first().isVisible()),
+        { timeout: TIMEOUT_30_SECONDS }
+      )
+      .toBe(true);
+
+    if (await this.noFilesMessage.isVisible()) {
+      return;
+    }
+
+    await expect(this.fileListTable).toBeVisible();
+    await expect(this.fileListRows.first()).toBeVisible();
+  }
+
+  async uploadFileWithFilePicker(uploadFixture: UploadFixture) {
+    const fileChooserPromise = this.page.waitForEvent('filechooser');
+    await expect(this.dropZone).toBeVisible();
+    await this.dropZone.click();
+    const fileChooser = await fileChooserPromise;
+    await fileChooser.setFiles(uploadFixture.filePath);
+
+    await this.uploadSelectedFileAndExpectVisible(uploadFixture.fileName);
+  }
+
+  async uploadFileWithDragAndDrop(uploadFixture: UploadFixture) {
+    await expect(this.dropZone).toBeVisible();
+    await dragAndDropUploadFile(this.page, '[data-testid="drop-zone"]', uploadFixture);
+
+    await this.uploadSelectedFileAndExpectVisible(uploadFixture.fileName);
+  }
+
+  async uploadSelectedFileAndExpectVisible(fileName: string) {
+    await expect(this.page.getByText(fileName, { exact: true }).first()).toBeVisible();
+    await expect(this.uploadButton).toBeVisible();
+    await expect(this.uploadButton).toBeEnabled();
+    await this.uploadButton.click();
+
+    await expect(this.completedUploadListItem(fileName)).toBeVisible({
+      timeout: TIMEOUT_60_SECONDS,
+    });
+    await expect(this.fileRow(fileName)).toBeVisible({
+      timeout: TIMEOUT_60_SECONDS,
+    });
+  }
+
+  async downloadFileAndExpectDownload(fileName: string) {
+    const fileRow = this.fileRow(fileName);
+
+    await expect(fileRow).toBeVisible();
+    await fileRow.scrollIntoViewIfNeeded();
+    await fileRow.click({ force: true });
+    await fileRow.getByRole('button').first().click({ force: true });
+
+    await this.page.waitForTimeout(TIMEOUT_1_SECOND); // mostly so captured on browserstack video
+    await expect(this.page.getByRole('heading', { name: 'Before you download' })).toBeVisible();
+
+    const downloadPromise = this.page.waitForEvent('download');
+    await this.page.getByTestId('confirm-download').click();
+    const download = await downloadPromise;
+
+    expect(download.suggestedFilename()).toBe(fileName);
+  }
+
+  async downloadFileFromInfoPanelAndExpectDownload(fileName: string) {
+    const fileRow = this.fileRow(fileName);
+
+    await expect(fileRow).toBeVisible();
+    await fileRow.scrollIntoViewIfNeeded();
+    await fileRow.click({ force: true });
+
+    const fileInfoPanel = this.page.locator('#send-page > aside').last();
+    await expect(fileInfoPanel.getByText(fileName, { exact: true })).toBeVisible({
+      timeout: TIMEOUT_30_SECONDS,
+    });
+
+    const downloadPromise = this.page.waitForEvent('download');
+    await fileInfoPanel.locator('footer button svg').last().click({ force: true });
+    const download = await downloadPromise;
+
+    expect(download.suggestedFilename()).toBe(fileName);
+  }
+
+  async deleteUploadedFiles(fileNames: string[]) {
+    for (const fileName of fileNames) {
+      await this.deleteUploadedFileIfVisible(fileName);
+    }
+  }
+
+  async deleteUploadedFileIfVisible(fileName: string) {
+    const fileRow = this.fileRow(fileName);
+
+    if (!(await fileRow.isVisible())) {
+      return;
+    }
+
+    await fileRow.scrollIntoViewIfNeeded();
+    await fileRow.getByTestId('delete-file').click({ force: true });
+
+    await this.page.waitForTimeout(TIMEOUT_1_SECOND); // mostly so captured on browserstack video
+    const deleteModal = this.page.getByTestId('delete-modal');
+    await expect(deleteModal).toBeVisible();
+    const confirmDeleteButton = deleteModal.getByRole('button', { name: 'Yes, Delete' });
+    await expect(confirmDeleteButton).toBeVisible();
+    await expect(confirmDeleteButton).toBeEnabled();
+    await confirmDeleteButton.click();
+
+    await expect(fileRow).not.toBeVisible({ timeout: TIMEOUT_60_SECONDS });
+  }
+
+  completedUploadListItem(fileName: string) {
+    return this.page.getByRole('listitem', {
+      name: new RegExp(`^Completed upload: ${this.escapeRegExp(fileName)},`),
+    });
+  }
+
+  fileRow(fileName: string) {
+    return this.page.locator('tbody tr').filter({ hasText: fileName });
+  }
+
+  escapeRegExp(value: string) {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   }
 }

--- a/packages/send/e2e/tests/desktop/encrypted-files.spec.ts
+++ b/packages/send/e2e/tests/desktop/encrypted-files.spec.ts
@@ -1,0 +1,42 @@
+import { test } from '@playwright/test';
+
+import {
+  PLAYWRIGHT_TAG_DESKTOP_NIGHTLY,
+  TB_SEND_DASHBOARD_URL,
+} from '../../const/const';
+import { DashboardPage } from '../../pages/dashboard-page';
+import { EncryptedFilesPage } from '../../pages/encrypted-files-page';
+import { createUniquePngUploadFixture } from '../../utils/upload-files';
+
+test.describe('encrypted files on desktop', () => {
+  test('your files page: upload, download, and delete', {
+    tag: [PLAYWRIGHT_TAG_DESKTOP_NIGHTLY],
+  }, async ({ page }, testInfo) => {
+    const dashboardPage = new DashboardPage(page);
+    const encryptedFilesPage = new EncryptedFilesPage(page);
+    // Use unique runtime copies so this test can run against accounts that
+    // already contain files with the original test fixture name.
+    const filePickerFixture = createUniquePngUploadFixture(testInfo, 'file-picker');
+    const dragDropFixture = createUniquePngUploadFixture(testInfo, 'drag-drop');
+    const uploadedFileNames = [
+      filePickerFixture.fileName,
+      dragDropFixture.fileName,
+    ];
+
+    await page.goto(TB_SEND_DASHBOARD_URL);
+    await dashboardPage.expectUnlockedDashboardVisible();
+    await dashboardPage.goToEncryptedFilesFromHeader();
+
+    await encryptedFilesPage.expectBasicUiVisible();
+
+    try {
+      // Cover both upload entry points: native file chooser and drag/drop.
+      await encryptedFilesPage.uploadFileWithFilePicker(filePickerFixture);
+      await encryptedFilesPage.uploadFileWithDragAndDrop(dragDropFixture);
+      await encryptedFilesPage.downloadFileAndExpectDownload(filePickerFixture.fileName);
+    } finally {
+      // Keep the shared test account tidy even if a later upload assertion fails.
+      await encryptedFilesPage.deleteUploadedFiles(uploadedFileNames);
+    }
+  });
+});

--- a/packages/send/e2e/tests/mobile/encrypted-files.spec.ts
+++ b/packages/send/e2e/tests/mobile/encrypted-files.spec.ts
@@ -1,0 +1,51 @@
+import { test } from '@playwright/test';
+
+import {
+  PLAYWRIGHT_TAG_MOBILE_NIGHTLY,
+  TB_SEND_DASHBOARD_URL,
+} from '../../const/const';
+import { DashboardPage } from '../../pages/dashboard-page';
+import { EncryptedFilesPage } from '../../pages/encrypted-files-page';
+import { createUniquePngUploadFixture } from '../../utils/upload-files';
+import { signInAndRestoreSendKey } from '../../utils/utils';
+
+const FIVE_MINUTES = 5 * 60 * 1000;
+
+test.describe('encrypted files on mobile', () => {
+  test('your files page: upload, download, and delete', {
+    tag: [PLAYWRIGHT_TAG_MOBILE_NIGHTLY],
+  }, async ({ page }, testInfo) => {
+    test.skip(true, 'Skipping on mobile until issue 977 (file info panel covers delete button on mobile) is resolved');
+    test.setTimeout(FIVE_MINUTES); // android BrowserStack can run very slow
+
+    await signInAndRestoreSendKey(page);
+
+    const dashboardPage = new DashboardPage(page);
+    const encryptedFilesPage = new EncryptedFilesPage(page);
+    // Use unique runtime copies so this test can run against accounts that
+    // already contain files with the original test fixture name.
+    const filePickerFixture = createUniquePngUploadFixture(testInfo, 'file-picker');
+    const dragDropFixture = createUniquePngUploadFixture(testInfo, 'drag-drop');
+    const uploadedFileNames = [
+      filePickerFixture.fileName,
+      dragDropFixture.fileName,
+    ];
+
+    await page.goto(TB_SEND_DASHBOARD_URL);
+    await dashboardPage.expectUnlockedDashboardVisible({ includeDesktopNav: false });
+    await dashboardPage.goToEncryptedFilesFromDashboard();
+
+    await encryptedFilesPage.expectBasicUiVisible();
+
+    try {
+      // Cover both upload entry points: native file chooser and drag/drop.
+      await encryptedFilesPage.uploadFileWithFilePicker(filePickerFixture);
+      await encryptedFilesPage.uploadFileWithDragAndDrop(dragDropFixture);
+      // Download one of the files
+      await encryptedFilesPage.downloadFileFromInfoPanelAndExpectDownload(filePickerFixture.fileName);
+    } finally {
+      // Keep the shared test account tidy even if a later upload assertion fails.
+      await encryptedFilesPage.deleteUploadedFiles(uploadedFileNames);
+    }
+  });
+});

--- a/packages/send/e2e/utils/upload-files.ts
+++ b/packages/send/e2e/utils/upload-files.ts
@@ -1,0 +1,60 @@
+import { type Page, type TestInfo } from '@playwright/test';
+import { copyFileSync, mkdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const TEST_PNG_FILE = path.resolve(__dirname, '../test-files/test.png');
+
+export type UploadFixture = {
+  fileName: string;
+  filePath: string;
+};
+
+export function createUniquePngUploadFixture(
+  testInfo: TestInfo,
+  uploadMethod: 'file-picker' | 'drag-drop'
+): UploadFixture {
+  // Keep the tracked test.png fixture immutable. Each upload uses a runtime
+  // copy with a unique name so assertions never depend on pre-existing files.
+  const timestamp = new Date().toISOString().replace(/[-:.TZ]/g, '');
+  const randomId = Math.random().toString(36).slice(2, 8);
+  const fileName = `e2e-test-${uploadMethod}-${timestamp}-${randomId}.png`;
+  const filePath = testInfo.outputPath('upload-fixtures', fileName);
+
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  copyFileSync(TEST_PNG_FILE, filePath);
+
+  return { fileName, filePath };
+}
+
+export async function dragAndDropUploadFile(
+  page: Page,
+  selector: string,
+  uploadFixture: UploadFixture
+) {
+  // Playwright cannot use the native file chooser for drag/drop, so build the
+  // same DataTransfer payload that the browser would provide during a drop.
+  const buffer = readFileSync(uploadFixture.filePath).toString('base64');
+  const dataTransfer = await page.evaluateHandle(
+    ({ bufferData, fileName }) => {
+      const dt = new DataTransfer();
+      const binary = window.atob(bufferData);
+      const bytes = new Uint8Array(binary.length);
+
+      for (let index = 0; index < binary.length; index++) {
+        bytes[index] = binary.charCodeAt(index);
+      }
+
+      const file = new File([bytes], fileName, { type: 'image/png' });
+
+      dt.items.add(file);
+      return dt;
+    },
+    {
+      bufferData: buffer,
+      fileName: uploadFixture.fileName,
+    }
+  );
+
+  await page.dispatchEvent(selector, 'drop', { dataTransfer });
+  await dataTransfer.dispose();
+}

--- a/packages/send/e2e/utils/utils.ts
+++ b/packages/send/e2e/utils/utils.ts
@@ -7,7 +7,6 @@ import {
   TB_SEND_TARGET_ENV,
   TB_SEND_BASE_URL,
   TIMEOUT_5_SECONDS,
-  TIMEOUT_10_SECONDS,
   TIMEOUT_30_SECONDS,
 } from "../const/const";
 
@@ -18,7 +17,7 @@ import {
  * the TB Accounts username (email) and password; when signing in on the local dev environment
  * you provide a username (email) and password already created for your local dev stack. After
  * sign-in we expect to arrive on the TB Send dashboard. After we are signed in, restore the send
- * encryption key using the values provided in the e2e/.env file. 
+ * encryption key using the values provided in the e2e/.env file.
  */
 export const signInAndRestoreSendKey = async (page: Page) => {
   console.log(`navigating to send ${TB_SEND_TARGET_ENV} (${TB_SEND_BASE_URL})`);


### PR DESCRIPTION
## What changed?
Add the next set of TB Send E2E tests that will run in BrowserStack. This next test is to verify the basic functionality of the `Encrypted Files` page: file upload, download, and delete from the `Your Files` area.

## Why?
To expand the set of tests that run in BrowserStack on desktop and mobile.

## Limitations and Notes
The file download here is from the `Your Files` list; downloading files via a share link will be done in a separate test. This test will currently skip on android mobile because of issue #977; but once that is resolved we can remove the test skip.

## Applicable Issues
Fixes #768.

## QA Log
Ran the new encrypted files test:

- On my local machine on Firefox desktop
- On my local machine in the Playwright Google Pixel 10 viewport
- On Firefox desktop on OSX [in BrowserStack](https://automate.browserstack.com/projects/Thunderbird+Send/builds/TB+Send+Nightly+Tests+Firefox+Desktop/214?tab=sessions&bls_localTimezone=true)
- On Chromium desktop on Win11 [in BrowserStack](https://automate.browserstack.com/projects/Thunderbird+Send/builds/TB+Send+Nightly+Tests+Chromium+Desktop/189?tab=sessions&testListView=spec)
- On Safari desktop on OSX [in BrowserStack](https://automate.browserstack.com/projects/Thunderbird+Send/builds/TB+Send+Nightly+Tests+Safari+Desktop/199?tab=sessions&bls_localTimezone=true)
- On Android Chrome on a Google Pixel 10 device [in BrowserStack](https://automate.browserstack.com/projects/Thunderbird+Send/builds/TB+Send+Nightly+Tests+Android+Chrome/223?tab=sessions&bls_localTimezone=true) (where the test is skipped as noted above)
