### PR TITLE
test(addon): add fake Thunderbird host harness for integration tests

### DIFF
--- a/packages/addon/src/test/integration/fakeThunderbirdHost.ts
+++ b/packages/addon/src/test/integration/fakeThunderbirdHost.ts
@@ -1,0 +1,383 @@
+/**
+ * Fake Thunderbird multi-context host for integration tests.
+ *
+ * Simulates the 3 JS-only WebExtension execution contexts that exist in a
+ * real running Thunderbird instance for this add-on:
+ *   - "background": the non-persistent background page (background.ts)
+ *   - "popup": the upload popup window (PopupView.vue / useUploadAndShare.ts)
+ *   - "web": a plain browser tab running the hosted send.tb.pro web app,
+ *     bridged into the extension via token-bridge.js content script
+ *
+ * Each context gets its OWN independent `browser` mock object (mirroring the
+ * real platform, where each JS realm has its own `browser.*` binding), but
+ * they all share ONE fake `browser.storage.local` backing store with real
+ * `storage.onChanged` event firing — this is the actual cross-context sync
+ * primitive in production (see shared-pinia.ts's per-context-singleton
+ * comment), so a real shared store (not per-context stubs) is essential for
+ * these tests to be meaningful.
+ *
+ * `browser.runtime.sendMessage` calls from any context fan out to every
+ * OTHER context's registered `onMessage` listeners, exactly like real
+ * WebExtension messaging (a message sent from a page context is delivered to
+ * the background and all other extension pages, not back to the sender).
+ *
+ * This harness deliberately does NOT implement `browser.TBProMenu`,
+ * `browser.CloudFileAccounts`, `browser.MailAccounts`, or `browser.AccountHub`
+ * with real behavior — those are privileged chrome UI/experiment APIs that
+ * only exist inside a real Thunderbird process (see
+ * ADDON-INTEGRATION-TEST-ENV-PLAN-2026-07-22.md, Tier 2/3). Here they are
+ * spies: we only assert that the right calls happened with the right args at
+ * the right time, which is what the sync-race findings actually depend on.
+ */
+import { vi } from 'vitest';
+
+type Listener = (message: any, sender?: any) => any;
+type StorageChangeListener = (
+  changes: Record<string, { oldValue?: any; newValue?: any }>
+) => void;
+type WindowRemovedListener = (windowId: number) => void;
+
+export interface FakeStorageBacking {
+  data: Record<string, any>;
+  changeListeners: StorageChangeListener[];
+}
+
+/** Creates one shared storage.local backing store used by ALL contexts. */
+function createSharedStorage(): FakeStorageBacking {
+  return { data: {}, changeListeners: [] };
+}
+
+function fireStorageChange(
+  backing: FakeStorageBacking,
+  changes: Record<string, { oldValue?: any; newValue?: any }>
+) {
+  for (const listener of backing.changeListeners) {
+    listener(changes);
+  }
+}
+
+/** Applies `apply` per key, collecting an onChanged-shaped diff, and fires it if non-empty. */
+function mutateAndFireChange(
+  backing: FakeStorageBacking,
+  keys: string[],
+  apply: (key: string) => { oldValue: any; newValue: any } | undefined
+) {
+  const changes: Record<string, { oldValue?: any; newValue?: any }> = {};
+  for (const key of keys) {
+    const change = apply(key);
+    if (change) changes[key] = change;
+  }
+  if (Object.keys(changes).length > 0) fireStorageChange(backing, changes);
+}
+
+export interface FakeWindow {
+  id: number;
+  url: string;
+  type: string;
+}
+
+export interface SharedWindowState {
+  windows: Map<number, FakeWindow>;
+  nextId: number;
+  removedListeners: WindowRemovedListener[];
+  /** Resolvers for windows.create() calls that are being held open by a test. */
+  pendingCreates: Array<{ resolve: (w: FakeWindow) => void }>;
+}
+
+function createSharedWindowState(): SharedWindowState {
+  return {
+    windows: new Map(),
+    nextId: 1,
+    removedListeners: [],
+    pendingCreates: [],
+  };
+}
+
+export interface FakeTab {
+  id: number;
+  url?: string;
+}
+
+export interface SharedTabState {
+  tabs: Map<number, FakeTab>;
+  nextId: number;
+}
+
+function createSharedTabState(): SharedTabState {
+  return { tabs: new Map(), nextId: 1 };
+}
+
+export interface FakeBrowserContext {
+  name: string;
+  browser: any;
+  /** Manually invoke this context's registered runtime.onMessage listeners. */
+  deliverMessage: (message: any, sender?: any) => Promise<any[]>;
+  onMessageListeners: Listener[];
+  /** Listeners registered via browser.cloudFile.onFileUpload.addListener(). */
+  onFileUploadListeners: Array<(tab: any, fileInfo: any) => any>;
+  /** Listeners registered via browser.cloudFile.onFileUploadAbort.addListener(). */
+  onFileUploadAbortListeners: Array<(tab: any, id: number) => any>;
+  /** Listeners registered via browser.windows.onRemoved.addListener(). */
+  onWindowRemovedListeners: WindowRemovedListener[];
+  /** Listeners registered via browser.storage.onChanged.addListener() for this context. */
+  onStorageChangedListeners: StorageChangeListener[];
+  /** Helper: fire this context's onFileUpload listeners as Thunderbird would. */
+  triggerFileUpload: (fileInfo: {
+    id: number;
+    name: string;
+    data: any;
+  }) => Promise<any>;
+}
+
+export interface FakeHost {
+  storage: FakeStorageBacking;
+  windowState: SharedWindowState;
+  tabState: SharedTabState;
+  contexts: Map<string, FakeBrowserContext>;
+  /** Create a new simulated context (e.g. 'background', 'popup', 'web'). */
+  createContext: (name: string) => FakeBrowserContext;
+  /** Fan a runtime.sendMessage call from `fromContext` out to all others. */
+  broadcast: (fromContext: string, message: any, sender?: any) => Promise<any>;
+}
+
+/**
+ * Builds a new fake host with a shared storage/window/tab backing.
+ * Call `createContext(name)` for each simulated execution context.
+ */
+export function createFakeThunderbirdHost(): FakeHost {
+  const storage = createSharedStorage();
+  const windowState = createSharedWindowState();
+  const tabState = createSharedTabState();
+  const contexts = new Map<string, FakeBrowserContext>();
+
+  function broadcast(fromContext: string, message: any, sender?: any) {
+    const results: any[] = [];
+    for (const [name, ctx] of contexts) {
+      if (name === fromContext) continue;
+      for (const listener of ctx.onMessageListeners) {
+        try {
+          const result = listener(message, sender);
+          results.push(result);
+        } catch (e) {
+          // Mirror real WebExtension behavior: a throwing listener doesn't
+          // block delivery to other listeners/contexts.
+          console.warn(`[fakeHost] listener in ${name} threw:`, e);
+        }
+      }
+    }
+    // Real sendMessage resolves with the first defined response, or
+    // undefined if no listener responded.
+    return Promise.resolve(results.find((r) => r !== undefined));
+  }
+
+  function createContext(name: string): FakeBrowserContext {
+    const onMessageListeners: Listener[] = [];
+    const onFileUploadListeners: Array<(tab: any, fileInfo: any) => any> = [];
+    const onFileUploadAbortListeners: Array<(tab: any, id: number) => any> = [];
+    const onWindowRemovedListeners: WindowRemovedListener[] = [];
+    const onStorageChangedListeners: StorageChangeListener[] = [];
+
+    const browserMock: any = {
+      storage: {
+        local: {
+          get: vi.fn(async (keys?: string | string[] | null) => {
+            if (keys === undefined || keys === null) {
+              return { ...storage.data };
+            }
+            const keyList = Array.isArray(keys) ? keys : [keys];
+            const result: Record<string, any> = {};
+            for (const k of keyList) {
+              if (k in storage.data) result[k] = storage.data[k];
+            }
+            return result;
+          }),
+          set: vi.fn(async (items: Record<string, any>) => {
+            mutateAndFireChange(storage, Object.keys(items), (k) => {
+              const change = { oldValue: storage.data[k], newValue: items[k] };
+              storage.data[k] = items[k];
+              return change;
+            });
+          }),
+          remove: vi.fn(async (keys: string | string[]) => {
+            const keyList = Array.isArray(keys) ? keys : [keys];
+            mutateAndFireChange(storage, keyList, (k) => {
+              if (!(k in storage.data)) return undefined;
+              const change = { oldValue: storage.data[k], newValue: undefined };
+              delete storage.data[k];
+              return change;
+            });
+          }),
+          clear: vi.fn(async () => {
+            const keys = Object.keys(storage.data);
+            mutateAndFireChange(storage, keys, (k) => ({
+              oldValue: storage.data[k],
+              newValue: undefined,
+            }));
+            storage.data = {};
+          }),
+        },
+        onChanged: {
+          addListener: vi.fn((fn: StorageChangeListener) => {
+            storage.changeListeners.push(fn);
+            onStorageChangedListeners.push(fn);
+          }),
+        },
+      },
+      runtime: {
+        id: 'fake-addon-id',
+        onMessage: {
+          addListener: vi.fn((fn: Listener) => {
+            onMessageListeners.push(fn);
+          }),
+        },
+        onInstalled: {
+          addListener: vi.fn(),
+        },
+        sendMessage: vi.fn((message: any) => broadcast(name, message)),
+        getURL: vi.fn((path: string) => `moz-extension://fake-id/${path}`),
+        getBrowserInfo: vi.fn(async () => ({ version: '145.0' })),
+      },
+      windows: {
+        // The `{url, type}` argument isn't inspected here -- the fake
+        // deliberately never auto-resolves windows.create() so tests can
+        // control exactly when it settles via resolveNextWindowCreate(),
+        // to exercise check-then-act races (B3).
+        create: vi.fn(async (_opts: { url: string; type: string }) => {
+          return new Promise<FakeWindow>((resolve) => {
+            windowState.pendingCreates.push({
+              resolve: (w) => resolve(w),
+            });
+          });
+        }),
+        onRemoved: {
+          addListener: vi.fn((fn: WindowRemovedListener) => {
+            windowState.removedListeners.push(fn);
+            onWindowRemovedListeners.push(fn);
+          }),
+        },
+        getAll: vi.fn(async () => Array.from(windowState.windows.values())),
+      },
+      tabs: {
+        create: vi.fn(async (opts: { url: string }) => {
+          const id = tabState.nextId++;
+          const tab: FakeTab = { id, url: opts.url };
+          tabState.tabs.set(id, tab);
+          return tab;
+        }),
+        query: vi.fn(async () => Array.from(tabState.tabs.values())),
+        remove: vi.fn(async (id: number) => {
+          tabState.tabs.delete(id);
+        }),
+        get: vi.fn(async (id: number) => {
+          const tab = tabState.tabs.get(id);
+          if (!tab) throw new Error('No tab with id ' + id);
+          return tab;
+        }),
+        sendMessage: vi.fn(async () => undefined),
+      },
+      cloudFile: {
+        onFileUpload: {
+          addListener: vi.fn((fn: (tab: any, fileInfo: any) => any) => {
+            onFileUploadListeners.push(fn);
+          }),
+        },
+        onFileUploadAbort: {
+          addListener: vi.fn((fn: (tab: any, id: number) => any) => {
+            onFileUploadAbortListeners.push(fn);
+          }),
+        },
+        getAllAccounts: vi.fn(async () => []),
+      },
+      CloudFileAccounts: {
+        registerProvider: vi.fn(async () => {}),
+        unregisterProvider: vi.fn(async () => {}),
+        createAccount: vi.fn(async () => ({ accountId: 'acct-1' })),
+      },
+      TBProMenu: {
+        create: vi.fn(async () => {}),
+        update: vi.fn(async () => {}),
+        clear: vi.fn(async () => {}),
+        onClicked: { addListener: vi.fn() },
+      },
+      MailAccounts: {
+        createAccount: vi.fn(async () => ({ success: true })),
+        setToken: vi.fn(async () => ({ success: true })),
+      },
+      AccountHub: {
+        onAccountAdded: { addListener: vi.fn() },
+      },
+      thundermailTelemetry: {
+        isTelemetryEnabled: vi.fn(async () => false),
+        onChanged: { addListener: vi.fn() },
+      },
+      webRequest: {
+        onBeforeSendHeaders: { addListener: vi.fn() },
+      },
+      i18n: {
+        getMessage: vi.fn((key: string) => key),
+      },
+      management: {
+        uninstallSelf: vi.fn(async () => {}),
+      },
+    };
+
+    const ctx: FakeBrowserContext = {
+      name,
+      browser: browserMock,
+      onMessageListeners,
+      onFileUploadListeners,
+      onFileUploadAbortListeners,
+      onWindowRemovedListeners,
+      onStorageChangedListeners,
+      deliverMessage: async (message: any, sender?: any) => {
+        return Promise.all(
+          onMessageListeners.map((fn) => fn(message, sender))
+        );
+      },
+      triggerFileUpload: async (fileInfo) => {
+        const results = onFileUploadListeners.map((fn) =>
+          fn({ id: 1 }, fileInfo)
+        );
+        return results[0];
+      },
+    };
+    contexts.set(name, ctx);
+    return ctx;
+  }
+
+  return {
+    storage,
+    windowState,
+    tabState,
+    contexts,
+    createContext,
+    broadcast,
+  };
+}
+
+/**
+ * Resolves the next pending `windows.create()` call for the given host,
+ * assigning it a window id and adding it to the shared window registry.
+ * Lets tests control exactly when a popup's `browser.windows.create()`
+ * await settles, e.g. to force two `openUnifiedPopup()` calls to race.
+ */
+export function resolveNextWindowCreate(
+  host: FakeHost,
+  url = 'moz-extension://fake-id/index.extension.html'
+): FakeWindow | null {
+  const pending = host.windowState.pendingCreates.shift();
+  if (!pending) return null;
+  const id = host.windowState.nextId++;
+  const win: FakeWindow = { id, url, type: 'popup' };
+  host.windowState.windows.set(id, win);
+  pending.resolve(win);
+  return win;
+}
+
+/** Simulates the popup window being closed (fires windows.onRemoved). */
+export function closeWindow(host: FakeHost, windowId: number) {
+  host.windowState.windows.delete(windowId);
+  for (const listener of host.windowState.removedListeners) {
+    listener(windowId);
+  }
+}

