### PR TITLE
fix(telemetry): scrub access-link secret from Sentry breadcrumbs & request URLs

### DIFF
--- a/packages/send/docs/TelemetryOptOut.md
+++ b/packages/send/docs/TelemetryOptOut.md
@@ -66,7 +66,10 @@ to Send tabs when the prefs change. `token-bridge.js` relays both between
 ### Sentry & PostHog
 
 - `sentry.ts` — `initSentry(app)` runs only with consent; session replay removed,
-  `sendDefaultPii: false`, `beforeSend` scrubs identity and request payloads.
+  `sendDefaultPii: false`, `beforeSend` (`scrubEvent`) scrubs identity and request
+  payloads and strips the query/fragment from `request.url`, and `beforeBreadcrumb`
+  (`scrubBreadcrumb`) strips the query and fragment from auto-captured breadcrumb
+  URLs (`data.url`/`to`/`from`) — the access-link secret lives in the URL fragment.
   `closeSentry()` tears down on runtime opt-out.
 - `posthog.js` — `init()` is deferred until first opt-in; `setPosthogConsent()`
   opts in/out at runtime.

--- a/packages/send/frontend/src/lib/sentry.test.ts
+++ b/packages/send/frontend/src/lib/sentry.test.ts
@@ -1,0 +1,82 @@
+import * as Sentry from '@sentry/vue';
+import { describe, expect, it } from 'vitest';
+import { scrubBreadcrumb, scrubEvent } from './sentry';
+
+describe('scrubEvent', () => {
+  it('drops user identity and sensitive request payloads', () => {
+    const event = {
+      user: { id: 'user-123', email: 'a@b.com' },
+      request: {
+        url: 'https://send.tb.pro/download/abc',
+        cookies: { session: 'secret' },
+        headers: { Authorization: 'Bearer token' },
+        query_string: 'token=secret',
+        data: { password: 'hunter2' },
+      },
+    } as unknown as Sentry.ErrorEvent;
+
+    const scrubbed = scrubEvent(event);
+
+    expect(scrubbed.user).toBeUndefined();
+    expect(scrubbed.request?.cookies).toBeUndefined();
+    expect(scrubbed.request?.headers).toBeUndefined();
+    expect(scrubbed.request?.query_string).toBeUndefined();
+    expect(scrubbed.request?.data).toBeUndefined();
+    expect(scrubbed.request?.url).toBe('https://send.tb.pro/download/abc');
+  });
+
+  it('strips the access-link secret (fragment) and query from request.url', () => {
+    const event = {
+      request: { url: 'https://send.tb.pro/download/abc?t=1#s3cretKey' },
+    } as unknown as Sentry.ErrorEvent;
+    expect(scrubEvent(event).request?.url).toBe(
+      'https://send.tb.pro/download/abc'
+    );
+  });
+
+  it('is a no-op when there is no user or request', () => {
+    const event = { message: 'boom' } as Sentry.ErrorEvent;
+    expect(scrubEvent(event)).toEqual({ message: 'boom' });
+  });
+});
+
+describe('scrubBreadcrumb', () => {
+  it('strips the fragment secret from navigation breadcrumbs (to/from)', () => {
+    const breadcrumb = {
+      category: 'navigation',
+      data: { from: '/upload?token=t', to: '/download/abc#s3cretKey' },
+    } as Sentry.Breadcrumb;
+
+    const scrubbed = scrubBreadcrumb(breadcrumb);
+
+    expect(scrubbed.data?.to).toBe('/download/abc');
+    expect(scrubbed.data?.from).toBe('/upload');
+  });
+
+  it('strips query and fragment from fetch/xhr breadcrumb URLs', () => {
+    const breadcrumb = {
+      category: 'fetch',
+      data: {
+        url: 'https://send.tb.pro/api?token=secret#frag',
+        status_code: 200,
+      },
+    } as Sentry.Breadcrumb;
+
+    const scrubbed = scrubBreadcrumb(breadcrumb);
+
+    expect(scrubbed.data?.url).toBe('https://send.tb.pro/api');
+    // Other breadcrumb data is preserved.
+    expect(scrubbed.data?.status_code).toBe(200);
+  });
+
+  it('leaves breadcrumbs without a URL untouched', () => {
+    const breadcrumb = {
+      category: 'ui.click',
+      message: 'button',
+    } as Sentry.Breadcrumb;
+    expect(scrubBreadcrumb(breadcrumb)).toEqual({
+      category: 'ui.click',
+      message: 'button',
+    });
+  });
+});

--- a/packages/send/frontend/src/lib/sentry.ts
+++ b/packages/send/frontend/src/lib/sentry.ts
@@ -8,6 +8,58 @@ const TRACING_LEVELS_DEV = ['error', 'warn', 'debug'];
 
 const isProduction = import.meta.env.MODE === 'production';
 
