### PR TITLE
fix(addon): close Send tabs on explicit logout

### DIFF
--- a/packages/addon/src/menu.ts
+++ b/packages/addon/src/menu.ts
@@ -128,10 +128,29 @@ export async function menuLogout() {
 
   console.log('✅ Cleared extension storage');
 
+  // Close any stale Send tabs left on the now-ended session, then open the
+  // logout page (kept open so it can clear the web session).
+  await closeAllAddOnTabs();
+
   // Open logout page to complete sign-out process
   await browser.tabs.create({
     url: `${BASE_URL}/logout`,
   });
+}
+
+// Close any tabs still pointing at the Send web app. Called only on genuine
+// logout (menuLogout) — never from the getLoginState() probe (see #948/#949).
+async function closeAllAddOnTabs() {
+  const tabs = await browser.tabs.query({});
+  for (const tab of tabs) {
+    if (tab.id && tab.url?.startsWith(BASE_URL)) {
+      try {
+        await browser.tabs.remove(tab.id);
+      } catch {
+        console.warn(`Could not close Send tab with id ${tab.id}`);
+      }
+    }
+  }
 }
 
 /*

--- a/packages/addon/src/test/menu.test.ts
+++ b/packages/addon/src/test/menu.test.ts
@@ -1,7 +1,8 @@
+import { BASE_URL } from '@send-frontend/apps/common/constants';
 import { STORAGE_KEY_AUTH } from '@send-frontend/lib/const';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { getLoginState } from '../menu';
+import { getLoginState, menuLogout } from '../menu';
 
 /**
  * Regression guard: getLoginState() is a read-only probe (called by the Send
@@ -10,24 +11,30 @@ import { getLoginState } from '../menu';
  * (short-lived `expires_at`) is NOT logged out — the web app refreshes it
  * silently with the refresh_token — so it must keep returning isLoggedIn: true
  * and leave open send.tb.pro tabs alone. Previously the expiry branch called
- * closeAllTbProTabs(), which closed the Send dashboard tab opened from the
+ * closeAllAddOnTabs(), which closed the Send dashboard tab opened from the
  * accounts dashboard.
  */
 
 const USERNAME = 'user@example.com';
 