--- a/packages/addon/src/test/integration/happy-clean-logout-no-inflight-work.test.ts
+++ b/packages/addon/src/test/integration/happy-clean-logout-no-inflight-work.test.ts
@@ -1,0 +1,67 @@
+/**
+ * HAPPY PATH — a logout with nothing else in flight closes exactly the
+ * expected tabs, clears storage, and opens the logout page, with no
+ * unrelated side effects. Correct-behavior counterpart to A1/A5 (which
+ * prove what an in-flight popup upload / unrelated staged data suffer when
+ * a logout blindsides them). Here there is no popup upload and no unrelated
+ * staged data, so menuLogout() should behave exactly as intended.
+ */
+import { BASE_URL } from '@send-frontend/apps/common/constants';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { type FakeHost } from './fakeThunderbirdHost';
+import { setupHost, stubContext, teardownHost } from './testHelpers';
+
+describe('Happy path: clean logout with no in-flight work', () => {
+  let host: FakeHost;
+
+  beforeEach(() => {
+    host = setupHost();
+  });
+
+  afterEach(() => {
+    teardownHost();
+  });
+
+  it('closes only Send tabs, clears storage, and opens the logout page', async () => {
+    const ctx = stubContext(host);
+    const { menuLogout } = await import('../../menu');
+
+    // A couple of ordinary open tabs: one Send tab, one unrelated site.
+    await ctx.browser.tabs.create({ url: `${BASE_URL}/send/profile` });
+    await ctx.browser.tabs.create({ url: 'https://example.com/' });
+
+    await menuLogout();
+
+    // The Send tab was closed; the unrelated tab was left alone.
+    expect(ctx.browser.tabs.remove).toHaveBeenCalledTimes(1);
+    expect(ctx.browser.tabs.remove).toHaveBeenCalledWith(1);
+
+    // Storage was cleared (there was nothing unrelated in it to lose, so
+    // this is the intended, harmless case).
+    expect(ctx.browser.storage.local.clear).toHaveBeenCalledTimes(1);
+
+    // Menu was reset to the logged-out state.
+    expect(ctx.browser.TBProMenu.clear).toHaveBeenCalledWith('root');
+    expect(ctx.browser.TBProMenu.update).toHaveBeenCalledWith(
+      'root',
+      expect.objectContaining({ secondaryTitle: 'thunderbirdPro' })
+    );
+
+    // The logout page was opened, after the tab cleanup (matching the
+    // load-bearing order menu.test.ts already guards for unit-level).
+    expect(ctx.browser.tabs.create).toHaveBeenCalledWith({
+      url: `${BASE_URL}/logout`,
+    });
+  });
+
+  it('SIGN_OUT message end-to-end: background unregisters the cloud file provider with no error', async () => {
+    const bg = stubContext(host);
+    await import('../../background');
+
+    await bg.deliverMessage({ type: 'SIGN_OUT' });
+
+    expect(bg.browser.CloudFileAccounts.unregisterProvider).toHaveBeenCalled();
+    // No pending uploads existed, so there is nothing to orphan here --
+    // this is the case A1 is the exception to.
+  });
+});

