### PR TITLE
fix(send): correct Restore Keys passphrase placeholder to 6 words

### DIFF
--- a/packages/send/frontend/src/apps/send/views/RestoreKeys.vue
+++ b/packages/send/frontend/src/apps/send/views/RestoreKeys.vue
@@ -65,7 +65,7 @@ const onContinue = async () => {
               v-model="encryptionKey"
               type="text"
               class="passphrase-input"
-              placeholder="text - text - text - text"
+              placeholder="text - text - text - text - text - text"
               data-testid="restore-key-input"
             />
           </div>


### PR DESCRIPTION
## What changed?

Updated the passphrase input placeholder on the Restore Keys screen (`packages/send/frontend/src/apps/send/views/RestoreKeys.vue`) from `text - text - text - text` (4 word slots) to `text - text - text - text - text - text` (6 word slots).

This was a one-line placeholder/copy change written with AI assistance (Claude Code); the reasoning, verification, and review were done in collaboration with the author. No logic was modified.

## Why?

`parsePassphrase` in `packages/send/frontend/src/lib/passphraseUtils.ts` requires **exactly 6 words** and throws `Expected 6 words, got N` otherwise. The placeholder showed only 4 word slots, misleading users into entering too few words and hitting a confusing validation error. The placeholder now matches the actual requirement.

## Limitations and Notes

None. Purely a UI copy fix — no logic or tests affected.

## Applicable Issues

Closes #993

## Screenshots
<img width="712" height="531" alt="Screenshot 2026-07-13 at 1 23 15 PM" src="https://github.com/user-attachments/assets/30661fcd-9498-498e-affb-121690592465" />

N/A — placeholder text now reads `text - text - text - text - text - text`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)