-function setupBrowserMock(authValue: unknown) {
+function setupBrowserMock(
+  authValue: unknown,
+  tabs: Array<{ id?: number; url?: string }> = []
+) {
   vi.stubGlobal('browser', {
     storage: {
       local: {
-        get: vi.fn().mockResolvedValue(
-          authValue === undefined ? {} : { [STORAGE_KEY_AUTH]: authValue }
-        ),
+        get: vi
+          .fn()
+          .mockResolvedValue(
+            authValue === undefined ? {} : { [STORAGE_KEY_AUTH]: authValue }
+          ),
         remove: vi.fn().mockResolvedValue(undefined),
         clear: vi.fn().mockResolvedValue(undefined),
       },
     },
     tabs: {
+      query: vi.fn().mockResolvedValue(tabs),
       remove: vi.fn().mockResolvedValue(undefined),
       create: vi.fn().mockResolvedValue({ id: 1 }),
     },
@@ -106,5 +113,68 @@ describe('getLoginState', () => {
 
     expect(state).toEqual({ isLoggedIn: false, username: null });
     expect(browser.tabs.remove).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * menuLogout() is the genuine-logout chokepoint (menu Logout click + SIGN_OUT
+ * message). Unlike getLoginState(), it MAY have destructive side effects: it
+ * closes stale Send tabs left on the now-ended session. It must only close tabs
+ * pointing at the Send web app (BASE_URL) and must still open the /logout page.
+ */
+describe('menuLogout', () => {
+  it('closes only Send tabs and leaves unrelated tabs alone', async () => {
+    setupBrowserMock(undefined, [
+      { id: 1, url: `${BASE_URL}/send/profile` },
+      { id: 2, url: `${BASE_URL}/logout` },
+      { id: 3, url: 'https://accounts.tb.pro/dashboard' },
+      { id: 4, url: 'https://example.com/' },
+      { id: 5, url: undefined },
+    ]);
+
+    await menuLogout();
+
+    expect(browser.tabs.remove).toHaveBeenCalledWith(1);
+    expect(browser.tabs.remove).toHaveBeenCalledWith(2);
+    expect(browser.tabs.remove).not.toHaveBeenCalledWith(3);
+    expect(browser.tabs.remove).not.toHaveBeenCalledWith(4);
+    expect(browser.tabs.remove).toHaveBeenCalledTimes(2);
+  });
+
+  it('opens the logout page and clears storage after closing tabs', async () => {
+    setupBrowserMock(undefined, [{ id: 1, url: `${BASE_URL}/send` }]);
+
+    await menuLogout();
+
+    expect(browser.storage.local.clear).toHaveBeenCalled();
+    expect(browser.tabs.create).toHaveBeenCalledWith({
+      url: `${BASE_URL}/logout`,
+    });
+
+    // Order is load-bearing: the freshly opened /logout tab also matches
+    // startsWith(BASE_URL), so tabs must be closed BEFORE it is created or it
+    // would be swept up and logout would break.
+    const removeOrder = (browser.tabs.remove as ReturnType<typeof vi.fn>).mock
+      .invocationCallOrder[0];
+    const createOrder = (browser.tabs.create as ReturnType<typeof vi.fn>).mock
+      .invocationCallOrder[0];
+    expect(removeOrder).toBeLessThan(createOrder);
+  });
+
+  it('keeps closing tabs and opens logout even if one removal fails', async () => {
+    setupBrowserMock(undefined, [
+      { id: 1, url: `${BASE_URL}/a` },
+      { id: 2, url: `${BASE_URL}/b` },
+    ]);
+    (browser.tabs.remove as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error('cannot remove')
+    );
+
+    await menuLogout();
+
+    expect(browser.tabs.remove).toHaveBeenCalledTimes(2);
+    expect(browser.tabs.create).toHaveBeenCalledWith({
+      url: `${BASE_URL}/logout`,
+    });
   });
 });


### PR DESCRIPTION
## What changed?

Restore "close all Send tabs on logout" behavior, scoped to the genuine-logout path.

- Add `closeAllAddOnTabs()` to `packages/addon/src/menu.ts`, called from `menuLogout()` **before** the `/logout` tab is opened. It closes every tab whose URL starts with `BASE_URL` (the Send web app).
- `menuLogout()` is the single chokepoint for all genuine logout, so this covers both the TBPro menu **Sign out** click and web-app-initiated logout inside Thunderbird — the Send web app posts `SIGN_OUT`, which is relayed by `token-bridge.js` → `background.ts` (`case SIGN_OUT` → `menuLogout()`).
- `getLoginState()` is deliberately left untouched — it stays a read-only probe (polled every 60s and by the Send route guard), so this does **not** reintroduce #948.
- Tests added in `packages/addon/src/test/menu.test.ts` covering: only `BASE_URL` tabs are closed (accounts.tb.pro / unrelated / URL-less tabs untouched); the `/logout` tab still opens and storage still clears; removal happens **before** the `/logout` tab is created; and one failed `tabs.remove` doesn't abort the rest.

**AI disclosure:** This change was written by Claude (Opus 4.8) via Claude Code, under interactive human direction and review. I (the author) reviewed the diff, ran the tests, ran a code-review pass, and directed the design decisions (scope = Send tabs only, placement on the `menuLogout()` chokepoint, ordering guarantee). The tab-closing name (`closeAllAddOnTabs`) and the approach were reviewed by a human.

## Why?

Commit f20c40e4 (#949) correctly removed the destructive `closeAllTbProTabs()` call from the `getLoginState()` probe, which had been closing Send tabs on routine access-token expiry (#948). But that left no tab cleanup on real logout, so Send tabs now linger in a signed-out/dead-session state after the user logs out. This restores the useful half of the old behavior on the correct, non-probe path.

## How to test

**Automated:**

```
cd packages/addon && pnpm exec vitest run src/test/menu.test.ts
```

All 8 tests pass, including coverage that only `BASE_URL` tabs close, that the `/logout` tab still opens, that closing happens *before* the `/logout` tab is created, and that a failed `tabs.remove` doesn't abort the rest.

**Manual (in Thunderbird, e.g. Daily via `debug-local.sh`):**

1. Sign in to Thunderbird Pro via the TBPro menu.
2. Open one or more Send tabs (TBPro menu → "Manage Send", or open the Send dashboard from the accounts dashboard).
3. Log out via the TBPro menu → "Sign out".
   - ✅ Expected: all Send (`send.tb.pro` / `BASE_URL`) tabs close, a fresh `/logout` page opens, and the menu returns to the signed-out state.
4. Sign back in, reopen one or more Send tabs, then log out from the **Send web app's own user menu** (Sign out) instead.
   - ✅ Expected: same result — the web-app `SIGN_OUT` path also closes the Send tabs.
5. Regression check for #948: while signed in with Send tabs open, leave the session idle past the access-token expiry (or wait for the 60s login-state probe to run).
   - ✅ Expected: tabs stay open and you remain logged in — the probe never closes tabs.

## Limitations and Notes

- Scope is intentionally **Send tabs only** (`BASE_URL`). The accounts.tb.pro dashboard tab is left open.
- When logging out from the Send web UI, the current tab is itself a `BASE_URL` tab and will be closed; `menuLogout()` then opens a fresh `/logout` tab to finish clearing the web/OIDC session. This matches the intended behavior.

## Applicable Issues

Closes #995

## Screenshots

N/A — no UI surface changed (tab lifecycle only).