--- a/packages/addon/src/test/integration/happy-full-upload-golden-path.test.ts
+++ b/packages/addon/src/test/integration/happy-full-upload-golden-path.test.ts
@@ -1,0 +1,131 @@
+/**
+ * HAPPY PATH — the full attach → popup → upload → complete round trip, with
+ * nothing going wrong. This is the correct-behavior counterpart to the B1-B5
+ * bug specs in this directory: it proves the harness (and background.ts's
+ * real message protocol) correctly models the ordinary case those bug specs
+ * are exceptions to, not just the failure modes.
+ *
+ * Flow under test (background.ts):
+ *   onFileUpload -> uploadInfoQueue + uploadPromiseMap + popupTimer(250ms)
+ *   -> openUnifiedPopup() -> windows.create() -> popupWindowId set
+ *   -> popup sends POPUP_READY -> background replies FILE_LIST, clears queue
+ *   -> popup sends ALL_UPLOADS_COMPLETE -> background resolves the matching
+ *      uploadPromiseMap entry and, for a passphrase-bearing (`#`-hash) URL,
+ *      calls the add-password API.
+ *
+ * See README.md for what this harness does/doesn't simulate.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type FakeHost } from './fakeThunderbirdHost';
+import {
+  attachAndOpenPopup,
+  setupHost,
+  stubContext,
+  teardownHost,
+} from './testHelpers';
+import { useApiStore } from 'send-frontend/src/stores';
+
+describe('Happy path: full upload golden path', () => {
+  let host: FakeHost;
+
+  beforeEach(() => {
+    host = setupHost({ fakeTimers: true });
+  });
+
+  afterEach(() => {
+    teardownHost({ fakeTimers: true });
+  });
+
+  it('attach -> popup opens -> FILE_LIST delivered -> upload completes -> promise resolves with the share URL', async () => {
+    const bg = stubContext(host);
+    await import('../../background');
+
+    const { upload, popupWindow } = await attachAndOpenPopup(host, bg, {
+      id: 1,
+      name: 'report.pdf',
+      data: new Blob(['contents']),
+    });
+    expect(popupWindow).not.toBeNull();
+
+    await bg.deliverMessage({ type: 'POPUP_READY' });
+
+    // The popup gets exactly the queued file, and only once.
+    const fileListCalls = (
+      bg.browser.runtime.sendMessage as ReturnType<typeof vi.fn>
+    ).mock.calls.filter(([msg]) => msg?.type === 'FILE_LIST');
+    expect(fileListCalls).toHaveLength(1);
+    expect(fileListCalls[0][0].files).toEqual([
+      { id: 1, name: 'report.pdf', data: expect.any(Blob) },
+    ]);
+
+    // Popup finishes uploading and reports success, matching
+    // useUploadAndShare.ts's shareComplete() message shape.
+    await bg.deliverMessage({
+      type: 'ALL_UPLOADS_COMPLETE',
+      url: 'https://send.tb.pro/share/abc123',
+      results: [{ originalId: 1 }],
+    });
+
+    // The onFileUpload promise Thunderbird is holding resolves with the URL
+    // — this is the actual signal Thunderbird uses to know the upload
+    // succeeded and attach the link to the outgoing message.
+    await expect(upload).resolves.toEqual({
+      aborted: false,
+      url: 'https://send.tb.pro/share/abc123',
+    });
+  });
+
+  it('a passphrase-bearing (hash) URL triggers the add-password API call with the right link id and hash', async () => {
+    const bg = stubContext(host);
+    await import('../../background');
+    const { api } = useApiStore();
+    const apiCallSpy = vi.spyOn(api, 'call').mockResolvedValue({ success: true });
+
+    const { upload } = await attachAndOpenPopup(host, bg, {
+      id: 2,
+      name: 'secret.txt',
+      data: new Blob(['s']),
+    });
+    await bg.deliverMessage({ type: 'POPUP_READY' });
+
+    await bg.deliverMessage({
+      type: 'ALL_UPLOADS_COMPLETE',
+      url: 'https://send.tb.pro/share/link-xyz#thepassphrasehash',
+      results: [{ originalId: 2 }],
+    });
+    await expect(upload).resolves.toMatchObject({ aborted: false });
+
+    expect(apiCallSpy).toHaveBeenCalledWith(
+      'sharing/link-xyz/add-password',
+      { linkId: 'link-xyz', password: 'thepassphrasehash' },
+      'POST'
+    );
+    apiCallSpy.mockRestore();
+  });
+
+  it('a plain (non-passphrase) URL does NOT trigger the add-password API call', async () => {
+    const bg = stubContext(host);
+    await import('../../background');
+    const { api } = useApiStore();
+    const apiCallSpy = vi.spyOn(api, 'call').mockResolvedValue({ success: true });
+
+    const { upload } = await attachAndOpenPopup(host, bg, {
+      id: 3,
+      name: 'public.txt',
+      data: new Blob(['p']),
+    });
+    await bg.deliverMessage({ type: 'POPUP_READY' });
+
+    await bg.deliverMessage({
+      type: 'ALL_UPLOADS_COMPLETE',
+      url: 'https://send.tb.pro/share/no-password-link',
+      results: [{ originalId: 3 }],
+    });
+    await expect(upload).resolves.toMatchObject({ aborted: false });
+
+    // No '#' in the URL -> isPasswordProtected is false -> the add-password
+    // branch (`if (!isPasswordProtected)`) does not run.
+    expect(apiCallSpy).not.toHaveBeenCalled();
+    apiCallSpy.mockRestore();
+  });
+});

--- a/packages/addon/src/test/integration/happy-init-no-conflict.test.ts
+++ b/packages/addon/src/test/integration/happy-init-no-conflict.test.ts
@@ -1,0 +1,82 @@
+/**
+ * HAPPY PATH — init.ts's ordinary, single-context init: a user with a
+ * healthy local user/keychain and an intact default folder resolves cleanly
+ * with no delete/recreate churn. Correct-behavior counterpart to D3 (which
+ * proves what happens when two independent contexts both decide the
+ * default folder is orphaned at the same time). Here there's only one
+ * context and nothing is orphaned, so init() should just succeed quietly.
+ */
+import { INIT_ERRORS } from '@send-frontend/apps/send/const';
+import { describe, expect, it, vi } from 'vitest';
+
+describe('Happy path: init() with an intact default folder, single context', () => {
+  it('resolves INIT_ERRORS.NONE without touching deleteFolder/createFolder when the default folder already has a key', async () => {
+    vi.resetModules();
+    const { default: init } = await import('@send-frontend/lib/init');
+
+    const userStore = { loadFromLocalStorage: vi.fn().mockResolvedValue(true) };
+    const keychain = {
+      load: vi.fn().mockResolvedValue(true),
+      keys: { 'healthy-default-folder': 'a-real-key' },
+    };
+    const folderStore = {
+      sync: vi.fn().mockResolvedValue(undefined),
+      defaultFolder: { id: 'healthy-default-folder' },
+      deleteFolder: vi.fn(),
+      createFolder: vi.fn(),
+    };
+
+    const result = await init(userStore as any, keychain as any, folderStore as any);
+
+    expect(result).toBe(INIT_ERRORS.NONE);
+    expect(folderStore.deleteFolder).not.toHaveBeenCalled();
+    expect(folderStore.createFolder).not.toHaveBeenCalled();
+  });
+
+  it('single-flight guard correctly coalesces two concurrent calls WITHIN one context into one _init() run', async () => {
+    vi.resetModules();
+    const { default: init } = await import('@send-frontend/lib/init');
+
+    const userStore = { loadFromLocalStorage: vi.fn().mockResolvedValue(true) };
+    const keychain = {
+      load: vi.fn().mockResolvedValue(true),
+      keys: { 'healthy-default-folder': 'a-real-key' },
+    };
+    let syncCallCount = 0;
+    const folderStore = {
+      sync: vi.fn().mockImplementation(async () => {
+        syncCallCount++;
+      }),
+      defaultFolder: { id: 'healthy-default-folder' },
+      deleteFolder: vi.fn(),
+      createFolder: vi.fn(),
+    };
+
+    // Two callers within the SAME module instance/context (e.g. the login
+    // flow and dbUserSetup firing during the same rapid navigation, per
+    // init.ts's own single-flight comment) fire at the same time.
+    const [result1, result2] = await Promise.all([
+      init(userStore as any, keychain as any, folderStore as any),
+      init(userStore as any, keychain as any, folderStore as any),
+    ]);
+
+    expect(result1).toBe(INIT_ERRORS.NONE);
+    expect(result2).toBe(INIT_ERRORS.NONE);
+    // This is the guard working as intended: one shared run, not two.
+    expect(syncCallCount).toBe(1);
+  });
+
+  it('returns NO_USER cleanly when there is no local user, without touching the keychain or folder store', async () => {
+    vi.resetModules();
+    const { default: init } = await import('@send-frontend/lib/init');
+
+    const userStore = { loadFromLocalStorage: vi.fn().mockResolvedValue(false) };
+    const keychain = { load: vi.fn(), keys: {} };
+    const folderStore = { sync: vi.fn(), deleteFolder: vi.fn(), createFolder: vi.fn() };
+
+    const result = await init(userStore as any, keychain as any, folderStore as any);
+
+    expect(result).toBe(INIT_ERRORS.NO_USER);
+    expect(folderStore.sync).not.toHaveBeenCalled();
+  });
+});