+/**
+ * Drops the query string and fragment from a URL. Send access links carry the
+ * decryption secret in the URL fragment (as split off by
+ * `getAccessLinkWithoutPasswordHash` in lib/utils.ts) and query params can carry
+ * tokens, so neither may reach Sentry. See issue #892 / #990.
+ */
+function stripUrlSecrets(url: string): string {
+  return url.split(/[?#]/)[0];
+}
+
+/**
+ * Scrubs user identity and sensitive request payloads from an outgoing event.
+ * Extracted so the privacy hardening is unit-testable independently of
+ * Sentry.init.
+ */
+export function scrubEvent(event: Sentry.ErrorEvent): Sentry.ErrorEvent {
+  delete event.user;
+  if (event.request) {
+    delete event.request.cookies;
+    delete event.request.headers;
+    delete event.request.query_string;
+    delete event.request.data;
+    // request.url is the full href, which includes the access-link secret in
+    // its fragment; keep the path for context but strip the rest.
+    if (typeof event.request.url === 'string') {
+      event.request.url = stripUrlSecrets(event.request.url);
+    }
+  }
+  return event;
+}
+
+/**
+ * Scrubs auto-captured breadcrumbs before they attach to an event. Navigation
+ * breadcrumbs record the URL in `data.to`/`data.from` and fetch/xhr breadcrumbs
+ * in `data.url`; each can carry the access-link secret (fragment) or tokens
+ * (query string). Keep the breadcrumb for debugging context but strip those.
+ * See issue #892 / #990.
+ */
+export function scrubBreadcrumb(
+  breadcrumb: Sentry.Breadcrumb
+): Sentry.Breadcrumb {
+  const { data } = breadcrumb;
+  if (data) {
+    for (const key of ['url', 'to', 'from'] as const) {
+      if (typeof data[key] === 'string') {
+        data[key] = stripUrlSecrets(data[key]);
+      }
+    }
+  }
+  return breadcrumb;
+}
+
 let initialized = false;
 
 export const initSentry = (app: App) => {
@@ -24,6 +76,9 @@ export const initSentry = (app: App) => {
       Sentry.browserTracingIntegration(),
       // Session Replay is intentionally NOT enabled: it records DOM contents
       // and input, which can capture PII. See issue #892 (privacy hardening).
+      // Console capture stays on: messages are developer-authored log
+      // statements, not auto-captured user data. Auto-captured breadcrumbs are
+      // scrubbed via beforeBreadcrumb below.
       Sentry.captureConsoleIntegration({
         levels: isProduction ? TRACING_LEVELS_PROD : TRACING_LEVELS_DEV,
       }),
@@ -33,19 +88,12 @@ export const initSentry = (app: App) => {
     // Set 'tracePropagationTargets' to control for which URLs distributed tracing should be enabled
     // tracePropagationTargets: ['localhost', /^https:\/\/yourserver\.io\/api/],
     environment: import.meta.env.MODE,
-    // Privacy hardening: never attach default PII, and scrub user identity /
-    // request payloads from outgoing events.
+    // Privacy hardening: never attach default PII, scrub user identity /
+    // request payloads from outgoing events, and strip access-link secrets and
+    // tokens from auto-captured breadcrumb URLs.
     sendDefaultPii: false,
-    beforeSend(event) {
-      delete event.user;
-      if (event.request) {
-        delete event.request.cookies;
-        delete event.request.headers;
-        delete event.request.query_string;
-        delete event.request.data;
-      }
-      return event;
-    },
+    beforeSend: scrubEvent,
+    beforeBreadcrumb: scrubBreadcrumb,
   });
 
   Sentry.setTag('environmentName', getEnvironmentName(import.meta.env));


### PR DESCRIPTION
## What changed?

Follow-up to #954 (telemetry opt-out). Even with telemetry enabled, Sentry was
capturing the **Send access-link secret** and query-string tokens through two
paths that the #954 `beforeSend` scrub didn't cover:

- **Auto-captured breadcrumbs** — navigation breadcrumbs store the URL in
  `data.to`/`data.from` and fetch/xhr breadcrumbs in `data.url`.
- **`event.request.url`** — the full href, which the previous `beforeSend` left
  untouched (it only dropped cookies/headers/query_string/data).

The Send access-link secret lives in the URL **fragment** (`#…`), as confirmed by
`getAccessLinkWithoutPasswordHash` in `lib/utils.ts`, so any breadcrumb or event
URL for a download page leaked it.

- Add `stripUrlSecrets()` (splits on `/[?#]/`) and wire `beforeBreadcrumb`
  (`scrubBreadcrumb`) to strip the query + fragment from `data.url`/`to`/`from`.
- Extract the inline `beforeSend` into an exported `scrubEvent()` and extend it
  to strip the query + fragment from `event.request.url`.
- Keep `captureConsoleIntegration` (console messages are developer-authored logs,
  not auto-captured user data).
- Add `sentry.test.ts` unit-testing the navigation, fetch, and `request.url` leak
  paths; update `TelemetryOptOut.md`.

<sub>**AI disclosure:** implemented with Claude Code (agent-written) under close
human direction — the author scoped the change, and it was reviewed by an
automated senior-code-reviewer pass that caught the fragment/navigation gap. This
description was AI-drafted and human-reviewed.</sub>

## Why?

Privacy hardening for #892: an opted-in user should still never have download
secrets or tokens shipped to Sentry via breadcrumbs or the request URL. Without
this, opening a password-protected Send link records the secret fragment in a
Sentry breadcrumb.

## Limitations and Notes

- Console **message** content remains developer-controlled (the team should avoid
  logging PII); `captureConsoleIntegration` is intentionally kept for debugging.
- Finding #2 from the #990 review (a theoretical opt-out→opt-in teardown race)
  was investigated and found **benign** — `Sentry.close()` acts on the client
  captured at call time and a later `init()` creates an independent client — so
  no code change was made there.

## Applicable Issues

- Closes #990
- Refs #892, #954

## Screenshots

N/A — non-visual telemetry scrubbing. Verified via unit tests
(`sentry.test.ts`); `tsc` and ESLint clean.
