### PR TITLE
fix(addon): authenticate teardown cleanup so the add-on removes orphaned upload parts

### DIFF
--- a/packages/send/frontend/src/apps/send/components/ProgressBarV2.vue
+++ b/packages/send/frontend/src/apps/send/components/ProgressBarV2.vue
@@ -20,6 +20,11 @@ const stageInfo = computed(() => {
     { text: string; color: string; bgColor: string }
   > = {
     idle: {
+      text: 'Starting...',
+      color: 'text-gray-600',
+      bgColor: 'bg-gray-100',
+    },
+    hashing: {
       text: 'Hashing...',
       color: 'text-gray-600',
       bgColor: 'bg-gray-100',
@@ -144,7 +149,9 @@ const progressDisplay = computed(() => {
             'bg-purple-500': progress.processStage === 'decrypting',
             'bg-indigo-500': progress.processStage === 'processing',
             'bg-red-500': progress.processStage === 'error',
-            'bg-gray-400': progress.processStage === 'idle',
+            'bg-gray-400':
+              progress.processStage === 'idle' ||
+              progress.processStage === 'hashing',
           }"
         ></div>
       </div>

--- a/packages/send/frontend/src/apps/send/stores/status-store.ts
+++ b/packages/send/frontend/src/apps/send/stores/status-store.ts
@@ -10,6 +10,7 @@ import { computed, ref } from 'vue';
 // Define the possible process stages
 export type ProcessStage =
   | 'idle'
+  | 'hashing'
   | 'preparing'
   | 'encrypting'
   | 'uploading'

--- a/packages/send/frontend/src/lib/upload.ts
+++ b/packages/send/frontend/src/lib/upload.ts
@@ -14,7 +14,7 @@ import { MAX_CONCURRENT_PARTS, SPLIT_SIZE } from './const';
 import {
   hashFiles,
   retryUntilSuccessOrTimeout,
-  splitIntoMultipleZips,
+  streamZippedParts,
 } from './utils';
 
 /**
@@ -95,17 +95,18 @@ export default class Uploader {
    */
   private createMultipartProgressTracker(
     mainTracker: ProgressTracker,
-    blobs: NamedBlob[],
+    // Per-part sizes, known up front from the window boundaries even though the
+    // (zipped) part blobs are produced lazily as the file streams in.
+    blobSizes: number[],
     isMultipart: boolean,
     originalFileSize: number
   ) {
-    const blobSizes = blobs.map((blob) => blob.size);
     const totalBlobSize = blobSizes.reduce((sum, size) => sum + size, 0);
     // Track progress for each part individually to handle concurrent uploads
-    const partProgress = new Array(blobs.length).fill(0);
+    const partProgress = new Array(blobSizes.length).fill(0);
 
     const updateOverallProgress = () => {
-      if (!isMultipart || blobs.length === 1) {
+      if (!isMultipart || blobSizes.length === 1) {
         // For single file uploads, use the part progress directly
         mainTracker.setProgress(Math.min(partProgress[0], originalFileSize));
       } else {
@@ -146,11 +147,7 @@ export default class Uploader {
             mainTracker.setProcessStage(stage);
           },
           setText: (message: string) => {
-            if (isMultipart && blobs.length > 1) {
-              mainTracker.setText(message);
-            } else {
-              mainTracker.setText(message);
-            }
+            mainTracker.setText(message);
           },
           setProgress: (progress: number) => {
             // Update this part's progress
@@ -197,48 +194,106 @@ export default class Uploader {
       wrappingKey
     );
 
-    let blobs: NamedBlob[];
+    const shouldSplit = fileBlob.size > SPLIT_SIZE;
+    const numChunks = shouldSplit ? Math.ceil(fileBlob.size / SPLIT_SIZE) : 1;
 
-    // Give immediate UI feedback before the (potentially multi-second) hashing
-    // and zipping work below. For large files hashFiles reads and hashes the
-    // whole file in chunks and splitIntoMultipleZips re-compresses each chunk,
-    // all before any bytes are uploaded — without this the progress meter sits
-    // static with no indication anything is happening (#968).
-    // Don't call initialize() here as it resets fileName.
-    progressTracker.setUploadSize(fileBlob.size); // Use original file size for progress tracking
-    progressTracker.setProcessStage('preparing');
-    progressTracker.setText('Preparing file for upload');
-
-    const hashes = await hashFiles(
-      api,
-      fileBlob,
-      SPLIT_SIZE,
-      (completed, total) => {
-        if (total > 1) {
-          progressTracker.setText(
-            `Preparing file for upload (${completed}/${total})`
-          );
-        }
-      }
+    // Per-part raw-size estimates, known from the window boundaries up front.
+    // The actual (zipped) part blobs are produced lazily as the file streams in,
+    // so the progress tracker is seeded with these estimates.
+    const partSizes = Array.from({ length: numChunks }, (_, i) =>
+      Math.min(SPLIT_SIZE, fileBlob.size - i * SPLIT_SIZE)
     );
 
-    const shouldSplit = fileBlob.size > SPLIT_SIZE;
-    if (shouldSplit) {
-      const zips = await splitIntoMultipleZips(fileBlob, SPLIT_SIZE);
-      blobs = zips || []; // Ensure blobs is never undefined
-    } else {
-      blobs = [fileBlob];
-    }
+    // Give immediate UI feedback: hashing a large file (read + SHA-256 + a
+    // suspicious-file check per window) can take several seconds. Previously the
+    // whole file was hashed AND zipped before any byte uploaded (#968); now we
+    // stream it and start uploading window 0 as soon as it is ready (#980).
+    // Don't call initialize() here as it resets fileName.
+    progressTracker.setUploadSize(fileBlob.size);
+    progressTracker.setProcessStage('hashing');
+    progressTracker.setText('Hashing file');
 
-    // Ensure we have valid blobs before proceeding
-    if (!blobs || blobs.length === 0) {
-      return null;
+    // Parts and their raw-bytes hashes are produced in order by the streaming
+    // producer below. partReady[i] resolves once parts[i]/hashes[i] are
+    // populated, so an upload worker can await just the part it needs and start
+    // uploading it while later windows are still being hashed/zipped.
+    // Elements are undefined until the producer fills them, and are nulled again
+    // once uploaded (see the release below) — hence the honest `| undefined`.
+    const parts: (NamedBlob | undefined)[] = new Array(numChunks);
+    const hashes: string[] = new Array(numChunks);
+    const partReady = Array.from({ length: numChunks }, () => {
+      let resolve!: () => void;
+      let reject!: (err: unknown) => void;
+      const promise = new Promise<void>((res, rej) => {
+        resolve = res;
+        reject = rej;
+      });
+      // Guarantee the rejection is always "handled" so a part that no worker
+      // ends up awaiting (e.g. after the pool aborts) doesn't surface as an
+      // unhandled promise rejection. Workers still observe it via their await.
+      void promise.catch(() => {});
+      return { promise, resolve, reject };
+    });
+
+    if (shouldSplit) {
+      // Fire-and-forget: streams the file from offset 0, filling parts/hashes in
+      // order. Reading via a stream (never a high-offset slice/arrayBuffer) is
+      // what lets files >2 GB upload at all (#981). A failure (read error or
+      // suspicious file) rejects every not-yet-ready part so the awaiting worker
+      // throws and the pool's normal abort+cleanup path runs.
+      void (async () => {
+        let produced = 0;
+        try {
+          for await (const part of streamZippedParts(
+            api,
+            fileBlob,
+            SPLIT_SIZE,
+            (bytesHashed) => {
+              // Only drive the hashing label until the first part is ready.
+              // After that, upload workers are running and own the tracker text,
+              // so continuing to write "Hashing…" here would flip-flop with
+              // their "Uploading…"/"Encrypting…" updates during the overlap.
+              if (parts[0] !== undefined) return;
+              const pct = Math.round((bytesHashed / fileBlob.size) * 100);
+              progressTracker.setText(`Hashing file (${pct}%)`);
+            }
+          )) {
+            parts[produced] = part.blob;
+            hashes[produced] = part.hash;
+            partReady[produced].resolve();
+            produced++;
+          }
+          // The producer completed without yielding every expected window — e.g.
+          // the on-disk file was truncated between selection and this (possibly
+          // minutes-long) streamed read. The waiting workers would otherwise hang
+          // forever with no cleanup, so funnel it into the fatal/cleanup path.
+          if (produced < numChunks) {
+            const err = new Error(
+              `Streaming produced ${produced} of ${numChunks} expected parts`
+            );
+            for (let i = produced; i < numChunks; i++) {
+              partReady[i].reject(err);
+            }
+          }
+        } catch (err) {
+          for (let i = produced; i < numChunks; i++) {
+            partReady[i].reject(err);
+          }
+        }
+      })();
+    } else {
+      // Single small part: safe to hash up front (bounded by SPLIT_SIZE) and it
+      // uploads raw (not zipped), matching the non-multipart download path.
+      const [singleHash] = await hashFiles(api, fileBlob, SPLIT_SIZE);
+      parts[0] = fileBlob;
+      hashes[0] = singleHash;
+      partReady[0].resolve();
     }
 
     // Create a multipart progress tracker that manages overall progress
     const multipartTracker = this.createMultipartProgressTracker(
       progressTracker,
-      blobs,
+      partSizes,
       shouldSplit,
       fileBlob.size // Pass original file size
     );
@@ -441,7 +496,7 @@ export default class Uploader {
     // part starts immediately. There is no per-batch barrier, so a slow or
     // failing part never blocks unrelated parts from starting. The first part
     // that fails permanently records the error and aborts the rest.
-    const uploadResponses: Item[] = new Array(blobs.length);
+    const uploadResponses: Item[] = new Array(numChunks);
     let nextIndex = 0;
     let fatalError: unknown = null;
 
@@ -451,15 +506,23 @@ export default class Uploader {
           return;
         }
         const index = nextIndex++;
-        if (index >= blobs.length) {
+        if (index >= numChunks) {
           return;
         }
         try {
-          const item = await uploadPart(blobs[index], index);
+          // Wait until the streaming producer has hashed + zipped this window.
+          // Rejects if hashing failed (read error / suspicious file), which the
+          // catch below turns into a fatal, cleanup-triggering upload error.
+          await partReady[index].promise;
+          // Non-null: awaiting partReady guarantees the producer populated it.
+          const item = await uploadPart(parts[index]!, index);
           if (!item) {
             throw new Error(`Upload part ${index} returned no item`);
           }
           uploadResponses[index] = item;
+          // Release the zipped part blob now that it's uploaded so a multi-GB
+          // file doesn't keep every window resident until the whole upload ends.
+          parts[index] = undefined;
         } catch (error) {
           // First failure dooms the upload: record it and cancel the in-flight
           // PUTs of the sibling parts. Those PUTs are cancelled instead of
@@ -481,7 +544,7 @@ export default class Uploader {
     window.addEventListener('pagehide', onPageHide);
 
     try {
-      const workerCount = Math.min(MAX_CONCURRENT_PARTS, blobs.length);
+      const workerCount = Math.min(MAX_CONCURRENT_PARTS, numChunks);
       await Promise.all(Array.from({ length: workerCount }, () => runWorker()));
 
       if (fatalError) {

--- a/packages/send/frontend/src/lib/upload.ts
+++ b/packages/send/frontend/src/lib/upload.ts
@@ -69,11 +69,17 @@ export default class Uploader {
    * Fire-and-forget cleanup for use during page teardown (pagehide), when an
    * upload is still in flight and the normal `if (fatalError)` cleanup will
    * never run. Uses a `keepalive` fetch so the request survives the page being
-   * torn down, and cookie auth (`credentials: 'include'`) since requireJWT reads
-   * the auth cookie — a Bearer header can't be attached reliably at unload time.
-   * Best-effort only: hard kills/crashes still rely on the server-side reaper.
+   * torn down. Sends the Bearer `token` (pre-captured at upload start, since we
+   * can't await `getAccessToken` at unload) so it authenticates in the add-on,
+   * which has no backend cookie; `credentials: 'include'` remains as the web
+   * cookie fallback. Best-effort only: hard kills/crashes still rely on the
+   * server-side reaper.
    */
-  private teardownCleanup(api: ApiConnection, ids: string[]) {
+  private teardownCleanup(
+    api: ApiConnection,
+    ids: string[],
+    token: string | null
+  ) {
     if (ids.length === 0) {
       return;
     }
@@ -82,7 +88,10 @@ export default class Uploader {
         method: 'POST',
         keepalive: true,
         credentials: 'include',
-        headers: { 'content-type': 'application/json' },
+        headers: {
+          'content-type': 'application/json',
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
         body: JSON.stringify({ ids }),
       });
     } catch {
@@ -304,6 +313,28 @@ export default class Uploader {
     // the bucket.
     const abortController = new AbortController();
     const writtenUploadIds = new Set<string>();
+
+    // Capture the OIDC access token now, while we can still await, so the
+    // pagehide teardown below (which fires at unload and cannot await) can send
+    // an authenticated cleanup. The add-on authenticates with a Bearer token,
+    // not the cookie the raw teardown fetch relied on, so without this the
+    // cleanup 401s in the add-on and orphaned parts are never removed. Falls
+    // back to cookie-only auth (the web app) when no token is available.
+    // Dynamic import mirrors api.ts to avoid a circular dependency.
+    let authToken: string | null = null;
+    try {
+      const { useAuthStore } = await import('@send-frontend/stores/auth-store');
+      authToken = await useAuthStore().getAccessToken();
+    } catch (error) {
+      // Mirror api.ts: authToken stays null (its initial value), so teardown
+      // cleanup falls back to cookie-only auth. Leave a breadcrumb since a
+      // silently-null token is the difference between an authenticated cleanup
+      // and a 401.
+      console.debug(
+        'Could not capture OIDC token for teardown cleanup:',
+        error
+      );
+    }
 
     const uploadPart = async (
       blob: NamedBlob,
@@ -540,7 +571,8 @@ export default class Uploader {
     // the normal failure cleanup below never runs — so strand-proof it with a
     // teardown-time cleanup of whatever we've started writing. Registered only
     // for the duration of the pool run and removed in the finally.
-    const onPageHide = () => this.teardownCleanup(api, [...writtenUploadIds]);
+    const onPageHide = () =>
+      this.teardownCleanup(api, [...writtenUploadIds], authToken);
     window.addEventListener('pagehide', onPageHide);
 
     try {

--- a/packages/send/frontend/src/lib/utils.ts
+++ b/packages/send/frontend/src/lib/utils.ts
@@ -11,13 +11,21 @@ import { trpc } from './trpc';
  * @returns {Promise<string>} - Returns a Promise that resolves to the hexadecimal hash string
  */
 export async function generateFileHash(fileBlob: Blob): Promise<string> {
+  // Small blobs (<= SPLIT_SIZE) only: reading the whole blob into one buffer is
+  // safe here. Large files are hashed window-by-window via streamZippedParts,
+  // which never materializes the whole file (and never slices at high offsets).
   const fileArrayBuffer = await fileBlob.arrayBuffer();
-  const hashBuffer = await crypto.subtle.digest('SHA-256', fileArrayBuffer);
-  const hashArray = Array.from(new Uint8Array(hashBuffer));
-  const fileHash = hashArray
+  return sha256Hex(fileArrayBuffer);
+}
+
+/**
+ * Hex-encodes the SHA-256 digest of an already-in-memory buffer.
+ */
+export async function sha256Hex(buffer: ArrayBuffer): Promise<string> {
+  const hashBuffer = await crypto.subtle.digest('SHA-256', buffer);
+  return Array.from(new Uint8Array(hashBuffer))
     .map((b) => b.toString(16).padStart(2, '0'))
     .join('');
-  return fileHash;
 }
 
 /*
@@ -197,11 +205,48 @@ export function formatBytes(bytes: number, decimals: number = 2): string {
   return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i];
 }
 
-export async function zipBlob(blob: Blob, filename: string) {
+/**
+ * Zips `blob` under `filename` and returns the archive as a Blob.
+ *
+ * Why this is not just `zip.generateAsync({ type: 'blob' })`:
+ * JSZip's one-shot blob output builds the entire archive as a single
+ * `Uint8Array` and then calls `new Blob([thatArray])`. Firefox rejects any
+ * single ArrayBuffer/ArrayBufferView Blob member larger than 2 GB with
+ * "can't construct the Blob ... larger than 2 GB" — so zipping a file bigger
+ * than ~2 GB (e.g. a typeless file wrapped by {@link formatBlob}) throws before
+ * a single byte is uploaded (#981). Note this is a hard per-member limit, not an
+ * out-of-memory condition: the same Firefox happily allocates a 6 GiB
+ * ArrayBuffer, but refuses a >2 GB Blob member.
+ *
+ * Instead we consume JSZip's streaming output and hand the (individually
+ * sub-2 GB) chunks to the Blob constructor as separate members. A Blob's *total*
+ * size may exceed 2 GB as long as no single member does, so the archive can be
+ * arbitrarily large.
+ *
+ * Backwards compatibility: `generateAsync` is itself implemented on top of this
+ * same internal stream with the same default settings (STORE, no compression),
+ * so the archive bytes are identical to the previous implementation. Files
+ * zipped before and after this change are byte-for-byte interchangeable and the
+ * download/unzip path is unaffected — this only changes how the output Blob is
+ * assembled in memory, not its contents.
+ */
+export async function zipBlob(blob: Blob, filename: string): Promise<Blob> {
   const zip = new JSZip();
   zip.file(filename, blob);
 
-  return zip.generateAsync({ type: 'blob' });
+  // Typed as BlobPart[] (not Uint8Array[]) so the chunks pass straight to the
+  // Blob constructor without tripping the Uint8Array<ArrayBufferLike> vs
+  // Uint8Array<ArrayBuffer> generic mismatch in newer lib.dom typings.
+  const chunks: BlobPart[] = [];
+  await new Promise<void>((resolve, reject) => {
+    zip
+      .generateInternalStream({ type: 'uint8array' })
+      .on('data', (chunk: Uint8Array) => chunks.push(chunk as BlobPart))
+      .on('error', reject)
+      .on('end', () => resolve())
+      .resume();
+  });
+  return new Blob(chunks, { type: 'application/zip' });
 }
 
 export async function unzipArrayBuffer(
@@ -306,6 +351,11 @@ export async function unzipMultipartPiece(
 
 export const formatBlob = async (blob: NamedBlob): Promise<NamedBlob> => {
   if (blob.type === '') {
+    // Typeless files are wrapped in a whole-file zip here, before doUpload. For
+    // files > ~2 GB this used to throw "can't construct the Blob" (#981); it now
+    // works because zipBlob assembles its output from sub-2 GB chunks. Wrapping
+    // the resulting (possibly >2 GB) Blob in another Blob is fine — the 2 GB cap
+    // is per ArrayBuffer/View member, not per Blob member.
     const zippedBlob = await zipBlob(blob, blob.name);
     const compressedBlob = new Blob([zippedBlob], {
       type: 'application/zip',
@@ -358,12 +408,11 @@ export const splitIntoMultipleZips = async (
   return chunks;
 };
 
-const hashAndCheck = async (api: ApiConnection, fileBlob: NamedBlob) => {
-  // generate a hash from the file
-  const fileHash = await generateFileHash(fileBlob);
-  console.log('File hash (SHA-256):', fileHash);
-
-  // check fileHash against suspicious files
+/**
+ * Checks a precomputed file hash against the suspicious-files list and blocks
+ * the upload (alert + throw) if it matches.
+ */
+const assertNotSuspicious = async (api: ApiConnection, fileHash: string) => {
   const { isSuspicious } = await api.call<{ isSuspicious: boolean }>(
     `uploads/check-upload-hash/${fileHash}`
   );
@@ -374,6 +423,13 @@ const hashAndCheck = async (api: ApiConnection, fileBlob: NamedBlob) => {
     );
     throw new Error('Suspicious file detected');
   }
+};
+
+const hashAndCheck = async (api: ApiConnection, fileBlob: NamedBlob) => {
+  // generate a hash from the file
+  const fileHash = await generateFileHash(fileBlob);
+  console.log('File hash (SHA-256):', fileHash);
+  await assertNotSuspicious(api, fileHash);
   return fileHash;
 };
 
@@ -416,6 +472,104 @@ export const hashFiles = async (
   }
   return hashFromChunk;
 };
+
+/**
+ * A single multipart piece ready to upload: the zipped chunk blob plus the
+ * SHA-256 hash of its *raw* (pre-zip) bytes, matching the per-chunk hash the
+ * backend records via the `uploads` create-entry call.
+ */
+export type UploadPart = { blob: NamedBlob; hash: string };
+
+/**
+ * Streams a large file into upload-ready parts, one `maxSize` window at a time.
+ *
+ * Crucially, it reads the file **sequentially from offset 0 via
+ * `fileBlob.stream()`** and never calls `.slice()`/`.arrayBuffer()` at a high
+ * byte offset. The previous approach (hashFiles + splitIntoMultipleZips) sliced
+ * the file at offsets past ~2 GiB, which Firefox rejects with a NotReadableError
+ * / "can't construct the Blob" on files larger than ~2 GB (#981). Reading via a
+ * ReadableStream keeps each in-memory buffer bounded to one window and avoids
+ * the 2^31 offset boundary entirely.
+ *
+ * Parts are yielded **in order as they become ready**, so a caller can begin
+ * uploading window 0 while later windows are still being read/hashed/zipped
+ * (#980).
+ *
+ * For each window it hashes the raw bytes, runs the suspicious-file check, then
+ * zips the window — producing the exact same wire format as
+ * splitIntoMultipleZips (a zip of the raw chunk, named after the original file).
+ */
+export async function* streamZippedParts(
+  api: ApiConnection,
+  fileBlob: NamedBlob,
+  maxSize: number,
+  // Invoked with cumulative bytes hashed so callers can show hashing progress.
+  onBytesHashed?: (bytesHashed: number) => void
+): AsyncGenerator<UploadPart, void, unknown> {
+  const reader = fileBlob.stream().getReader();
+  let windowChunks: Uint8Array[] = [];
+  let windowSize = 0;
+  let totalHashed = 0;
+
+  // Turn the accumulated (<= maxSize) window into an upload-ready part.
+  const flushWindow = async (): Promise<UploadPart> => {
+    const windowBytes = new Uint8Array(windowSize);
+    let offset = 0;
+    for (const piece of windowChunks) {
+      windowBytes.set(piece, offset);
+      offset += piece.byteLength;
+    }
+    windowChunks = [];
+    windowSize = 0;
+
+    const hash = await sha256Hex(windowBytes.buffer);
+    await assertNotSuspicious(api, hash);
+
+    const rawBlob = new Blob([windowBytes], {
+      type: fileBlob.type,
+    }) as NamedBlob;
+    rawBlob.name = fileBlob.name;
+    const zipped = await zipBlob(rawBlob, fileBlob.name);
+    const zippedBlob = new Blob([zipped], {
+      type: 'application/zip',
+    }) as NamedBlob;
+    zippedBlob.name = fileBlob.name;
+
+    return { blob: zippedBlob, hash };
+  };
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      let chunk = value;
+      // A single stream read can straddle one or more window boundaries.
+      while (windowSize + chunk.byteLength >= maxSize) {
+        const take = maxSize - windowSize;
+        windowChunks.push(chunk.subarray(0, take));
+        windowSize += take;
+        totalHashed += take;
+        onBytesHashed?.(totalHashed);
+        yield await flushWindow();
+        chunk = chunk.subarray(take);
+      }
+      if (chunk.byteLength > 0) {
+        windowChunks.push(chunk);
+        windowSize += chunk.byteLength;
+      }
+    }
+
+    // Trailing partial window.
+    if (windowSize > 0) {
+      totalHashed += windowSize;
+      onBytesHashed?.(totalHashed);
+      yield await flushWindow();
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
 
 export const checkBlobSize = async (blob: NamedBlob) => {
   console.log(blob);

--- a/packages/send/frontend/src/test/lib/upload.test.ts
+++ b/packages/send/frontend/src/test/lib/upload.test.ts
@@ -4,7 +4,7 @@ import { MAX_CONCURRENT_PARTS, SPLIT_SIZE } from '@send-frontend/lib/const';
 import { NamedBlob, sendBlob } from '@send-frontend/lib/filesync';
 import { Keychain } from '@send-frontend/lib/keychain';
 import Uploader from '@send-frontend/lib/upload';
-import { hashFiles, splitIntoMultipleZips } from '@send-frontend/lib/utils';
+import { hashFiles, streamZippedParts } from '@send-frontend/lib/utils';
 import { UserType } from '@send-frontend/types';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -14,16 +14,21 @@ vi.mock('@send-frontend/lib/filesync', () => ({
 }));
 
 vi.mock('@send-frontend/lib/utils', () => ({
-  splitIntoMultipleZips: vi
-    .fn()
-    .mockResolvedValue([
-      Object.assign(new Blob(['part1']), { name: 'large-file.txt' }),
-      Object.assign(new Blob(['part2']), { name: 'large-file.txt' }),
-    ]),
   retryUntilSuccessOrTimeout: vi.fn().mockResolvedValue(undefined),
   generateFileHash: vi.fn().mockResolvedValue('abc123def456'),
+  // Single-part (small file) path.
   hashFiles: vi.fn().mockResolvedValue(['abc123def456']),
+  // Multipart path: a streaming producer yielding one {blob, hash} per window.
+  streamZippedParts: vi.fn(),
 }));
+
+// Builds the async generator the mocked streamZippedParts returns, yielding one
+// upload-ready part per blob (hash "h<index>"), mirroring the real producer.
+async function* yieldParts(parts: NamedBlob[]) {
+  for (let i = 0; i < parts.length; i++) {
+    yield { blob: parts[i], hash: `h${i}` };
+  }
+}
 
 describe('Uploader', () => {
   let uploader: Uploader;
@@ -94,7 +99,7 @@ describe('Uploader', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const tracker = (uploader as any).createMultipartProgressTracker(
         mockProgressTracker,
-        [blob],
+        [blob.size],
         false,
         originalFileSize
       );
@@ -117,12 +122,10 @@ describe('Uploader', () => {
       }) as NamedBlob;
       blob2.name = 'test.zip';
 
-      const blobs = [blob1, blob2];
-
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const tracker = (uploader as any).createMultipartProgressTracker(
         mockProgressTracker,
-        blobs,
+        [blob1.size, blob2.size],
         true,
         originalFileSize
       );
@@ -165,7 +168,7 @@ describe('Uploader', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const tracker = (uploader as any).createMultipartProgressTracker(
         mockProgressTracker,
-        [blob1, blob2],
+        [blob1.size, blob2.size],
         true,
         2000
       );
@@ -185,7 +188,7 @@ describe('Uploader', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const tracker = (uploader as any).createMultipartProgressTracker(
         mockProgressTracker,
-        [blob],
+        [blob.size],
         false,
         1000
       );
@@ -209,7 +212,7 @@ describe('Uploader', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const tracker = (uploader as any).createMultipartProgressTracker(
         mockProgressTracker,
-        [blob],
+        [blob.size],
         false,
         originalFileSize
       );
@@ -327,8 +330,17 @@ describe('Uploader', () => {
       }) as NamedBlob;
       largeBlob.name = 'large-file.txt';
 
-      // Mock hashFiles to return two hashes for multipart upload
-      vi.mocked(hashFiles).mockResolvedValueOnce(['hash1', 'hash2']);
+      // Mock the streaming producer to yield two parts for this multipart upload.
+      vi.mocked(streamZippedParts).mockImplementationOnce(() =>
+        yieldParts([
+          Object.assign(new Blob(['part0']), {
+            name: 'large-file.txt',
+          }) as NamedBlob,
+          Object.assign(new Blob(['part1']), {
+            name: 'large-file.txt',
+          }) as NamedBlob,
+        ])
+      );
 
       // Mock API calls for both parts - handle concurrent calls by checking the endpoint
       let uploadCallCount = 0;
@@ -364,21 +376,21 @@ describe('Uploader', () => {
         largeFileSize
       ); // Original file size
       expect(mockProgressTracker.setProcessStage).toHaveBeenCalledWith(
-        'preparing'
+        'hashing'
       );
-      expect(mockProgressTracker.setText).toHaveBeenCalledWith(
-        'Preparing file for upload'
-      );
+      expect(mockProgressTracker.setText).toHaveBeenCalledWith('Hashing file');
     });
   });
 
   describe('doUpload concurrency & failure handling', () => {
     // A lightweight stand-in for the source file: doUpload only reads .size /
-    // .name off it and passes it to the (mocked) splitter + hasher, so we avoid
-    // allocating a real >SPLIT_SIZE (500MB) buffer.
-    const makeSourceBlob = (): NamedBlob =>
+    // .name off it and passes it to the (mocked) streaming producer, so we avoid
+    // allocating a real >SPLIT_SIZE buffer. Its size must yield exactly
+    // `nChunks` windows (ceil(size / SPLIT_SIZE)) so numChunks matches the number
+    // of parts the mocked producer yields.
+    const makeSourceBlob = (nChunks = 2): NamedBlob =>
       ({
-        size: SPLIT_SIZE + 1000,
+        size: SPLIT_SIZE * (nChunks - 1) + 1000,
         name: 'big.txt',
         type: 'text/plain',
       }) as unknown as NamedBlob;
@@ -408,8 +420,9 @@ describe('Uploader', () => {
     });
 
     it('passes an abort signal and an onUploadId reporter to each part', async () => {
-      vi.mocked(splitIntoMultipleZips).mockResolvedValueOnce(makeParts(2));
-      vi.mocked(hashFiles).mockResolvedValueOnce(['h0', 'h1']);
+      vi.mocked(streamZippedParts).mockImplementationOnce(() =>
+        yieldParts(makeParts(2))
+      );
       mockApi.call = resolveDbCalls();
 
       await uploader.doUpload(
@@ -427,11 +440,8 @@ describe('Uploader', () => {
 
     it('does not block later parts behind a stalled earlier part (no batch barrier)', async () => {
       const partCount = MAX_CONCURRENT_PARTS + 2; // 7 parts, 5 concurrent
-      vi.mocked(splitIntoMultipleZips).mockResolvedValueOnce(
-        makeParts(partCount)
-      );
-      vi.mocked(hashFiles).mockResolvedValueOnce(
-        Array.from({ length: partCount }, (_, i) => `h${i}`)
+      vi.mocked(streamZippedParts).mockImplementationOnce(() =>
+        yieldParts(makeParts(partCount))
       );
       mockApi.call = resolveDbCalls();
 
@@ -456,7 +466,7 @@ describe('Uploader', () => {
       );
 
       const uploadPromise = uploader.doUpload(
-        makeSourceBlob(),
+        makeSourceBlob(partCount),
         'container-id',
         mockApi,
         mockProgressTracker
@@ -474,8 +484,9 @@ describe('Uploader', () => {
 
     it('cleans up every written part and aborts siblings when a part fails', async () => {
       const parts = makeParts(3);
-      vi.mocked(splitIntoMultipleZips).mockResolvedValueOnce(parts);
-      vi.mocked(hashFiles).mockResolvedValueOnce(['h0', 'h1', 'h2']);
+      vi.mocked(streamZippedParts).mockImplementationOnce(() =>
+        yieldParts(parts)
+      );
       mockApi.call = resolveDbCalls();
 
       let capturedSignal: AbortSignal | undefined;
@@ -496,7 +507,7 @@ describe('Uploader', () => {
 
       await expect(
         uploader.doUpload(
-          makeSourceBlob(),
+          makeSourceBlob(3),
           'container-id',
           mockApi,
           mockProgressTracker
@@ -513,6 +524,26 @@ describe('Uploader', () => {
         .mock.calls.find(([endpoint]) => endpoint === 'uploads/cleanup');
       expect(cleanupCall).toBeDefined();
       expect(cleanupCall?.[1]?.ids).toContain('upload-1');
+    });
+
+    it('fails (instead of hanging) when the producer yields fewer parts than expected', async () => {
+      // Source implies 3 windows, but the stream only yields 2 (e.g. the file
+      // was truncated between selection and the streamed read). The waiting
+      // worker for the missing part must fail, not hang forever.
+      vi.mocked(streamZippedParts).mockImplementationOnce(() =>
+        yieldParts(makeParts(2))
+      );
+      mockApi.call = resolveDbCalls();
+      vi.mocked(sendBlob).mockResolvedValue('upload-id');
+
+      await expect(
+        uploader.doUpload(
+          makeSourceBlob(3),
+          'container-id',
+          mockApi,
+          mockProgressTracker
+        )
+      ).rejects.toThrow(/expected parts/);
     });
   });
 });

--- a/packages/send/frontend/src/test/lib/upload.test.ts
+++ b/packages/send/frontend/src/test/lib/upload.test.ts
@@ -6,7 +6,7 @@ import { Keychain } from '@send-frontend/lib/keychain';
 import Uploader from '@send-frontend/lib/upload';
 import { hashFiles, streamZippedParts } from '@send-frontend/lib/utils';
 import { UserType } from '@send-frontend/types';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock dependencies
 vi.mock('@send-frontend/lib/filesync', () => ({
@@ -20,6 +20,15 @@ vi.mock('@send-frontend/lib/utils', () => ({
   hashFiles: vi.fn().mockResolvedValue(['abc123def456']),
   // Multipart path: a streaming producer yielding one {blob, hash} per window.
   streamZippedParts: vi.fn(),
+}));
+
+// doUpload pre-captures the OIDC access token (via a dynamic import) so the
+// pagehide teardown can send an authenticated cleanup — this is what makes the
+// cleanup work in the add-on, which has no backend cookie.
+vi.mock('@send-frontend/stores/auth-store', () => ({
+  useAuthStore: () => ({
+    getAccessToken: vi.fn().mockResolvedValue('test-bearer-token'),
+  }),
 }));
 
 // Builds the async generator the mocked streamZippedParts returns, yielding one
@@ -419,6 +428,12 @@ describe('Uploader', () => {
       vi.mocked(sendBlob).mockReset().mockResolvedValue('upload-id');
     });
 
+    // Restore any global stubbed within a test (e.g. the fetch stub used by the
+    // pagehide-teardown test) even if an assertion throws mid-test.
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
     it('passes an abort signal and an onUploadId reporter to each part', async () => {
       vi.mocked(streamZippedParts).mockImplementationOnce(() =>
         yieldParts(makeParts(2))
@@ -544,6 +559,66 @@ describe('Uploader', () => {
           mockProgressTracker
         )
       ).rejects.toThrow(/expected parts/);
+    });
+
+    it('sends an authenticated keepalive cleanup on pagehide while parts are in flight', async () => {
+      // Guards the add-on divergence: the teardown cleanup that fires when the
+      // user closes the tab/popup mid-upload must carry the Bearer token, since
+      // the add-on has no backend cookie for the raw `credentials: 'include'`
+      // fetch to rely on. A regression here would silently strand orphaned parts
+      // in the add-on only.
+      vi.mocked(streamZippedParts).mockImplementationOnce(() =>
+        yieldParts(makeParts(3))
+      );
+      mockApi.call = resolveDbCalls();
+
+      const fetchMock = vi.fn().mockResolvedValue(undefined);
+      vi.stubGlobal('fetch', fetchMock);
+
+      // Hold every part open so the upload is still in flight (and the pagehide
+      // listener still registered) when the page hides.
+      let releaseParts: () => void = () => {};
+      const gate = new Promise<void>((resolve) => {
+        releaseParts = resolve;
+      });
+      vi.mocked(sendBlob).mockImplementation(
+        async (blob, _key, _api, _tracker, _isBucket, options) => {
+          const id = `upload-${indexFromName(blob)}`;
+          options?.onUploadId?.(id); // populates writtenUploadIds before stalling
+          await gate;
+          return id;
+        }
+      );
+
+      const uploadPromise = uploader.doUpload(
+        makeSourceBlob(3),
+        'container-id',
+        mockApi,
+        mockProgressTracker
+      );
+
+      // Wait until at least one part has registered its upload id.
+      await vi.waitFor(() =>
+        expect(vi.mocked(sendBlob).mock.calls.length).toBeGreaterThan(0)
+      );
+
+      // User closes the tab/popup mid-upload.
+      window.dispatchEvent(new Event('pagehide'));
+
+      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalled());
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe('http://localhost/api/uploads/cleanup');
+      expect(init).toMatchObject({
+        method: 'POST',
+        keepalive: true,
+        headers: expect.objectContaining({
+          Authorization: 'Bearer test-bearer-token',
+        }),
+      });
+      expect(JSON.parse(init.body).ids.length).toBeGreaterThan(0);
+
+      releaseParts();
+      await uploadPromise;
     });
   });
 });

--- a/packages/send/frontend/src/test/lib/utils.test.ts
+++ b/packages/send/frontend/src/test/lib/utils.test.ts
@@ -1,4 +1,14 @@
-import { generateFileHash, getDaysUntilDate } from '@send-frontend/lib/utils';
+import { ApiConnection } from '@send-frontend/lib/api';
+import { NamedBlob } from '@send-frontend/types';
+import {
+  generateFileHash,
+  getDaysUntilDate,
+  sha256Hex,
+  streamZippedParts,
+  unzipArrayBuffer,
+  zipBlob,
+} from '@send-frontend/lib/utils';
+import JSZip from 'jszip';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 describe('generateFileHash', () => {
@@ -126,6 +136,176 @@ describe('generateFileHash', () => {
     results.forEach((hash) => {
       expect(hash).toBe(firstHash);
     });
+  });
+});
+
+describe('zipBlob', () => {
+  it('produces an application/zip Blob that round-trips through unzipArrayBuffer', async () => {
+    const original = 'hello world — round trip me';
+    const blob = new Blob([new TextEncoder().encode(original)]);
+
+    const zipped = await zipBlob(blob, 'hello.txt');
+    expect(zipped).toBeInstanceOf(Blob);
+    expect(zipped.type).toBe('application/zip');
+
+    const out = await unzipArrayBuffer(await zipped.arrayBuffer());
+    expect(new TextDecoder().decode(out)).toBe(original);
+  });
+
+  it('preserves binary content exactly', async () => {
+    const bytes = new Uint8Array(4096);
+    for (let i = 0; i < bytes.length; i++) bytes[i] = (i * 7) % 256;
+    const zipped = await zipBlob(new Blob([bytes]), 'data.bin');
+
+    const out = new Uint8Array(
+      await unzipArrayBuffer(await zipped.arrayBuffer())
+    );
+    expect(out.length).toBe(bytes.length);
+    expect(Array.from(out)).toEqual(Array.from(bytes));
+  });
+
+  it('is byte-identical to JSZip one-shot output (backwards compatible) and spans multiple chunks', async () => {
+    // Big enough that the STORE archive is emitted across several stream chunks,
+    // exercising the multi-member Blob assembly (the reason for the rewrite).
+    const bytes = new Uint8Array(512 * 1024);
+    for (let i = 0; i < bytes.length; i++) bytes[i] = (i * 31) % 256;
+
+    const streamedZip = await zipBlob(new Blob([bytes]), 'big.bin');
+    const streamed = new Uint8Array(await streamedZip.arrayBuffer());
+
+    // The pre-change implementation: one-shot generateAsync.
+    const jszip = new JSZip();
+    jszip.file('big.bin', new Blob([bytes]));
+    const oneShot = await jszip.generateAsync({ type: 'uint8array' });
+
+    expect(Array.from(streamed)).toEqual(Array.from(oneShot));
+  });
+
+  // The >2 GB case (the #981 crash: JSZip's one-shot blob output builds a single
+  // >2 GB Blob member and Firefox rejects it) is validated end-to-end by the e2e
+  // drag-drop test with a typeless 3 GB file — a 2 GB fixture is impractical in a
+  // unit test. This suite locks in that the streamed assembly stays byte-correct.
+});
+
+describe('streamZippedParts', () => {
+  // A fake API whose suspicious-file check always passes and records the hashes
+  // it was asked about.
+  const makeApi = (checked: string[]) =>
+    ({
+      call: vi.fn(async (path: string) => {
+        checked.push(path.replace('uploads/check-upload-hash/', ''));
+        return { isSuspicious: false };
+      }),
+    }) as unknown as ApiConnection;
+
+  const makeBlob = (size: number): NamedBlob => {
+    // Deterministic, non-uniform bytes so per-window hashes differ.
+    const bytes = new Uint8Array(size);
+    for (let i = 0; i < size; i++) bytes[i] = i % 251;
+    const blob = new Blob([bytes], { type: 'text/plain' }) as NamedBlob;
+    blob.name = 'source.bin';
+    return blob;
+  };
+
+  const collect = async (
+    blob: NamedBlob,
+    maxSize: number,
+    api: ApiConnection
+  ) => {
+    const hashProgress: number[] = [];
+    const parts: { blob: NamedBlob; hash: string }[] = [];
+    for await (const part of streamZippedParts(api, blob, maxSize, (n) =>
+      hashProgress.push(n)
+    )) {
+      parts.push(part);
+    }
+    return { parts, hashProgress };
+  };
+
+  it('splits a file into ceil(size / maxSize) windows across stream reads', async () => {
+    const api = makeApi([]);
+    const { parts } = await collect(makeBlob(250), 100, api);
+    // 250 bytes / 100 => 3 windows (100, 100, 50)
+    expect(parts).toHaveLength(3);
+  });
+
+  it('hashes the RAW bytes of each window (matching the per-chunk upload hash)', async () => {
+    const api = makeApi([]);
+    const source = makeBlob(250);
+    const { parts } = await collect(source, 100, api);
+
+    const buf = new Uint8Array(await source.arrayBuffer());
+    const boundaries = [
+      [0, 100],
+      [100, 200],
+      [200, 250],
+    ];
+    for (let i = 0; i < boundaries.length; i++) {
+      const [start, end] = boundaries[i];
+      const expected = await sha256Hex(buf.slice(start, end).buffer);
+      expect(parts[i].hash).toBe(expected);
+    }
+  });
+
+  it('yields zipped parts that unzip back to the exact raw window bytes', async () => {
+    const api = makeApi([]);
+    const source = makeBlob(250);
+    const { parts } = await collect(source, 100, api);
+
+    const buf = new Uint8Array(await source.arrayBuffer());
+    const boundaries = [
+      [0, 100],
+      [100, 200],
+      [200, 250],
+    ];
+    for (let i = 0; i < parts.length; i++) {
+      const [start, end] = boundaries[i];
+      const out = new Uint8Array(
+        await unzipArrayBuffer(await parts[i].blob.arrayBuffer())
+      );
+      expect(Array.from(out)).toEqual(Array.from(buf.slice(start, end)));
+    }
+  });
+
+  it('runs the suspicious-file check once per window and reports cumulative progress', async () => {
+    const checked: string[] = [];
+    const api = makeApi(checked);
+    const { parts, hashProgress } = await collect(makeBlob(250), 100, api);
+
+    expect(checked).toEqual(parts.map((p) => p.hash));
+    expect(hashProgress).toEqual([100, 200, 250]);
+  });
+
+  it('yields a single part for a file that fits in one window', async () => {
+    const api = makeApi([]);
+    const { parts } = await collect(makeBlob(40), 100, api);
+    expect(parts).toHaveLength(1);
+  });
+
+  it('aborts as soon as a window is flagged suspicious', async () => {
+    vi.stubGlobal('alert', vi.fn());
+    let seen = 0;
+    const api = {
+      call: vi.fn(async () => {
+        seen++;
+        return { isSuspicious: seen === 2 };
+      }),
+    } as unknown as ApiConnection;
+
+    await expect(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      for await (const _ of streamZippedParts(
+        api,
+        makeBlob(250),
+        100,
+        () => {}
+      )) {
+        // drain
+      }
+    }).rejects.toThrow('Suspicious file detected');
+    // Stopped at the second window; never checked the third.
+    expect(seen).toBe(2);
+    vi.unstubAllGlobals();
   });
 });
 


### PR DESCRIPTION
## What changed?

The best-effort **teardown cleanup** that removes already-written multipart parts when a user closes the tab/popup mid-upload (`Uploader.teardownCleanup` in `packages/send/frontend/src/lib/upload.ts`) now authenticates with the OIDC **Bearer token** instead of relying on a cookie.

- `doUpload` pre-captures the access token at upload start (via the same dynamic-import-of-`auth-store` pattern `lib/api.ts` uses), because `getAccessToken()` is async and can't be awaited at the `pagehide` unload event.
- `teardownCleanup` attaches `Authorization: Bearer <token>` on its `keepalive` fetch, keeping `credentials: 'include'` as the web cookie fallback.
- Adds a regression test asserting that a `pagehide` during an in-flight multipart upload issues an authenticated keepalive `POST /api/uploads/cleanup` with the Bearer header.

**AI disclosure:** Substantially agent-written by Claude Code (Anthropic, Opus 4.8) under human direction — the human set the scope, chose to base the change on #984, and reviewed the diff (including a senior-review pass whose findings were applied). ~2 files, +114/−7.

## Why?

The Send web app authenticates with cookies, but the Thunderbird **add-on** authenticates via an OIDC Bearer token bridge and has **no usable backend cookie** in its extension-popup origin. So the cookie-only teardown fetch 401'd in the add-on — meaning the orphaned-part cleanup from #965 was effectively **web-only**, and cancel/tab-close mid-upload stranded bytes in the bucket for add-on users. This makes cancel/close cleanup behave identically in both surfaces, so we maintain one upload workflow.

## Limitations and Notes

- **Best-effort, unchanged contract:** cleanup remains fire-and-forget with the server-side reaper as the backstop. For an upload that outlives the access-token lifetime the captured token can be stale at unload (you can't refresh at `pagehide`); the reaper covers that case.
- **Based on #984, not `main`:** this branch targets `fix/stream-large-file-uploads` so the diff shows only this change. The test uses that PR's `streamZippedParts` producer model. Retarget to `main` once #984 merges.

## Applicable Issues

Relates to #887 (multipart orphaned-storage cleanup).

## Screenshots

No UI change.