--- a/packages/addon/src/test/integration/happy-login-sync-across-contexts.test.ts
+++ b/packages/addon/src/test/integration/happy-login-sync-across-contexts.test.ts
@@ -1,0 +1,73 @@
+/**
+ * HAPPY PATH — a normal, uncontested OIDC login correctly syncs auth state
+ * from the web tab into background's storage and out to the hamburger menu,
+ * with no other login racing it. Correct-behavior counterpart to A7 (which
+ * proves what happens when two logins for the same account race).
+ *
+ * Flow under test:
+ *   web tab (token-bridge.js) posts OIDC_USER after handleOIDCCallback()
+ *   -> background.ts's onMessage handler stores it under STORAGE_KEY_AUTH
+ *      in the SHARED browser.storage.local
+ *   -> menuLoggedIn() updates the TBProMenu to show the signed-in state
+ *   -> any other context (e.g. popup) watching storage.onChanged for
+ *      STORAGE_KEY_AUTH observes the same value, proving the shared-storage
+ *      sync primitive this harness models actually propagates correctly.
+ */
+import { OIDC_USER, STORAGE_KEY_AUTH } from '@send-frontend/lib/const';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type FakeHost } from './fakeThunderbirdHost';
+import { setupHost, stubContext, teardownHost } from './testHelpers';
+
+describe('Happy path: clean login sync across contexts', () => {
+  let host: FakeHost;
+
+  beforeEach(() => {
+    host = setupHost();
+  });
+
+  afterEach(() => {
+    teardownHost();
+  });
+
+  it('a single OIDC_USER message stores auth, updates the menu, and is visible to a second context via storage.onChanged', async () => {
+    const bg = stubContext(host);
+    await import('../../background');
+
+    // A second, independent context (e.g. the popup) is watching auth
+    // state the same way real code does -- via storage.onChanged.
+    const popup = host.createContext('popup');
+    const onAuthChanged = vi.fn();
+    popup.browser.storage.onChanged.addListener((changes: any) => {
+      if (changes[STORAGE_KEY_AUTH]) onAuthChanged(changes[STORAGE_KEY_AUTH]);
+    });
+
+    const user = {
+      profile: { preferred_username: 'user@example.com' },
+      refresh_token: 'fresh-refresh-token',
+      expires_at: Math.floor(Date.now() / 1000) + 3600,
+    };
+
+    await bg.deliverMessage({ type: OIDC_USER, user, email: 'user@example.com' });
+
+    // Background persisted the full user object under STORAGE_KEY_AUTH.
+    const stored = await bg.browser.storage.local.get(STORAGE_KEY_AUTH);
+    expect(stored[STORAGE_KEY_AUTH]).toEqual(user);
+
+    // The menu was updated to reflect the signed-in state.
+    expect(bg.browser.TBProMenu.update).toHaveBeenCalledWith(
+      'root',
+      expect.objectContaining({ secondaryTitle: 'user@example.com' })
+    );
+    expect(bg.browser.TBProMenu.create).toHaveBeenCalledWith(
+      'logout',
+      expect.anything()
+    );
+
+    // The independent popup context saw the SAME auth value propagate
+    // through the shared storage.onChanged event -- this is the real
+    // cross-context sync primitive this add-on relies on in production.
+    expect(onAuthChanged).toHaveBeenCalledWith(
+      expect.objectContaining({ newValue: user })
+    );
+  });
+});

--- a/packages/addon/src/test/integration/happy-sequential-multi-file-reuse.test.ts
+++ b/packages/addon/src/test/integration/happy-sequential-multi-file-reuse.test.ts
@@ -1,0 +1,102 @@
+/**
+ * HAPPY PATH — a single popup session correctly handles two SEPARATE
+ * attach-and-complete cycles in sequence (attach file 1, complete it, close
+ * the popup; then attach file 2 as a fresh popup session). Proves the
+ * background<->popup handshake (popupTimer/popupWindowId reset,
+ * uploadInfoQueue/uploadPromiseMap bookkeeping) is correctly reusable
+ * across sessions, not a one-shot fluke that only happens to work once.
+ *
+ * This is deliberately two SEPARATE popup sessions (not one popup handling
+ * two files back-to-back mid-session) because that's what popupWindowId
+ * being reset to null on windows.onRemoved actually models: each attach
+ * that arrives after the previous popup fully closed gets its own popup.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { closeWindow, type FakeHost } from './fakeThunderbirdHost';
+import {
+  attachAndOpenPopup,
+  setupHost,
+  stubContext,
+  teardownHost,
+} from './testHelpers';
+
+describe('Happy path: sequential multi-file reuse across popup sessions', () => {
+  let host: FakeHost;
+
+  beforeEach(() => {
+    host = setupHost({ fakeTimers: true });
+  });
+
+  afterEach(() => {
+    teardownHost({ fakeTimers: true });
+  });
+
+  it('completes file 1 in one popup session, then correctly opens a fresh popup and completes file 2', async () => {
+    const bg = stubContext(host);
+    await import('../../background');
+
+    // --- Session 1: file 1 ---
+    const { upload: upload1, popupWindow: popup1 } = await attachAndOpenPopup(
+      host,
+      bg,
+      { id: 1, name: 'first.txt', data: new Blob(['a']) }
+    );
+    expect(popup1).not.toBeNull();
+
+    await bg.deliverMessage({ type: 'POPUP_READY' });
+    const firstFileListCall = (
+      bg.browser.runtime.sendMessage as ReturnType<typeof vi.fn>
+    ).mock.calls.find(([msg]) => msg?.type === 'FILE_LIST');
+    expect(firstFileListCall![0].files).toEqual([
+      { id: 1, name: 'first.txt', data: expect.any(Blob) },
+    ]);
+
+    await bg.deliverMessage({
+      type: 'ALL_UPLOADS_COMPLETE',
+      url: 'https://send.tb.pro/share/session-1-link',
+      results: [{ originalId: 1 }],
+    });
+    await expect(upload1).resolves.toEqual({
+      aborted: false,
+      url: 'https://send.tb.pro/share/session-1-link',
+    });
+
+    // The popup closes once the share is done (matches shareComplete()'s
+    // window.close() in useUploadAndShare.ts) -- this resets popupWindowId
+    // so a NEW attach can open a fresh popup rather than being blocked by
+    // the "popup already open" guard.
+    closeWindow(host, popup1!.id);
+
+    // --- Session 2: a completely separate later attach, file 2 ---
+    const { upload: upload2, popupWindow: popup2 } = await attachAndOpenPopup(
+      host,
+      bg,
+      { id: 2, name: 'second.txt', data: new Blob(['b']) }
+    );
+    // A genuinely new popup window was opened -- not blocked, not reused.
+    expect(popup2).not.toBeNull();
+    expect(popup2!.id).not.toBe(popup1!.id);
+
+    await bg.deliverMessage({ type: 'POPUP_READY' });
+    const fileListCalls = (
+      bg.browser.runtime.sendMessage as ReturnType<typeof vi.fn>
+    ).mock.calls.filter(([msg]) => msg?.type === 'FILE_LIST');
+    // Two POPUP_READY deliveries total across both sessions -> two FILE_LIST
+    // sends, and the second one contains ONLY file 2 (the queue was cleared
+    // after session 1, so there's no stale carry-over from file 1).
+    expect(fileListCalls).toHaveLength(2);
+    expect(fileListCalls[1][0].files).toEqual([
+      { id: 2, name: 'second.txt', data: expect.any(Blob) },
+    ]);
+
+    await bg.deliverMessage({
+      type: 'ALL_UPLOADS_COMPLETE',
+      url: 'https://send.tb.pro/share/session-2-link',
+      results: [{ originalId: 2 }],
+    });
+    await expect(upload2).resolves.toEqual({
+      aborted: false,
+      url: 'https://send.tb.pro/share/session-2-link',
+    });
+  });
+});

--- a/packages/addon/src/test/integration/testHelpers.ts
+++ b/packages/addon/src/test/integration/testHelpers.ts
@@ -1,0 +1,52 @@
+/**
+ * Shared setup/teardown glue for specs in this directory, so the same
+ * `vi.resetModules()` / `createFakeThunderbirdHost()` / `vi.stubGlobal()`
+ * boilerplate isn't repeated verbatim in every file. See README.md for what
+ * the fake host itself simulates and why.
+ */
+import { resolve } from 'node:path';
+import { vi } from 'vitest';
+import {
+  createFakeThunderbirdHost,
+  type FakeBrowserContext,
+  type FakeHost,
+} from './fakeThunderbirdHost';
+
+/** packages/addon, resolved once since every spec in this directory shares the same __dirname depth. */
+export const ADDON_ROOT = resolve(__dirname, '../../..');
+
+/** Call in beforeEach. Pass `fakeTimers: true` for specs that drive popupTimer/setTimeout races. */
+export function setupHost(opts: { fakeTimers?: boolean } = {}): FakeHost {
+  vi.resetModules();
+  if (opts.fakeTimers) vi.useFakeTimers();
+  return createFakeThunderbirdHost();
+}
+
+/** Pairs with setupHost(); call in afterEach with the same opts. */
+export function teardownHost(opts: { fakeTimers?: boolean } = {}): void {
+  vi.unstubAllGlobals();
+  if (opts.fakeTimers) vi.useRealTimers();
+}
+
+/** Creates a context and stubs it as the global `browser`, ready for a module import that follows. */
+export function stubContext(
+  host: FakeHost,
+  name = 'background'
+): FakeBrowserContext {
+  const ctx = host.createContext(name);
+  vi.stubGlobal('browser', ctx.browser);
+  return ctx;
+}
+
+/**
+ * Deferred-resolution helper: lets a test hold an async call open (e.g. a
+ * mocked folderStore.sync()) so two contexts' in-flight windows can be
+ * forced to overlap deterministically.
+ */
+export function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}

--- a/packages/addon/src/test/integration/testHelpers.ts
+++ b/packages/addon/src/test/integration/testHelpers.ts
@@ -8,8 +8,10 @@ import { resolve } from 'node:path';
 import { vi } from 'vitest';
 import {
   createFakeThunderbirdHost,
+  resolveNextWindowCreate,
   type FakeBrowserContext,
   type FakeHost,
+  type FakeWindow,
 } from './fakeThunderbirdHost';
 
 /** packages/addon, resolved once since every spec in this directory shares the same __dirname depth. */
@@ -36,6 +38,30 @@ export function stubContext(
   const ctx = host.createContext(name);
   vi.stubGlobal('browser', ctx.browser);
   return ctx;
+}
+
+/**
+ * Drives background.ts's onFileUpload -> popupTimer(250ms) -> windows.create()
+ * -> POPUP_READY handshake through to the point where FILE_LIST has been
+ * sent, exactly as real Thunderbird + the real popup would. Requires
+ * `setupHost({ fakeTimers: true })`.
+ *
+ * This is the "nothing goes wrong" path every happy-path upload spec needs
+ * before it can assert its own thing (a specific FILE_LIST payload, an
+ * add-password call, a second sequential session, etc.) -- the bug specs in
+ * this directory each interrupt one particular step of this same sequence,
+ * so they intentionally do NOT use this helper.
+ */
+export async function attachAndOpenPopup(
+  host: FakeHost,
+  bg: FakeBrowserContext,
+  fileInfo: { id: number; name: string; data: any }
+): Promise<{ upload: Promise<any>; popupWindow: FakeWindow }> {
+  const upload = bg.triggerFileUpload(fileInfo);
+  await vi.advanceTimersByTimeAsync(250);
+  const popupWindow = resolveNextWindowCreate(host);
+  await Promise.resolve(); // let popupWindowId assignment settle
+  return { upload, popupWindow: popupWindow as FakeWindow };
 }
 
 /**


### PR DESCRIPTION
## What changed?

This adds the test harness that later PRs in this stack build their regression tests on. It doesn't change any shipping code — it's test infrastructure only.

The add-on is unusual to test because a running add-on isn't one program: it's **three separate JavaScript worlds** running at once — the background page, the popup window, and the web tab — that only talk to each other through shared browser storage. Most bugs in this add-on live in the seams *between* those worlds, so a test harness that pretends everything runs in one place can't catch them.

The harness models that reality:

- **`fakeThunderbirdHost.ts`** — a fake Thunderbird add-on host that gives each of the three contexts its own `browser` mock, but wires them all to **one** shared `browser.storage.local` store that fires real `onChanged` events across contexts. That shared store with cross-context change events is the exact mechanism the real add-on relies on in production, so tests can exercise it for real instead of faking it.
- **`testHelpers.ts`** — shared setup/teardown helpers (`setupHost()`, `teardownHost()`, `stubContext()`, `createDeferred()`, `attachAndOpenPopup()`) used by the spec files in the rest of the stack.

It also adds **5 "happy path" specs** that run the real production modules against the harness on normal, uncontested flows. These prove the harness correctly models everyday behavior — not just the bug cases the later PRs target — and they're meant to pass forever, so a regression in normal add-on behavior breaks one of them:

- `happy-full-upload-golden-path` — attach → popup opens → file list delivered → upload completes → the share URL comes back (covers both the add-password branch and the skip-it branch).
- `happy-login-sync-across-contexts` — a clean login stores auth, updates the menu, and propagates to a second context via storage change events.
- `happy-clean-logout-no-inflight-work` — logout closes only Send tabs, clears storage, opens the logout page, and cleanly unregisters the cloud file provider when nothing is uploading.
- `happy-init-no-conflict` — folder setup resolves without needless delete/recreate churn when the default folder is intact, concurrent calls in the same context coalesce, and the no-user case short-circuits.
- `happy-sequential-multi-file-reuse` — two popup sessions in a row each get their own popup and see only their own file, proving the handshake is reusable rather than a one-shot.

**AI disclosure:** This harness and the specs were written by an AI agent (Claude) from a testing plan, with a human reviewing the approach, the code, and the results. The happy-path specs were added in response to review feedback that the harness was landing as untested infrastructure.

## Why?

This is PR 1 of a 6-PR stack. The point of the harness is that the following PRs' regression tests load and exercise the **real** production modules (`background.ts`, `menu.ts`, `token-bridge.js`, `PopupView.vue`, `init.ts`) against a realistic fake host, instead of reimplementing the behavior they're supposed to be testing. Without that, the regression tests wouldn't actually prove anything about the shipped code.

## Limitations and Notes

- Test infrastructure only — no production code changes in this PR.
- The bug-regression specs that use this harness land in the later PRs of the stack; this PR ships the harness plus the happy-path coverage that validates it.
- The full 3-tier testing strategy this fits into is documented in `ADDON-INTEGRATION-TEST-ENV-PLAN-2026-07-22.md`, landing in the docs PR later in the stack.

**How it was verified:**

```
cd packages/addon && VITE_TESTING=true \
  VITE_SEND_CLIENT_URL=https://send.tb.pro \
  VITE_SEND_SERVER_URL=https://localhost:8088 \
  npx vitest run
# 51 passed, 1 pre-existing skip, 0 failed

npx eslint 'src/test/integration/**/*.ts'
# 0 errors (any-type warnings only, consistent with existing test-mock style)
```

## Applicable Issues

Closes #1035
