### PR TITLE
test(addon): add integration tests for upload popup dropping or mishandling attached files

### DIFF
--- a/packages/addon/package.json
+++ b/packages/addon/package.json
@@ -29,6 +29,7 @@
     "sync:builtin": "pnpm build:dev:system && ./scripts/sync-to-builtin.sh",
     "sync:builtin:local": "pnpm build:dev:system:local && ./scripts/sync-to-builtin.sh",
     "test": "VITE_TESTING=true vitest run --silent",
+    "test:integration": "VITE_TESTING=true VITE_SEND_CLIENT_URL=https://send.tb.pro VITE_SEND_SERVER_URL=https://localhost:8088 vitest run src/test/integration --silent",
     "test:watch": "VITE_TESTING=true vitest --watch",
     "test-debug": "VITE_TESTING=true vitest --inspect-brk --single-thread",
     "typecheck": "tsc --noEmit",

--- a/packages/addon/src/test/integration/README.md
+++ b/packages/addon/src/test/integration/README.md
@@ -1,0 +1,125 @@
+# Add-on Integration Tests (Tier 1: Fake-Host Harness)
+
+This directory implements **Tier 1** of
+`packages/send/e2e/ADDON-INTEGRATION-TEST-ENV-PLAN-2026-07-22.md`: a fast,
+deterministic, CI-friendly harness that loads the **real** production
+modules (`background.ts`, `menu.ts`, `token-bridge.js`, `init.ts`,
+`UserMenu.vue`, `PopupView.vue`) against a fake multi-context Thunderbird
+host, and drives the exact race windows described in
+`packages/send/e2e/ADDON-BUG-REPORTS-2026-07-22.md` deterministically.
+
+## Running
+
+```sh
+pnpm --filter addon test:integration
+```
+
+(equivalent to `VITE_TESTING=true VITE_SEND_CLIENT_URL=https://send.tb.pro
+VITE_SEND_SERVER_URL=https://localhost:8088 vitest run src/test/integration`)
+
+## What this harness is
+
+`fakeThunderbirdHost.ts` simulates the 3 JS-only WebExtension execution
+contexts this add-on has in a real running Thunderbird. `testHelpers.ts`
+holds the shared per-spec setup/teardown boilerplate (`setupHost()` /
+`teardownHost()` / `stubContext()` / `ADDON_ROOT` / `createDeferred()`) so
+individual spec files stay focused on the race they're proving instead of
+repeating harness wiring.
+
+The three execution contexts:
+
+- **background** — the non-persistent background page (`background.ts`)
+- **popup** — the upload popup window (`PopupView.vue`)
+- **web** — a plain browser tab running send.tb.pro, bridged via
+  `token-bridge.js`
+
+Each context gets its own independent `browser` mock object (mirroring the
+real platform, where each JS realm has its own `browser.*` binding), but all
+contexts share **one** fake `browser.storage.local` backing store with real
+`storage.onChanged` firing — this is the actual cross-context sync primitive
+in production (see `shared-pinia.ts`'s per-context-singleton comment), so a
+real shared store (not per-context stubs) is essential for these tests to be
+meaningful.
+
+`browser.runtime.sendMessage` calls from any context fan out to every OTHER
+context's registered `onMessage` listeners, exactly like real WebExtension
+messaging. `browser.windows.create()` returns a deliberately controllable,
+unresolved Promise (see `resolveNextWindowCreate()`) so tests can force exact
+check-then-act interleavings (e.g. B3) that are effectively impossible to
+reproduce reliably against a real window manager.
+
+## What this harness deliberately does NOT do
+
+Per the integration-environment plan's key finding: the hamburger/TBPro menu
+(`menu.ts` + `public/api/TBProMenu/implementation.js`) is built with
+`ChromeUtils.importESModule` + `ExtensionCommon.ExtensionAPI` — privileged
+Thunderbird-internal APIs that only exist inside a real running Thunderbird
+process. This harness stubs `browser.TBProMenu`, `browser.CloudFileAccounts`,
+`browser.MailAccounts`, and `browser.AccountHub` as plain spies — it does
+**not** attempt to simulate real chrome UI behavior for them. Tests only
+assert that the right calls happened with the right arguments at the right
+time, which is what the confirmed sync-race findings actually depend on.
+
+Anything requiring real platform timing/window-manager behavior (B3's
+magnitude-of-likelihood question, B5's background-page-recycle trigger
+condition, C1's window auto-close-on-disable behavior) is explicitly a
+**Tier 2/3** concern — see the environment plan doc — and is called out with
+a "Needs live test" comment in the relevant spec here.
+
+## Regression-test contract
+
+Every spec in this directory is named after and directly traces to a finding
+ID in `ADDON-BUG-REPORTS-2026-07-22.md` (e.g. `b1-*.test.ts` → finding B1).
+Each spec:
+
+1. Imports the **real** production module(s) under test (not
+   reimplementations).
+2. Drives the exact interleaving/race described in the finding.
+3. Asserts the **current (buggy) behavior**, with a `CONFIRMED BUG:` prefix
+   in the test name.
+
+**These specs are expected to FAIL once the underlying bug is fixed.** That
+is the point — a failing spec here is the CI signal that a fix landed. When
+that happens:
+
+- Do not just delete the spec.
+- Update it to assert the new, correct behavior instead (turn the
+  `CONFIRMED BUG:` assertion into a `FIXED:` assertion of the desired
+  outcome), so the fix gets permanent regression coverage.
+- Remove the `Needs live test` caveat from the doc comment only if the fix
+  addresses the client-side structural gap; live-test-only sub-questions
+  (server-side outcomes, platform timing) still need Tier 2/3 verification
+  even after a client-side fix lands.
+
+## Coverage status
+
+| ID | Spec file | Priority |
+|----|-----------|----------|
+| A1 | `a1-logout-does-not-abort-popup-upload.test.ts` | Medium |
+| A2 | `a2-origin-mismatch-logout-not-delivered.test.ts` | Medium |
+| A5 | `a5-logout-clears-unrelated-storage.test.ts` | Medium |
+| A6 | `a6-menu-stale-login-no-push-refresh.test.ts` | Medium |
+| A7 | `a7-accounthub-login-races-web-login.test.ts` | Medium |
+| B1 | `b1-rapid-attach-before-popup-ready.test.ts` | Medium |
+| B2 | `b2-popup-close-mid-upload.test.ts` | Medium |
+| B3 | `b3-popup-check-then-act-race.test.ts` | Medium |
+| B4 | `b4-attach-while-popup-open.test.ts` | Medium |
+| B5 | `b5-background-restart-loses-bookkeeping.test.ts` | **High** |
+| C1 | `c1-disable-mid-upload-orphans-popup.test.ts` | **High** |
+| C2 | `c2-reenable-trusts-stale-auth.test.ts` | Medium |
+| D3 | `d3-init-single-flight-per-context-only.test.ts` | Medium |
+
+**Not yet covered** (deferred — see reasoning below):
+
+- **A3** (forced-logout races concurrent multipart parts) and **A4**
+  (cross-context refresh-token race) — both live in `auth-store.ts`'s OIDC
+  client internals (`signinSilent()`, `MAX_CONCURRENT_PARTS` fan-out),
+  which need deeper mocking of `oidc-client-ts`/`UserManager` than this
+  harness currently provides. Left for a follow-up harness extension.
+- **D2** (bridged-passphrase one-shot consume race) — needs the real
+  `Keychain`/`bridgePassphrase.ts` wired into two contexts sharing storage;
+  doable with this harness's shared-storage primitive, just not yet written.
+
+Extend this harness's mocks (particularly around `oidc-client-ts` and
+`Keychain`) to close the remaining three before considering Tier 1 complete
+per the original environment plan's effort estimate.

--- a/packages/addon/src/test/integration/b1-rapid-attach-before-popup-ready.test.ts
+++ b/packages/addon/src/test/integration/b1-rapid-attach-before-popup-ready.test.ts
@@ -1,0 +1,122 @@
+/**
+ * B1 — Two rapid, separate `onFileUpload` bursts can silently lose files to a
+ * popup that already drained the queue.
+ *
+ * See ADDON-BUG-REPORTS-2026-07-22.md #B1 and
+ * ADDON-SYNC-VERIFIED-FINDINGS-2026-07-21.md §B1. See README.md for the
+ * regression-test contract these specs follow.
+ *
+ * Mechanism (background.ts): onFileUpload pushes to `uploadInfoQueue` and
+ * (re)arms a 250ms `popupTimer` -> `openUnifiedPopup()`. `POPUP_READY` sends
+ * the ENTIRE queue as one `FILE_LIST` and unconditionally clears it -- no
+ * per-batch id, no ack. If a second burst lands after the popup already
+ * drained the queue once, those files sit unread: the "popup already open"
+ * guard blocks a second popup from opening to re-deliver them.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  closeWindow,
+  resolveNextWindowCreate,
+  type FakeHost,
+} from './fakeThunderbirdHost';
+import { setupHost, stubContext, teardownHost } from './testHelpers';
+
+describe('B1: rapid onFileUpload bursts drop a second batch silently', () => {
+  let host: FakeHost;
+
+  beforeEach(() => {
+    host = setupHost({ fakeTimers: true });
+  });
+
+  afterEach(() => {
+    teardownHost({ fakeTimers: true });
+  });
+
+  it('CONFIRMED BUG: second onFileUpload burst after popup already drained the queue is lost', async () => {
+    const bg = stubContext(host);
+    await import('../../background');
+
+    // First burst: one file attached, triggers popupTimer.
+    const firstUpload = bg.triggerFileUpload({
+      id: 1,
+      name: 'first.txt',
+      data: new Blob(['a']),
+    });
+
+    // Let the 250ms popupTimer fire, invoking openUnifiedPopup().
+    await vi.advanceTimersByTimeAsync(250);
+
+    // openUnifiedPopup() is now awaiting browser.windows.create(). Resolve it
+    // so popupWindowId gets set and the popup is considered "open".
+    const popupWindow = resolveNextWindowCreate(host);
+    expect(popupWindow).not.toBeNull();
+
+    // Let any pending microtasks (popupWindowId assignment) settle.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Popup announces it's ready — background sends FILE_LIST with the
+    // queue (file 1) and clears the queue.
+    host.createContext('popup');
+    await bg.deliverMessage({ type: 'POPUP_READY' });
+
+    // Confirm background sent FILE_LIST containing exactly file 1, and that
+    // sendMessage was actually invoked (fan-out to popup context).
+    expect(bg.browser.runtime.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'FILE_LIST',
+        files: expect.arrayContaining([
+          expect.objectContaining({ id: 1, name: 'first.txt' }),
+        ]),
+      })
+    );
+
+    // --- Second burst arrives while the popup is still open/uploading ---
+    const secondUpload = bg.triggerFileUpload({
+      id: 2,
+      name: 'second.txt',
+      data: new Blob(['b']),
+    });
+
+    // Advance past the second popupTimer window. openUnifiedPopup() runs
+    // again but should hit the "popup already open" guard (popupWindowId is
+    // still set) and exit without notifying anyone about file 2.
+    await vi.advanceTimersByTimeAsync(250);
+    await Promise.resolve();
+
+    // THE BUG: no second FILE_LIST is ever sent for file 2. Background never
+    // told the (already-open) popup that a new file arrived.
+    const fileListCalls = (
+      bg.browser.runtime.sendMessage as ReturnType<typeof vi.fn>
+    ).mock.calls.filter(([msg]) => msg?.type === 'FILE_LIST');
+    expect(fileListCalls).toHaveLength(1); // only the first batch was ever delivered
+    expect(
+      fileListCalls.some(([msg]) =>
+        msg.files.some((f: any) => f.id === 2)
+      )
+    ).toBe(false); // file 2 was never included in any FILE_LIST
+
+    // File 2's promise is left pending in uploadPromiseMap with no consumer.
+    // It eventually gets rejected only when the popup closes (see B2/B4),
+    // which is a misleading "popup closed prematurely" error rather than
+    // an accurate "your file was silently dropped" error — reproduced here:
+    closeWindow(host, popupWindow!.id);
+
+    // The FIRST upload's promise had already been resolved-or-lost with the
+    // popup context (not exercised further in this narrowly-scoped spec —
+    // see B2 for close-mid-upload behavior). What matters for B1 is that the
+    // second upload's promise rejects with the generic, misleading message,
+    // never having been told its file was actually silently dropped from an
+    // undelivered queue.
+    await expect(secondUpload).rejects.toThrow(
+      'Popup window was closed prematurely.'
+    );
+
+    // Cleanup: the first upload promise is also pending; reject-all clears it
+    // via the same close event, so it too rejects (documented for completeness,
+    // not the focus of this spec).
+    await expect(firstUpload).rejects.toThrow(
+      'Popup window was closed prematurely.'
+    );
+  });
+});

--- a/packages/addon/src/test/integration/b2-popup-close-mid-upload.test.ts
+++ b/packages/addon/src/test/integration/b2-popup-close-mid-upload.test.ts
@@ -1,0 +1,114 @@
+/**
+ * B2 — Popup closed mid-upload leaves orphaned server-side item, no client
+ * record; the AbortController created in background.ts is never wired to
+ * the popup's actual network upload.
+ *
+ * See ADDON-BUG-REPORTS-2026-07-22.md #B2 and
+ * ADDON-SYNC-VERIFIED-FINDINGS-2026-07-21.md §B2.
+ *
+ * This spec verifies the CLIENT-SIDE half of the finding, which is fully
+ * code-confirmable without a live server: the `AbortController` background
+ * creates per-file in `onFileUpload` is stored in `uploadPromiseMap` and
+ * `.abort()`-ed by `rejectAllInQueue()` on window close, but NOTHING in the
+ * background→popup message protocol (FILE_LIST) ever forwards that
+ * AbortController's `signal` to the popup, and the popup's own upload code
+ * (`useUploadAndShare.ts`/`folder-store.ts`) never checks for or listens to
+ * any abort signal at all. So aborting it is a no-op from the network's
+ * perspective -- confirmed here by showing the abort() call happens exactly
+ * once per pending upload, but no signal ever crosses the FILE_LIST message
+ * boundary to the popup context.
+ *
+ * The SERVER-SIDE half (does the backend actually persist the item after
+ * the client window is destroyed) is explicitly a "needs live test" item
+ * and is NOT claimed as covered by this spec -- see the bug report and the
+ * Tier 2/3 sections of ADDON-INTEGRATION-TEST-ENV-PLAN-2026-07-22.md.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  closeWindow,
+  resolveNextWindowCreate,
+  type FakeHost,
+} from './fakeThunderbirdHost';
+import { setupHost, stubContext, teardownHost } from './testHelpers';
+
+describe('B2: popup close mid-upload aborts background bookkeeping but not the network request', () => {
+  let host: FakeHost;
+  let abortSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    host = setupHost({ fakeTimers: true });
+    abortSpy = vi.fn();
+  });
+
+  afterEach(() => {
+    teardownHost({ fakeTimers: true });
+  });
+
+  it('CONFIRMED BUG: window close aborts the background AbortController, but the FILE_LIST payload sent to the popup never included that signal', async () => {
+    // Spy on the real AbortController's prototype.abort to observe exactly
+    // how many times background.ts's own bookkeeping-only controller gets
+    // aborted, without needing to reach into module internals.
+    const originalAbort = AbortController.prototype.abort;
+    AbortController.prototype.abort = function (...args) {
+      abortSpy();
+      return originalAbort.apply(this, args as []);
+    };
+
+    try {
+      const bg = stubContext(host);
+      await import('../../background');
+
+      const upload = bg.triggerFileUpload({
+        id: 1,
+        name: 'file.txt',
+        data: new Blob(['x']),
+      });
+
+      await vi.advanceTimersByTimeAsync(250);
+      const popupWindow = resolveNextWindowCreate(host);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // Popup announces ready; background sends FILE_LIST.
+      await bg.deliverMessage({ type: 'POPUP_READY' });
+
+      const fileListCall = (
+        bg.browser.runtime.sendMessage as ReturnType<typeof vi.fn>
+      ).mock.calls.find(([msg]) => msg?.type === 'FILE_LIST');
+      expect(fileListCall).toBeDefined();
+
+      // THE BUG, part 1: the FILE_LIST payload's file entries are plain
+      // {id, name, data} -- no AbortController/signal is ever attached or
+      // forwarded to the popup. Confirms the popup has structurally no way
+      // to observe an abort even if it wanted to.
+      const [fileListMsg] = fileListCall!;
+      for (const file of fileListMsg.files) {
+        expect(file).not.toHaveProperty('signal');
+        expect(file).not.toHaveProperty('abortController');
+        expect(Object.keys(file).sort()).toEqual(['data', 'id', 'name']);
+      }
+
+      // User closes the popup mid-upload (before ALL_UPLOADS_COMPLETE).
+      expect(abortSpy).not.toHaveBeenCalled();
+      closeWindow(host, popupWindow!.id);
+
+      // THE BUG, part 2: background's rejectAllInQueue() DOES call
+      // abortController.abort() on its own bookkeeping-only controller --
+      // proving the abort mechanism exists and fires -- but this abort has
+      // no real HTTP request/fetch attached to it anywhere in this process
+      // (per the source review: folder-store.ts / useUploadAndShare.ts have
+      // zero AbortController/signal usage). So from the network's point of
+      // view, this abort() call is a no-op; a real popup's in-flight
+      // fetch() would keep running to completion regardless.
+      expect(abortSpy).toHaveBeenCalledTimes(1);
+
+      // The background-side promise IS rejected (this part works correctly
+      // -- it's purely the network-cancellation wiring that's missing).
+      await expect(upload).rejects.toThrow(
+        'Popup window was closed prematurely.'
+      );
+    } finally {
+      AbortController.prototype.abort = originalAbort;
+    }
+  });
+});

--- a/packages/addon/src/test/integration/b3-popup-check-then-act-race.test.ts
+++ b/packages/addon/src/test/integration/b3-popup-check-then-act-race.test.ts
@@ -1,0 +1,85 @@
+/**
+ * B3 — Check-then-act race in `openUnifiedPopup()`'s `popupWindowId` guard.
+ *
+ * See ADDON-BUG-REPORTS-2026-07-22.md #B3 and
+ * ADDON-SYNC-VERIFIED-FINDINGS-2026-07-21.md §B3.
+ *
+ * Mechanism under test (background.ts, openUnifiedPopup()):
+ *   if (uploadInfoQueue.length === 0 || popupWindowId) return;
+ *   const popup = await browser.windows.create({...});
+ *   popupWindowId = popup.id;
+ *
+ * The guard is read synchronously but `popupWindowId` is only WRITTEN after
+ * the `await browser.windows.create()` resolves. If a second
+ * `openUnifiedPopup()` invocation begins while the first's
+ * `windows.create()` call is still pending, it reads `popupWindowId` as
+ * still null/undefined and also calls `windows.create()` — opening two
+ * popups for what should be one unified upload session.
+ *
+ * This harness's fake `windows.create()` returns a controllable, unresolved
+ * Promise (see resolveNextWindowCreate) specifically so tests can force this
+ * exact interleaving deterministically, which is impossible to do reliably
+ * against a real Thunderbird window manager.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  resolveNextWindowCreate,
+  type FakeHost,
+} from './fakeThunderbirdHost';
+import { setupHost, stubContext, teardownHost } from './testHelpers';
+
+describe('B3: openUnifiedPopup() check-then-act race can open two popups', () => {
+  let host: FakeHost;
+
+  beforeEach(() => {
+    host = setupHost({ fakeTimers: true });
+  });
+
+  afterEach(() => {
+    teardownHost({ fakeTimers: true });
+  });
+
+  it('CONFIRMED BUG: two near-simultaneous onFileUpload events can both pass the popupWindowId guard', async () => {
+    const bg = stubContext(host);
+    await import('../../background');
+
+    // First file triggers the first popupTimer -> openUnifiedPopup() call.
+    bg.triggerFileUpload({ id: 1, name: 'a.txt', data: new Blob(['a']) });
+    await vi.advanceTimersByTimeAsync(250);
+
+    // At this point background's first openUnifiedPopup() invocation has
+    // read `popupWindowId` as null, passed the guard, and is now awaiting
+    // browser.windows.create() — that await has NOT resolved yet (we
+    // haven't called resolveNextWindowCreate). This is the exact race
+    // window described in the bug report.
+    expect(bg.browser.windows.create).toHaveBeenCalledTimes(1);
+
+    // A second file attaches WHILE the first windows.create() is still
+    // pending. Its onFileUpload handler clears/re-arms popupTimer (250ms),
+    // so simulate that timer firing too, calling openUnifiedPopup() again
+    // BEFORE the first call's popupWindowId assignment has happened.
+    bg.triggerFileUpload({ id: 2, name: 'b.txt', data: new Blob(['b']) });
+    await vi.advanceTimersByTimeAsync(250);
+
+    // THE BUG: because popupWindowId is still null/undefined (the first
+    // windows.create() hasn't resolved), the guard `if (... || popupWindowId)
+    // return;` does not block this second invocation, and background calls
+    // browser.windows.create() a second time.
+    expect(bg.browser.windows.create).toHaveBeenCalledTimes(2);
+
+    // Now let both windows.create() calls resolve, in order, and confirm
+    // two separate windows were actually created/tracked.
+    const win1 = resolveNextWindowCreate(host);
+    const win2 = resolveNextWindowCreate(host);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(win1).not.toBeNull();
+    expect(win2).not.toBeNull();
+    expect(win1!.id).not.toBe(win2!.id);
+    // Confirms this repo's fix target: popupWindowId should be set
+    // synchronously (a 'pending' sentinel) BEFORE the await, which would
+    // make the second call see a truthy guard and skip windows.create()
+    // entirely -- windows.create would then only ever be called once.
+  });
+});

--- a/packages/addon/src/test/integration/b4-attach-while-popup-open.test.ts
+++ b/packages/addon/src/test/integration/b4-attach-while-popup-open.test.ts
@@ -1,0 +1,94 @@
+/**
+ * B4 — New file attached while popup already open is silently dropped, not
+ * merged into the existing upload session.
+ *
+ * See ADDON-BUG-REPORTS-2026-07-22.md #B4 and
+ * ADDON-SYNC-VERIFIED-FINDINGS-2026-07-21.md §B4.
+ *
+ * This is the mirror case of B1 from a different trigger path: rather than
+ * two bursts racing to be the FIRST batch, here the popup has already fully
+ * initialized (POPUP_READY answered) and is idle/mid-upload when a fresh
+ * `onFileUpload` fires. `openUnifiedPopup()`'s guard treats "popup already
+ * open" as "nothing to do", so the new file is queued but nobody ever tells
+ * the open popup about it — and `PopupView.vue`'s `files.value =
+ * message.files` is a plain overwrite even if a second FILE_LIST were ever
+ * sent (which this test also demonstrates never happens).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  closeWindow,
+  resolveNextWindowCreate,
+  type FakeHost,
+} from './fakeThunderbirdHost';
+import { setupHost, stubContext, teardownHost } from './testHelpers';
+
+describe('B4: file attached while popup already open is dropped, not merged', () => {
+  let host: FakeHost;
+
+  beforeEach(() => {
+    host = setupHost({ fakeTimers: true });
+  });
+
+  afterEach(() => {
+    teardownHost({ fakeTimers: true });
+  });
+
+  it('CONFIRMED BUG: openUnifiedPopup() no-ops for a file attached after the popup is fully open, and no second FILE_LIST is ever sent', async () => {
+    const bg = stubContext(host);
+    await import('../../background');
+
+    // First file: full happy-path popup open + POPUP_READY round trip.
+    const firstUpload = bg.triggerFileUpload({
+      id: 1,
+      name: 'first.txt',
+      data: new Blob(['a']),
+    });
+    await vi.advanceTimersByTimeAsync(250);
+    const popupWindow = resolveNextWindowCreate(host);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    await bg.deliverMessage({ type: 'POPUP_READY' });
+    (bg.browser.runtime.sendMessage as ReturnType<typeof vi.fn>).mockClear();
+
+    // Popup is now fully open, initialized, and (from the user's
+    // perspective) may be mid-upload. A second file gets attached from
+    // another compose window while this popup is still on screen.
+    const secondUpload = bg.triggerFileUpload({
+      id: 2,
+      name: 'second.txt',
+      data: new Blob(['b']),
+    });
+    await vi.advanceTimersByTimeAsync(250);
+    await Promise.resolve();
+
+    // THE BUG: openUnifiedPopup()'s guard (`popupWindowId` truthy) causes it
+    // to return early -- browser.windows.create() is NOT called again...
+    expect(bg.browser.windows.create).toHaveBeenCalledTimes(1); // still just the original popup
+
+    // ...AND critically, no message is sent to notify the already-open
+    // popup that a new file has arrived. There is no "merge into open
+    // popup" code path at all in this repo.
+    expect(bg.browser.runtime.sendMessage).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'FILE_LIST' })
+    );
+
+    // File 2 sits in uploadInfoQueue with a pending, un-actioned promise.
+    // The only thing that will ever settle it is the popup eventually
+    // closing (see B2/B1) -- surfacing the same misleading generic error
+    // rather than any indication the file was silently dropped from an
+    // active session.
+    closeWindow(host, popupWindow!.id);
+
+    await expect(secondUpload).rejects.toThrow(
+      'Popup window was closed prematurely.'
+    );
+    // File 1's promise (never resolved via ALL_UPLOADS_COMPLETE in this
+    // narrowly-scoped spec) is also swept up by the same close-triggered
+    // rejectAllInQueue() call; assert on it too so it isn't left as an
+    // unhandled rejection.
+    await expect(firstUpload).rejects.toThrow(
+      'Popup window was closed prematurely.'
+    );
+  });
+});

--- a/packages/addon/src/test/integration/c2-reenable-trusts-stale-auth.test.ts
+++ b/packages/addon/src/test/integration/c2-reenable-trusts-stale-auth.test.ts
@@ -1,0 +1,89 @@
+/**
+ * C2 — Add-on re-enable trusts stale `STORAGE_KEY_AUTH` without
+ * re-validating against the backend.
+ *
+ * See ADDON-BUG-REPORTS-2026-07-22.md #C2 and
+ * ADDON-SYNC-VERIFIED-FINDINGS-2026-07-21.md §C2.
+ *
+ * Mechanism under test:
+ *   - Re-enabling the add-on re-runs background.ts's top-level `main()` IIFE
+ *     from scratch, identically to a cold start.
+ *   - `main()` calls `getLoginState()` (menu.ts), which is a PURE LOCAL
+ *     STORAGE READ -- it checks only for the presence of `refresh_token` in
+ *     `browser.storage.local[STORAGE_KEY_AUTH]`, with zero network call to
+ *     validate that token against the backend.
+ *   - `shouldInitCloudFileOnStartup(isLoggedIn)` is a pure boolean
+ *     passthrough of whatever `getLoginState()` produced.
+ *   - If `isLoggedIn` is (falsely) true, `initCloudFile()` runs, which
+ *     re-registers the cloud file provider and creates/reactivates a cloud
+ *     file account -- fully re-activating cloud-file features for a session
+ *     that may have been revoked entirely server-side.
+ *
+ * This test seeds a stale (but locally well-formed) auth object into shared
+ * storage, imports background.ts fresh (simulating a re-enable / cold
+ * start), and confirms initCloudFile()'s effects run (CloudFileAccounts
+ * re-registration + account creation) with ZERO network/API validation call
+ * having occurred anywhere in the process.
+ */
+import { STORAGE_KEY_AUTH } from '@send-frontend/lib/const';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type FakeHost } from './fakeThunderbirdHost';
+import { setupHost, stubContext, teardownHost } from './testHelpers';
+
+describe('C2: add-on re-enable trusts stale STORAGE_KEY_AUTH without backend revalidation', () => {
+  let host: FakeHost;
+
+  beforeEach(() => {
+    host = setupHost();
+  });
+
+  afterEach(() => {
+    teardownHost();
+  });
+
+  it('CONFIRMED BUG: re-enable (fresh module load) re-activates cloud file with no backend validation call', async () => {
+    const ctx = stubContext(host);
+
+    // Seed a previously-stored session -- this is exactly the shape
+    // getLoginState() checks: refresh_token + a resolvable username. In
+    // reality this token may have been revoked/expired server-side at any
+    // point after it was stored; nothing here re-checks that.
+    ctx.browser.storage.local.get = vi.fn(async () => ({
+      [STORAGE_KEY_AUTH]: {
+        refresh_token: 'potentially-revoked-refresh-token',
+        expires_at: Math.floor(Date.now() / 1000) - 999999, // long expired access token
+        profile: { preferred_username: 'user@example.com' },
+      },
+    }));
+
+    // Simulate re-enable: this is functionally identical to a cold start --
+    // the add-on's background page re-runs main() from scratch.
+    await import('../../background');
+
+    // Let main()'s async IIFE (checkAndUninstallIfDeprecated -> initMenu ->
+    // getLoginState -> initCloudFile chain) fully settle.
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // THE BUG: getLoginState() trusted the stale refresh_token's mere
+    // presence and returned isLoggedIn: true purely from local storage, so
+    // shouldInitCloudFileOnStartup() green-lit initCloudFile(), which:
+    //   1. re-registered the cloud file provider,
+    expect(ctx.browser.CloudFileAccounts.registerProvider).toHaveBeenCalled();
+    //   2. created/reactivated a cloud file account,
+    expect(ctx.browser.CloudFileAccounts.createAccount).toHaveBeenCalled();
+
+    // ...all without a SINGLE call that could have validated the refresh
+    // token against the backend (e.g. no auth/oidc/me equivalent, no
+    // api.call at all during this startup path). If a validation call
+    // existed, it would have to go through browser.storage.local (there is
+    // no other backend interface mocked here) or an explicit fetch --
+    // neither happened.
+    //
+    // (unregisterProvider is the "signed out" branch and must NOT have run,
+    // confirming the code took the "trust local storage" happy path.)
+    expect(ctx.browser.CloudFileAccounts.unregisterProvider).not.toHaveBeenCalled();
+  });
+});

--- a/packages/addon/src/test/integration/d3-init-single-flight-per-context-only.test.ts
+++ b/packages/addon/src/test/integration/d3-init-single-flight-per-context-only.test.ts
@@ -1,0 +1,224 @@
+/**
+ * D3 — `init.ts`'s single-flight guard is per-context only; cross-context
+ * default-folder race can reintroduce issue #930 (duplicate default
+ * folders).
+ *
+ * See ADDON-BUG-REPORTS-2026-07-22.md #D3 and
+ * ADDON-SYNC-VERIFIED-FINDINGS-2026-07-21.md §D3.
+ *
+ * Mechanism under test (send-frontend/src/lib/init.ts):
+ *   let inFlight: Promise<INIT_ERRORS> | null = null;
+ *   function init(...) {
+ *     if (inFlight) return inFlight;
+ *     inFlight = _init(...).finally(() => { inFlight = null; });
+ *     return inFlight;
+ *   }
+ *
+ * `inFlight` is a plain module-scope `let`. Background, popup, and any
+ * web-app tab each load their own independent copy of this module (see
+ * shared-pinia.ts's per-context-singleton comment, and A4/D1's identical
+ * reasoning) -- so this guard only ever prevents duplicate concurrent runs
+ * WITHIN one JS execution context. On its own it provides zero protection
+ * if two different contexts both decide, at the same moment, that the
+ * default folder's key is missing and both proceed to delete+recreate it.
+ *
+ * FIX (see issue #1032): init.ts now also acquires a short-TTL lock in
+ * `browser.storage.local`, keyed by account id, around the delete+recreate
+ * branch specifically. That storage is the one thing every context
+ * genuinely shares, so it's what lets one context's in-flight decision be
+ * visible to the others. This test drives the REAL `init.ts` module (not a
+ * reimplementation) via two separate module instances stubbed onto two
+ * separate fake-host contexts (the same technique used in the B5 spec to
+ * simulate a background restart), and proves that with the fix in place,
+ * only ONE of the two contexts performs the delete+recreate for a given
+ * account's default folder -- the other observes the lock and defers
+ * instead of independently recreating it.
+ */
+import { INIT_ERRORS } from '@send-frontend/apps/send/const';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createDeferred, setupHost, stubContext, teardownHost } from './testHelpers';
+import type { FakeHost } from './fakeThunderbirdHost';
+
+describe('D3: init.ts single-flight guard does not coordinate across contexts (fixed via storage lock)', () => {
+  let host: FakeHost;
+
+  beforeEach(() => {
+    host = setupHost();
+  });
+
+  afterEach(() => {
+    teardownHost();
+  });
+
+  it('FIXED: the lock does not deadlock -- a second context can still acquire it and run its own init after the first releases it', async () => {
+    const sharedAccountId = 'shared-account-id';
+
+    // --- "Context 1" (e.g. background) ---
+    stubContext(host, 'background');
+    const initModule1 = await import('@send-frontend/lib/init');
+    const init1 = initModule1.default;
+
+    const sync1Deferred = createDeferred<void>();
+    let context1SyncCalled = false;
+    const userStore1 = {
+      user: { id: sharedAccountId },
+      loadFromLocalStorage: vi.fn().mockResolvedValue(true),
+    };
+    const keychain1 = {
+      load: vi.fn().mockResolvedValue(true),
+      keys: {}, // no key for the default folder -> triggers delete+recreate branch
+    };
+    const folderStore1 = {
+      sync: vi.fn().mockImplementation(async () => {
+        context1SyncCalled = true;
+        return sync1Deferred.promise;
+      }),
+      defaultFolder: { id: 'shared-account-default-folder' },
+      deleteFolder: vi.fn().mockResolvedValue(undefined),
+      createFolder: vi.fn().mockResolvedValue({ id: 'new-folder-id' }),
+    };
+
+    // Start context 1's init() -- it will block inside folderStore.sync()
+    // until we resolve sync1Deferred below, simulating "context 1 is
+    // mid-init, hasn't yet decided to delete+recreate the folder."
+    const context1InitPromise = init1(
+      userStore1 as any,
+      keychain1 as any,
+      folderStore1 as any
+    );
+
+    // Let context 1 actually enter _init() and reach folderStore.sync().
+    await vi.waitFor(() => expect(context1SyncCalled).toBe(true));
+
+    // Let context 1 finish sync and go on to acquire the lock and run
+    // deleteFolder/createFolder, before context 2 gets a chance to try.
+    sync1Deferred.resolve();
+    await vi.waitFor(() => expect(folderStore1.createFolder).toHaveBeenCalled());
+
+    // --- "Context 2" (e.g. popup), a totally separate module instance,
+    // stubbed onto a SEPARATE fake-host context that shares the same
+    // underlying browser.storage.local backing store as context 1. ---
+    vi.resetModules();
+    stubContext(host, 'popup');
+    const initModule2 = await import('@send-frontend/lib/init');
+    const init2 = initModule2.default;
+
+    expect(init2).not.toBe(init1); // confirms genuinely separate module instances
+
+    const userStore2 = {
+      user: { id: sharedAccountId }, // SAME account
+      loadFromLocalStorage: vi.fn().mockResolvedValue(true),
+    };
+    const keychain2 = {
+      load: vi.fn().mockResolvedValue(true),
+      keys: {},
+    };
+    const folderStore2 = {
+      sync: vi.fn().mockResolvedValue(undefined),
+      defaultFolder: { id: 'shared-account-default-folder' }, // SAME folder
+      deleteFolder: vi.fn().mockResolvedValue(undefined),
+      createFolder: vi.fn().mockResolvedValue({ id: 'another-new-folder-id' }),
+    };
+
+    // By the time context 2 runs, context 1 has already released its lock
+    // (its delete+recreate finished above), so context 2 must be free to
+    // acquire it fresh and run its own decision -- the lock must not get
+    // stuck held forever after a clean release. (The actual overlap-
+    // prevention claim is covered by the next test, where the two contexts
+    // genuinely race.)
+    const context2Result = await init2(
+      userStore2 as any,
+      keychain2 as any,
+      folderStore2 as any
+    );
+
+    expect(context2Result).toBe(INIT_ERRORS.NONE);
+    expect(folderStore2.createFolder).toHaveBeenCalled();
+
+    const context1Result = await context1InitPromise;
+    expect(context1Result).toBe(INIT_ERRORS.NONE);
+    expect(folderStore1.createFolder).toHaveBeenCalled();
+  });
+
+  it('FIXED: a context racing an in-progress delete+recreate defers instead of running its own', async () => {
+    const sharedAccountId = 'another-shared-account-id';
+
+    // --- "Context 1" holds the lock and is mid delete+recreate ---
+    stubContext(host, 'background');
+    const initModule1 = await import('@send-frontend/lib/init');
+    const init1 = initModule1.default;
+
+    const deleteDeferred = createDeferred<void>();
+    let deleteFolderCalled = false;
+    const userStore1 = {
+      user: { id: sharedAccountId },
+      loadFromLocalStorage: vi.fn().mockResolvedValue(true),
+    };
+    const keychain1 = {
+      load: vi.fn().mockResolvedValue(true),
+      keys: {},
+    };
+    const folderStore1 = {
+      sync: vi.fn().mockResolvedValue(undefined),
+      defaultFolder: { id: 'another-shared-default-folder' },
+      deleteFolder: vi.fn().mockImplementation(async () => {
+        deleteFolderCalled = true;
+        return deleteDeferred.promise;
+      }),
+      createFolder: vi.fn().mockResolvedValue({ id: 'new-folder-id' }),
+    };
+
+    const context1InitPromise = init1(
+      userStore1 as any,
+      keychain1 as any,
+      folderStore1 as any
+    );
+
+    // Let context 1 reach deleteFolder -- it now holds the lock and is
+    // blocked inside the guarded section.
+    await vi.waitFor(() => expect(deleteFolderCalled).toBe(true));
+
+    // --- "Context 2" tries to init() for the SAME account while context 1
+    // still holds the lock. ---
+    vi.resetModules();
+    stubContext(host, 'popup');
+    const initModule2 = await import('@send-frontend/lib/init');
+    const init2 = initModule2.default;
+
+    const userStore2 = {
+      user: { id: sharedAccountId },
+      loadFromLocalStorage: vi.fn().mockResolvedValue(true),
+    };
+    const keychain2 = {
+      load: vi.fn().mockResolvedValue(true),
+      keys: {},
+    };
+    const folderStore2 = {
+      // After deferring to the lock, init() re-syncs and reports whatever
+      // context 1 leaves behind. Simulate that context 1's new folder is
+      // now visible.
+      sync: vi.fn().mockResolvedValue(undefined),
+      defaultFolder: { id: 'context-1s-recreated-folder' },
+      deleteFolder: vi.fn().mockResolvedValue(undefined),
+      createFolder: vi.fn().mockResolvedValue({ id: 'should-not-be-used' }),
+    };
+
+    const context2Result = await init2(
+      userStore2 as any,
+      keychain2 as any,
+      folderStore2 as any
+    );
+
+    // THE FIX: context 2 must NOT run its own delete+recreate while
+    // context 1's is still in flight for the same account.
+    expect(folderStore2.deleteFolder).not.toHaveBeenCalled();
+    expect(folderStore2.createFolder).not.toHaveBeenCalled();
+    expect(context2Result).toBe(INIT_ERRORS.NONE);
+
+    // Let context 1 finish.
+    deleteDeferred.resolve();
+    const context1Result = await context1InitPromise;
+    expect(context1Result).toBe(INIT_ERRORS.NONE);
+    expect(folderStore1.createFolder).toHaveBeenCalled();
+  });
+});

--- a/packages/send/e2e/ADDON-BUG-REPORTS-2026-07-22.md
+++ b/packages/send/e2e/ADDON-BUG-REPORTS-2026-07-22.md
@@ -1,0 +1,156 @@
+# Add-on Bug Reports — For Ticket Filing
+
+**Source:** Distilled from `ADDON-SYNC-VERIFIED-FINDINGS-2026-07-21.md` (full
+evidence/repro detail) and `TICKET-TRIAGE-TABLE-2026-07-21.md` (priority
+rationale). This file is the **concise, agent-consumable version** — enough
+to verify and file a ticket without reading the full findings doc, but link
+back to it for deep evidence if needed.
+
+**Verification method for all 17:** confirmed via direct source-code
+re-reading + existing/new vitest unit test runs. **None involved live
+Thunderbird testing** — see the "Needs Live Test" column; treat those as
+"structural gap 100% confirmed, exact runtime outcome unconfirmed."
+
+**Scope:** add-on client only (background script / popup / hamburger menu /
+web-app token-bridge sync). Backend bugs (BUG-1..8) are tracked separately
+and are NOT in this file. **Total: 17 add-on findings** (1 High client bug
+was previously grouped only in the priority-table pass and is restored here
+as C1 alongside B5).
+
+**All repro/evidence file paths are relative to** `~/.openclaw/workspace/projects/tbpro-add-on/`.
+
+---
+
+## How to use this file (for the filing agent)
+
+For each item below:
+1. Open the cited file(s)/line(s) and confirm the code still matches the
+   quoted snippet (repo may have moved since 2026-07-21).
+2. If confirmed unchanged: file a ticket using Title + Priority + Summary +
+   Repro/Evidence + Fix as the ticket body.
+3. If code has changed: re-check whether the fix already landed before
+   filing — note it in the ticket as "verify still open."
+4. Full technical writeup for any ID is in
+   `ADDON-SYNC-VERIFIED-FINDINGS-2026-07-21.md` (search by ID, e.g. "### B5").
+
+---
+
+## HIGH Priority
+
+### B5 — Background script restart mid-upload loses upload bookkeeping; share link still gets created server-side with zero user notification
+- **Files:** `packages/addon/src/background.ts` (upload queue state ~L187-190, `ALL_UPLOADS_COMPLETE` handler ~L528-556)
+- **Issue:** `uploadInfoQueue`, `uploadPromiseMap`, `popupWindowId` are plain in-memory module vars with no persistence to `browser.storage.*`. If the WebExtension background page restarts mid-upload, `uploadPromiseMap` is empty on the next `ALL_UPLOADS_COMPLETE` — the `forEach` resolving promises silently no-ops, but the `add-password` API call still runs unconditionally afterward. Net effect: a live, real, shareable link gets created and persisted server-side that the user is never told about and never gets to manage/revoke.
+- **Needs live test:** Whether TB's WebExtensions platform actually recycles background pages while `cloudFile.onFileUpload` promises are unresolved (platform behavior, not code-confirmable).
+- **Fix:** Persist pending upload IDs to `browser.storage.session`/`.local` so a restarted background can detect an orphaned completion and surface a notification instead of silently succeeding invisibly.
+
+### C1 — Add-on disabled mid-upload orphans popup window + in-flight promises
+- **Files:** grep for `onSuspend`/`onDisabled`/`onEnabled` across `packages/addon/src`, `packages/send/frontend/src` → zero matches
+- **Issue:** No lifecycle hook reacts to the add-on being disabled. If disabled mid-upload, the popup window and any pending `uploadPromiseMap` entries are orphaned with no cleanup — nothing resolves/rejects the waiting promises, nothing closes the popup.
+- **Needs live test:** Whether TB's platform-level window management auto-closes extension-created windows on disable (Gecko/TB platform behavior, not code-confirmable).
+- **Fix:** Register `browser.runtime.onSuspend` (where supported), or persist queue state via `browser.storage.session` so the next startup can detect and clean up an interrupted session.
+
+---
+
+## MEDIUM Priority
+
+### A1 — Web-tab logout doesn't abort an in-flight popup upload
+- **Files:** `packages/addon/src/background.ts` SIGN_OUT handler (~L352-361); `packages/send/frontend/src/apps/send/views/PopupView.vue` (~L139-146, only listens for `FILE_LIST`)
+- **Issue:** `SIGN_OUT` handler never touches `uploadInfoQueue`/`uploadPromiseMap`/`popupWindowId` and never messages an open popup. Popup's `onMessage` has no `SIGN_OUT` case. An upload started before logout can silently finish and get shared using the still-valid in-memory popup session.
+- **Partial mitigation exists:** `x-logout` header handling in `auth-store.ts` will eventually reject an in-flight request post-401, but this is reactive per-request, not a proactive abort.
+- **Fix:** Add `SIGN_OUT` case to popup's message listener (flip local "session ended" flag checked before each upload); forward `SIGN_OUT` from background to the popup window if open.
+
+### A2 — Hamburger-menu logout doesn't reach add-on background on non-matching origins (staging/localhost)
+- **Files:** `packages/addon/public/manifest.json` content_scripts matches (~L143-153, only `send.tb.pro`/`send-stage.tb.pro`/`http://localhost`); `packages/send/frontend/src/apps/send/stores/config-store.ts` `isThunderbirdHost` (~L11-14, plain User-Agent sniff); `UserMenu.vue` (~L35-46)
+- **Issue:** `isRunningInsideThunderbird` is a UA-string check totally independent of whether `token-bridge.js` is actually injected on the current origin. Any deployed host not matching the manifest's glob (e.g. `https://localhost` w/ https, `127.0.0.1`, any other staging domain) has the UA true but no bridge listener — the logout `postMessage` goes nowhere and the add-on silently stays logged in.
+- **Fix:** Broaden content-script `matches` to cover configured `VITE_SEND_CLIENT_URL` deployment hosts, or add an explicit content-script ping handshake before trusting `isRunningInsideThunderbird` for messaging.
+
+### A3 — `x-logout` forced logout can race concurrent multipart upload parts
+- **Files:** `packages/send/frontend/src/stores/auth-store.ts` `forcedLogoutInProgress` latch (~L277-289); `lib/const.ts` `MAX_CONCURRENT_PARTS = 4`
+- **Issue:** No `AbortController` wiring ties `handleForcedLogout()` to in-flight multipart upload parts (`useUploadAndShare.ts`/`folder-store.ts`). A forced logout mid-multipart-upload leaves already-issued parallel part-requests uncancelled.
+- **Needs live test:** Whether this actually produces a corrupt upload reported as `ALL_UPLOADS_COMPLETE` vs `ALL_UPLOADS_ABORTED` requires a live, timed server-side revocation — structural gap confirmed, exact outcome not.
+- **Fix:** Thread an `AbortController` through `uploadItem()` that aborts on `handleForcedLogout()`, mirroring background.ts's existing (but disconnected — see B2) abort wiring.
+
+### A4 — Cross-context `signinSilent()` refresh-token-rotation race → possible false logout
+- **Files:** `packages/send/frontend/src/stores/auth-store.ts` module-scope `inFlightRefresh`/`lastRefreshFailedGenuinely` (~L78-84); `lib/shared-pinia.ts` (per-context singleton, not cross-context)
+- **Issue:** Each of background/popup/web-tab gets its own independent module instance, so refresh-dedup guards don't coordinate across contexts. If the OIDC provider rotates refresh tokens on `signinSilent()`, a losing concurrent caller in another context could get `invalid_grant`.
+- **Needs live test:** Whether the OIDC provider (accounts.tb.pro) actually rotates tokens this way — provider behavior, not code-confirmable.
+- **Fix:** Add a cross-context mutex via `browser.storage.local` (short-TTL lock key) around `signinSilent()` calls.
+
+### A5 — `menuLogout()`'s blanket `storage.local.clear()` wipes unrelated in-flight data
+- **Files:** `packages/addon/src/menu.ts` `menuLogout()` (~L104-135, unconditional `browser.storage.local.clear()`)
+- **Issue:** Same `browser.storage.local` namespace also holds `PENDING_ADDON_TOKEN` (staged AccountHub login) and `SEND_MESSAGE_TO_BRIDGE` (staged passphrase) and per-account cloud-file server config. A logout racing either of those flows silently destroys them with no error surfaced.
+- **Fix:** Scope the clear to an explicit allow-list (at minimum `STORAGE_KEY_AUTH`) instead of a blanket `.clear()`.
+
+### A6 — Hamburger/web menu shows stale login state; no push refresh on `SIGN_OUT`/`OIDC_USER`
+- **Files:** `packages/send/frontend/src/lib/auth.ts` (~L38-42, `refetchOnMount`/`refetchOnWindowFocus` computed once at setup, not reactive); `UserMenu.vue` (sends `SIGN_OUT` but never listens for inbound); `menu.ts` `checkLoginStateOnInterval()` (60s poller only updates the add-on's own TBProMenu, not the web-app's `UserMenu.vue`)
+- **Issue:** No code path pushes a re-check of `isLoggedIn` into `UserMenu.vue` when another context signs out. UI can keep showing logged-in after a background-initiated sign-out.
+- **Fix:** Add a `browser.runtime.onMessage`/window-message listener in `useAuth()`/`UserMenu.vue` that triggers `refetchAuth()` on `SIGN_OUT`/`OIDC_USER`.
+
+### A7 — AccountHub-driven add-on login races a concurrent hamburger-menu web login for the same account
+- **Files:** `packages/addon/src/background.ts` `initAccountHubListener()`/`triggerAddonLogin()` (~L769-791, ~L636-644); `menu.ts` `menuLogin()` (~L31-36)
+- **Issue:** No mutual-exclusion guard between the two login flows. Both write to the same `STORAGE_KEY_AUTH` — last `OIDC_USER` message wins, silently overwriting the other's session data.
+- **Fix:** Add a shared "login in progress for this account" guard (e.g. `browser.storage.local` flag keyed by email) checked by both flows before opening a new tab.
+
+### B1 — Rapid `onFileUpload` bursts can drop a second batch's popup delivery
+- **Files:** `packages/addon/src/background.ts` `POPUP_READY` handler (~L493-500, sends entire queue then unconditionally clears it); `openUnifiedPopup()` guard (~L238-243)
+- **Issue:** Once a popup is open, subsequent `onFileUpload` bursts hit the "popup already open" guard and exit — nothing re-sends `FILE_LIST` or notifies the open popup. Files silently vanish into a queue nobody reads again, later surfacing as a misleading "popup closed prematurely" rejection.
+- **Note:** Zero existing unit test coverage for this queue/popup logic at all.
+- **Fix:** Add a batch ID/timestamp; require ack from popup before queue clear, or explicitly queue for the *next* popup rather than silently folding into the current one.
+
+### B2 — Popup closed mid-upload doesn't actually cancel the in-flight network request
+- **Files:** `packages/addon/src/background.ts` `windows.onRemoved` → `rejectAllInQueue()` (~L585-663); `folder-store.ts`/`useUploadAndShare.ts` (no `AbortController`/`signal` usage found)
+- **Issue:** The `AbortController` created in background.ts's `onFileUpload` listener is entirely disconnected from the popup's actual `fetch()`/upload calls — `rejectAllInQueue()`'s `.abort()` call aborts nothing on the network side; it only rejects background's own bookkeeping promise. Closing the popup does not stop the server-side upload — it can complete and become an orphaned, unrecorded item.
+- **Needs live test:** Whether the backend actually completes/persists the item after client window destruction (browser/OS fetch-keepalive + backend behavior).
+- **Fix:** Pass the `AbortController`'s `signal` into the popup's actual upload call via the message protocol; add a `beforeunload` handler in the popup to best-effort notify background before closing.
+
+### B3 — Check-then-act race in `openUnifiedPopup()`'s `popupWindowId` guard (no mutex around the `await`)
+- **Files:** `packages/addon/src/background.ts` `openUnifiedPopup()` (~L159-181); `popupTimer` debounce (~L148-150)
+- **Issue:** Guard reads `popupWindowId` synchronously but only sets it after `await browser.windows.create()` resolves. A second `onFileUpload` firing while that await is pending reads `popupWindowId` as still null and opens a second popup. The 250ms `popupTimer` debounce only gates *when* `openUnifiedPopup` is first called, not concurrent execution once called.
+- **Needs live test:** Real-world timing of how close together two `cloudFile.onFileUpload` events can fire, and `browser.windows.create()` latency.
+- **Fix:** Set a synchronous "opening" sentinel (e.g. `popupWindowId = 'pending'`) *before* the `await`, not only after.
+
+### B4 — Files attached while a popup is already open are dropped, not merged
+- **Files:** Same as B1/B3 — `openUnifiedPopup()` guard (~L238-243); `PopupView.vue` `files.value = message.files` (~L139-146, plain overwrite, no append)
+- **Issue:** Once popup is open, later-attached files never trigger a second `FILE_LIST` send; even if they did, the popup overwrites rather than merges. Combined with B2's window-close handling, these files end up rejected via `rejectAllInQueue()` when the first batch's popup eventually closes.
+- **Fix:** Same as B1 — merge into open popup via a new message type it listens for, or explicitly defer to next popup.
+
+### C2 — Add-on re-enable trusts stale `STORAGE_KEY_AUTH` without re-validating against backend
+- **Files:** `packages/addon/src/background.ts` `main()` (~L833-859); `menu.ts` `getLoginState()` (~L161-181, pure local-storage read, no network call); `cloudFileGate.ts` `shouldInitCloudFileOnStartup` (pure passthrough)
+- **Issue:** Re-enable re-runs `main()` identical to cold start. `getLoginState()` trusts mere presence of `refresh_token` in local storage with zero backend validation. A previously-revoked session stays "active" until an unrelated action happens to 401.
+- **Fix:** After `getLoginState()` returns true, fire a non-blocking backend validation call (e.g. `auth/oidc/me`) and run forced-logout cleanup if it fails.
+
+### D2 — `pullBridgedPassphrase()`'s one-shot consume can race two concurrent restorers
+- **Files:** `packages/send/frontend/src/lib/bridgePassphrase.ts` `pullBridgedPassphrase()` (~L20-38, plain get-then-remove, no lock); `lib/keychain.ts` `restoreKeysUsingLocalStorage()` (~L720-733, called independently by both background startup and `PopupView.vue#initialize()`)
+- **Issue:** No lock around the bridge-to-keychain handoff. Narrow window: if context B's read happens strictly between context A's get() and its store-write, both could end up empty-handed, requiring the user to re-enter their passphrase.
+- **Assessment:** Likely benign in the common case (both read the same shared moz-extension-origin localStorage value), but the narrow race is real and unguarded.
+- **Fix:** Add compare-and-swap-style lock around the handoff, or make restore tolerant of "already consumed" by re-checking after a short delay instead of treating empty as final.
+
+### D3 — `init.ts`'s single-flight guard is per-context only; cross-context race can reintroduce issue #930 (duplicate default folders)
+- **Files:** `packages/send/frontend/src/lib/init.ts` `inFlight` (~L71-85, plain module-scope `let`)
+- **Issue:** Guard only prevents duplicate delete/recreate races *within* one JS context. Background, popup, and web-tab each have independent `inFlight` state — nothing stops all three from being `null` simultaneously and each performing the delete+recreate for the same account, exactly reintroducing the bug the guard was meant to fix.
+- **Fix:** Add a `browser.storage.local`-based mutex (short-TTL lock keyed by account id) around the default-folder-recreate branch.
+
+---
+
+## Summary Table
+
+| ID | Title | Priority | Confidence |
+|----|-------|----------|------------|
+| B5 | Background restart mid-upload loses bookkeeping, link still created silently | High | High |
+| C1 | Add-on disabled mid-upload orphans popup + promises | High | High (cleanup absence confirmed; TB auto-close behavior needs live test) |
+| A1 | Logout doesn't abort in-flight popup upload | Medium | High |
+| A2 | Hamburger-menu logout doesn't reach add-on on non-matching origin | Medium | High |
+| A3 | Forced logout races concurrent multipart upload parts | Medium | Medium (needs live test for exact outcome) |
+| A4 | Cross-context refresh-token race → false logout | Medium | Medium (OIDC provider behavior unconfirmed) |
+| A5 | `menuLogout()` blanket storage clear wipes unrelated data | Medium | High |
+| A6 | Menu/UI shows stale login state, no push refresh | Medium | High |
+| A7 | AccountHub login races concurrent web login | Medium | High |
+| B1 | Rapid upload bursts drop second batch | Medium | High (zero test coverage) |
+| B2 | Popup close doesn't cancel in-flight network upload | Medium | Medium (server-side outcome needs live test) |
+| B3 | `popupWindowId` check-then-act race can open two popups | Medium | Medium (needs live timing test) |
+| B4 | Files attached while popup open are dropped, not merged | Medium | High |
+| C2 | Add-on re-enable trusts stale auth without revalidation | Medium | High |
+| D2 | Bridged-passphrase one-shot consume race | Medium | Medium (likely benign in common case) |
+| D3 | `init.ts` single-flight guard is per-context only | Medium | High |
+
+**Not included here (separate, backend-only):** BUG-1, BUG-2, BUG-3, BUG-4, BUG-5, BUG-6, BUG-7, BUG-8 — see `TICKET-TRIAGE-TABLE-2026-07-21.md`.

--- a/packages/send/e2e/ADDON-INTEGRATION-TEST-ENV-PLAN-2026-07-22.md
+++ b/packages/send/e2e/ADDON-INTEGRATION-TEST-ENV-PLAN-2026-07-22.md
@@ -1,0 +1,285 @@
+# Plan: Add-on ↔ Hamburger Menu ↔ Popup ↔ Web-Client Integration Test Environment
+
+**Date:** 2026-07-22
+**Author:** Munky (assistant), for Alejandro
+**Motivation:** The 17 A/B/C/D sync-race findings in
+`ADDON-SYNC-VERIFIED-FINDINGS-2026-07-21.md` were all confirmed by source
+reading + unit tests, but every one of them carries a caveat like *"needs
+live Thunderbird testing"* because this repo has **no automated harness that
+actually runs the four surfaces together** the way a real user's Thunderbird
+does. This plan proposes building that harness.
+
+---
+
+## 1. The four surfaces, restated
+
+| # | Surface | Where it lives | Runs inside real TB as |
+|---|---|---|---|
+| 1 | **Background script** | `packages/addon/src/background.ts` (system build, has experiment APIs) / `packages/send/frontend/src/background.ts` (plain/dev twin) | a non-persistent WebExtension background page |
+| 2 | **Upload popup** | `packages/send/frontend/src/apps/send/views/PopupView.vue`, opened via `browser.windows.create(index.extension.html)` | a real OS popup window |
+| 3 | **Hamburger/TBPro menu** | `packages/addon/src/menu.ts` + `public/api/TBProMenu/implementation.js` | **privileged chrome UI injected directly into `messenger.xhtml`** via `ChromeUtils`/`ExtensionCommon.ExtensionAPI` — this is not a webpage, not a popup, not reachable by web-ext/Playwright at all |
+| 4 | **Web client** | `packages/send/frontend` (send.tb.pro), bridged via `public/token-bridge.js` content script | an ordinary tab, or the in-app `UserMenu.vue` |
+
+**The key finding from source review:** surface #3 (hamburger menu) is built
+with `ChromeUtils.importESModule('resource:///modules/cloudFileAccounts.sys.mjs')`
+and `ExtensionCommon.ExtensionAPI` — these are Thunderbird-internal privileged
+APIs that only exist inside an actual running Thunderbird process. **There is
+no way to test the hamburger menu without a real Thunderbird binary.** Any
+"integration environment" that wants to cover all four surfaces, including
+the menu, must ultimately drive a real Thunderbird window. Everything else
+(background, popup, web client, token-bridge) *can* be faked/simulated
+outside Thunderbird, and should be, for speed — but the menu is the forcing
+function for a real-Thunderbird tier.
+
+This means the environment should be **three tiers**, not one — each tier
+trading off speed/determinism against realism, matching what each of the 17
+findings actually needs to be verified.
+
+---
+
+## 2. Tier 1 — Fake-host cross-context harness (fast, deterministic, CI-friendly)
+
+**Goal:** Simulate the *3 JS-only* surfaces (background, popup, web-tab) as
+separate execution contexts communicating only through the same primitives
+they use in real Thunderbird — `browser.runtime.sendMessage`,
+`browser.storage.local` (+ `onChanged`), `browser.windows`, `browser.tabs`,
+and `window.postMessage`/content-script bridging — without needing Thunderbird
+at all. This directly targets 13 of the 17 A/B/C/D findings (everything
+except the ones that fundamentally need real platform timing/window
+management: B3, B5, C1, and the live-account-effect halves of A3/B2).
+
+### Why this is worth building first
+- It's the **only tier that can deterministically control timing** — most of
+  the 17 findings are races that are rare/unreproducible by hand. A fake host
+  can force the exact interleaving (e.g. "fire `SIGN_OUT` exactly while an
+  upload's `fetch()` is in flight") every single run.
+- Runs in plain Node/Vitest, no Docker, no Thunderbird binary, no macOS-only
+  tooling — can run in CI on every PR.
+- Reuses infrastructure that already exists: `packages/addon/src/test/*`
+  already mocks `browser.*`; `initSharedPinia()` already isolates state per
+  context; the existing 41 addon unit tests are close to this shape already,
+  just single-context.
+
+### What to build
+1. **`packages/addon/src/test/fakeThunderbirdHost.ts`** — a shared test
+   utility that:
+   - Creates 2–3 independent `browser.*` mock instances (one per simulated
+     context: background, popup, web-tab), each with its own
+     `runtime.onMessage` listener array, but sharing one **fake
+     `browser.storage.local`** backing store with real `onChanged` firing
+     (this is the actual cross-context sync primitive in production — a real
+     shared store is important, not per-context mocks).
+   - Wires `browser.runtime.sendMessage` calls from any context to fan out
+     to every other context's `onMessage` listeners (mirrors real
+     WebExtension messaging).
+   - Provides a fake `browser.windows.create/onRemoved` that tracks
+     "popup window" lifecycle so `popupWindowId` logic can be exercised
+     (open/close/check-then-act races).
+   - Provides fake `browser.tabs.create/query/sendMessage` for the
+     token-bridge web-tab simulation.
+   - Exposes a manual clock (vitest fake timers) so tests can pause
+     execution mid-`await` and interleave two contexts' code deterministically.
+   - Stubs `browser.TBProMenu`, `browser.CloudFileAccounts`,
+     `browser.MailAccounts`, `browser.AccountHub`, `browser.cloudFile` as
+     spies (Tier 1 does not need real chrome UI — it only needs to assert
+     *that* `menuLoggedIn`/`menuLogout`/`registerProvider` etc. were called
+     with the right args at the right time, which is what actually matters
+     for the sync-race bugs).
+2. **Load the *real* `background.ts`, `menu.ts`, `token-bridge.js`, and
+   `PopupView.vue`/auth-store code into each simulated context** (not
+   re-implementations) — import the actual modules and mount them against
+   the fake `browser` global per context, the same way the current single-
+   context unit tests already do, just three instances instead of one.
+3. **Write one integration spec per confirmed finding**, in a new
+   `packages/addon/src/test/integration/` dir, e.g.:
+   - `a1-logout-during-upload.test.ts`
+   - `a4-concurrent-token-refresh.test.ts`
+   - `a5-logout-clears-unrelated-storage.test.ts`
+   - `b1-rapid-attach-before-popup-ready.test.ts`
+   - `b2-popup-close-mid-upload.test.ts`
+   - `b4-attach-while-popup-busy.test.ts`
+   - `c2-reenable-stale-token.test.ts`
+   - `d2-passphrase-consume-race.test.ts`
+   - `d3-cross-context-duplicate-folder.test.ts`
+   - … etc. Each test drives the fake host into the exact race window
+     described in the finding and asserts the *current* (buggy) behavior,
+     so these specs double as **regression tests once each bug is fixed** —
+     they should fail today (documenting the bug) and pass after a fix.
+4. Add `pnpm --filter addon test:integration` script wired into
+   `ci:validate` alongside the existing unit tests.
+
+### Effort estimate
+Medium — 1 fake-host utility (~1–2 days) + ~13 integration specs (~0.5–1 day
+each depending on how deep the race is) ≈ **1.5–2.5 weeks** for full A/B/C/D
+coverage. Can be delivered incrementally, ticket by ticket, in the same
+order as the triage priority list (B5/B1/B2/B4 first as High/Medium client
+bugs, then the A-series auth races, then C/D).
+
+---
+
+## 3. Tier 2 — Real Thunderbird, lightweight (manual + semi-scripted smoke)
+
+**Goal:** Get the actual hamburger menu, actual popup window management, and
+actual `cloudFile.onFileUpload` compose integration under test, without
+paying for a full comm-central source build. Use this for the things Tier 1
+*cannot* touch: B3 (real popup-window race timing), B5 (does TB's WebExtension
+platform actually recycle a non-persistent background page mid-upload), C1
+(does disabling the add-on actually close its windows).
+
+### Environment
+- **Thunderbird Daily/Nightly** build (not the release build already
+  installed at `/Applications/Thunderbird.app`, currently 148.0.1 release).
+  Daily builds ship with `xpinstall.signatures.required=false` and
+  `extensions.experiments.enabled=true` by default, so the add-on's
+  `experiment_apis` (TBProMenu, CloudFileAccounts, MailAccounts, AccountHub)
+  load without needing a full source build or signing.
+  - Download: https://www.thunderbird.net/en-US/download/daily/
+  - Alternative: flip the two prefs above on the existing release install via
+    a dedicated test profile (`./thunderbird -P tb-addon-test-profile`) if
+    Daily is undesirable — needs verifying those prefs aren't locked in
+    release builds on macOS; Daily is the documented, lower-friction path.
+- **Local Send stack** — reuse the existing `docker compose` stack
+  (`compose.yml`) exactly as-is: `pnpm dev:send` brings up postgres +
+  backend + reverse-proxy (`https://localhost:8088`) + frontend
+  (`http://localhost:5173`).
+- **Add-on build** — `pnpm --filter addon build:dev:system:local` (the repo
+  already has this exact "system add-on wired to localhost" build path
+  documented in `packages/addon/README.md`). Handles the self-signed cert
+  gotcha via the documented `security.enterprise_roots.enabled=true` +
+  macOS keychain trust, so `wss://` uploads work end-to-end against the
+  local backend.
+- **Install** — for Daily, install the built `dist/` as a **temporary
+  add-on** (Tools → Developer Tools → Debug Add-ons → Load Temporary
+  Add-on → select `dist/manifest.json`). This is the closest to "real"
+  without a comm-central build: real chrome hamburger menu, real popup
+  windows, real cloudFile provider registration — just running under the
+  standalone id instead of the system id (acceptable for everything except
+  `installGate.ts`/`selfUninstall.ts`'s id-keyed guards, which are Tier 3's
+  job).
+
+### What to script vs. do by hand
+- **By hand (exploratory, ad hoc):** clicking the hamburger menu, watching
+  it update after login/logout, dragging attachments into compose to trigger
+  multiple `onFileUpload` events close together (for B3), disabling the
+  add-on mid-upload from the Add-ons Manager (for C1).
+- **Semi-scripted via Marionette** (Thunderbird ships Marionette support —
+  see `mach marionette-test`): write a small Python/JS Marionette script
+  that drives the already-running Daily instance (connect over the
+  Marionette port) to click hamburger menu items, open compose windows, and
+  attach files programmatically with controlled timing — this gets you
+  repeatable B3/C1 checks without needing the full comm-central mochitest
+  environment. Marionette can attach to *any* running Thunderbird that was
+  started with `--marionette`, it doesn't require building from source.
+
+### Effort estimate
+Low-to-medium — mostly reuses existing repo tooling (build:dev:system:local,
+docker compose, the documented cert-trust steps). Main new work is a
+Marionette driver script (~2-3 days) plus a written exploratory test
+checklist for the manual parts. Good candidate for a fast follow after Tier 1.
+
+---
+
+## 4. Tier 3 — Full comm-central mochitest (authoritative, CI-grade, heavy)
+
+**Goal:** The only environment that is bit-for-bit what a real Thunderbird
+user runs: the add-on vendored at
+`comm/mail/extensions/builtin-addons/thundermail/extension/`, built under the
+**system add-on id**, loaded from `resource://builtin-addons/thundermail/`,
+enabled by default, tested via Thunderbird's own mochitest browser-test
+framework (`mach mochitest`) which mounts full `messenger.xhtml` windows and
+uses `EventUtils`/`BrowserTestUtils` to script real UI — including the
+hamburger menu — headlessly in CI.
+
+This is the tier that fully retires every "needs live Thunderbird testing"
+caveat in `ADDON-SYNC-VERIFIED-FINDINGS-2026-07-21.md`, including the ones
+Tier 2 can't reach cheaply (C2's exact downstream 401 surfacing, D1/D2's
+sub-second multi-window timing, general "does the dashboard actually show an
+orphaned item" questions).
+
+### Environment
+1. **comm-central checkout + build** — follow
+   https://developer.thunderbird.net/thunderbird-development/setting-up-a-build-environment
+   (macOS prerequisites doc referenced from that page). This is a multi-hour
+   one-time build (`./mach bootstrap` + `./mach build`), needs its own disk
+   budget (~30GB+) and is the heaviest part of this plan.
+2. **Vendor the add-on** — the repo already has the tooling for this:
+   ```sh
+   export TB_COMM_SRC=/path/to/comm-central
+   pnpm --filter addon sync:builtin:local   # or sync:builtin for prod/stage
+   cd "$TB_COMM_SRC" && ./mach build faster
+   ```
+3. **Write mochitest browser tests** under a new
+   `comm/mail/extensions/builtin-addons/thundermail/test/browser/` dir (or
+   wherever Thunderbird's own extension mochitests for built-ins live —
+   confirm exact convention against `mail/components/extensions/test/browser`
+   as a template), scripting:
+   - Hamburger menu state transitions (logged-out → logged-in →
+     stale-after-external-logout, matching A6).
+   - Real `cloudFile.onFileUpload` firing from an actual compose window with
+     multiple attachments dropped in quick succession (B1/B3/B4 with real
+     platform timing instead of simulated).
+   - Disabling/re-enabling the add-on via `AddonManager` mid-upload (C1/C2)
+     and asserting on real window lifecycle (does TB actually close the
+     popup window it opened?).
+   - A genuine background-page teardown/restart forced via
+     `Extension.terminateBackground()` or profile idle-shutdown timers, to
+     settle B5's core platform question.
+   - Full `SIGN_OUT`/logout-tab race against the real menu using
+     `BrowserTestUtils.openNewForegroundTab` + `EventUtils.synthesizeMouseAtCenter`
+     on the actual injected `tbpro-menu-id-*` XUL elements from
+     `public/api/TBProMenu/implementation.js`.
+4. **Run with `mach mochitest --headless`** in CI via a new GitHub Actions
+   job (separate from the existing `e2e-*` Playwright jobs, since this
+   requires a full comm-central build environment/container — likely its
+   own scheduled/nightly job rather than per-PR, given build time).
+
+### Effort estimate
+High — the comm-central build/bootstrap alone is a multi-hour one-time cost
+and a non-trivial CI image to maintain (would need a persistent
+prebuilt-object-directory cache akin to Mozilla's own CI, or accept slow
+builds). Writing the actual mochitest specs is comparable effort to Tier 1's
+integration specs, but each one requires learning Thunderbird's
+mochitest/`BrowserTestUtils` idioms rather than reusing existing
+Vitest/Playwright knowledge already in this repo. Estimate **3–5 weeks**
+including the one-time environment setup, best treated as a follow-on
+investment once Tier 1 has already caught the cheap wins and Tier 2 has
+validated the riskier findings by hand.
+
+---
+
+## 5. Recommended sequencing
+
+| Order | Tier | Covers | Effort | When |
+|---|---|---|---|---|
+| 1 | **Tier 1** (fake host) | A1,A2,A4,A5,A6,A7,B1,B2,B4,C2,D1,D2,D3 (13/17) | 1.5–2.5 wk | Now — highest bug-catching ROI, no infra needed, can start immediately, doubles as CI regression suite |
+| 2 | **Tier 2** (real Daily + temp install) | B3,C1 fully; B5,A3,B2 partially (real timing/platform confirmation) | few days–1 wk | Right after Tier 1, or in parallel — mostly reuses existing repo tooling |
+| 3 | **Tier 3** (comm-central mochitest) | Closes every remaining live-Thunderbird caveat, becomes permanent regression coverage for the real shipped built-in add-on | 3–5 wk | Later — biggest investment, best justified once Tier 1+2 have already fixed/confirmed the cheaper findings and the team wants durable CI coverage matching production exactly |
+
+**Immediate next step recommendation:** Start Tier 1 with the `B5` and `B1`
+specs first — both are already High/Medium priority in the triage table
+(`TICKET-TRIAGE-TABLE-2026-07-21.md`) and are pure background/popup-queue
+logic with no chrome-menu dependency, so they're the fastest path to a
+working fake-host harness plus a first real regression test.
+
+---
+
+## 6. Open questions / things to confirm with the team before starting
+
+1. **Daily vs. profile-pref-flip for Tier 2** — confirm whether
+   `xpinstall.signatures.required` / `extensions.experiments.enabled` are
+   actually user-settable (not policy-locked) on the release
+   `/Applications/Thunderbird.app` 148.0.1 already installed, which would let
+   Tier 2 skip downloading Daily entirely.
+2. **Marionette script maintenance owner** — Tier 2's semi-scripted timing
+   tests are the newest kind of test this team would maintain; confirm who
+   owns Marionette-based scripts going forward (vs. Playwright, which the
+   team already owns via `packages/send/e2e`).
+3. **Tier 3 CI budget** — a full comm-central build is a large, ongoing CI
+   cost (compute + cache storage). Confirm whether this is worth a dedicated
+   nightly job vs. running it manually/quarterly as a spot-check before
+   major releases.
+4. **Mochitest test location convention** — confirm with a Thunderbird
+   platform engineer where built-in-add-on-specific mochitests should live
+   in the comm-central tree (this plan assumes alongside
+   `mail/components/extensions/test/browser` but that needs verifying
+   against current comm-central conventions, which may have changed).

--- a/packages/send/frontend/src/lib/init.ts
+++ b/packages/send/frontend/src/lib/init.ts
@@ -7,6 +7,10 @@ import {
 import { useFolderStore } from '@send-frontend/stores';
 import useApiStore from '@send-frontend/stores/api-store';
 import { UserStoreType as UserStore } from '@send-frontend/stores/user-store';
+import {
+  acquireDefaultFolderLock,
+  releaseDefaultFolderLock,
+} from '@send-frontend/lib/initFolderLock';
 
 /**
  * Loads user and keychain from storage; creates default folder if necessary.
@@ -48,26 +52,58 @@ async function _init(
   const defaultFolderKeyIsMissing =
     defaultFolder && !keychain.keys[defaultFolder.id];
 
-  if (defaultFolderKeyIsMissing) {
-    console.warn(
-      `Default folder ${defaultFolder.id} exists but has no key. Deleting orphaned container and recreating.`
-    );
-    await folderStore.deleteFolder(defaultFolder.id);
-  }
-
   if (!defaultFolder || defaultFolderKeyIsMissing) {
-    const createFolderResp = await folderStore.createFolder();
-    if (!createFolderResp?.id) {
-      return INIT_ERRORS.COULD_NOT_CREATE_DEFAULT_FOLDER;
+    // The delete+recreate branch below is the one that must never run twice
+    // concurrently for the same account (see #930, #1032): background, popup,
+    // and any web-app tab each hold their own JS module instance of this file,
+    // so the in-process `inFlight` guard in init() below only protects against
+    // duplicate runs WITHIN one of those contexts, not across them. This
+    // storage-backed lock is the cross-context equivalent -- it's a no-op (and
+    // this whole branch just proceeds unguarded) in any context where
+    // `browser.storage.local` isn't available, since only extension contexts
+    // can race each other this way; a lone web-app tab has no sibling context
+    // to race against.
+    const lockToken = await acquireDefaultFolderLock(userStore.user?.id);
+
+    if (lockToken === null) {
+      // Another context currently holds the lock and is already deciding
+      // whether to delete + recreate this exact account's default folder.
+      // Don't pile on: re-sync and trust whatever that other context leaves
+      // behind rather than racing it. If it fails partway (e.g. the tab
+      // closes), the lock's short TTL lets the next init() attempt through.
+      await folderStore.sync();
+      return folderStore?.defaultFolder ? INIT_ERRORS.NONE : INIT_ERRORS.NO_KEYCHAIN;
+    }
+
+    try {
+      if (defaultFolderKeyIsMissing) {
+        console.warn(
+          `Default folder ${defaultFolder.id} exists but has no key. Deleting orphaned container and recreating.`
+        );
+        await folderStore.deleteFolder(defaultFolder.id);
+      }
+
+      const createFolderResp = await folderStore.createFolder();
+      if (!createFolderResp?.id) {
+        return INIT_ERRORS.COULD_NOT_CREATE_DEFAULT_FOLDER;
+      }
+    } finally {
+      await releaseDefaultFolderLock(userStore.user?.id, lockToken);
     }
   }
 
   return INIT_ERRORS.NONE;
 }
 
-// Single-flight guard: concurrent callers (e.g. the login flow and dbUserSetup
-// firing during the same rapid navigation) share one run instead of each
-// independently deciding to delete + recreate the default folder. See issue #930.
+// Single-flight guard: concurrent callers WITHIN THE SAME CONTEXT (e.g. the
+// login flow and dbUserSetup firing during the same rapid navigation) share
+// one run instead of each independently deciding to delete + recreate the
+// default folder. See issue #930.
+//
+// This only helps callers sharing this exact module instance. It does NOT
+// coordinate across background/popup/web-tab contexts, each of which loads
+// its own independent copy of this module -- that's what the storage-backed
+// lock inside _init() above is for. See issue #1032.
 let inFlight: Promise<INIT_ERRORS> | null = null;
 
 function init(

--- a/packages/send/frontend/src/lib/initFolderLock.ts
+++ b/packages/send/frontend/src/lib/initFolderLock.ts
@@ -1,0 +1,118 @@
+/**
+ * Cross-context lock for the default-folder delete+recreate branch in
+ * init.ts. See issue #1032 (and its ancestor, #930).
+ *
+ * Why this exists: background.ts, the popup, and any web-app tab bridged
+ * into the extension each load their OWN independent copy of init.ts as a
+ * separate JS module instance (same reasoning as shared-pinia.ts's
+ * per-context-singleton comment). A plain in-memory flag in one of those
+ * copies is invisible to the others. `browser.storage.local` is the one
+ * thing all of those contexts genuinely share, so it's the only place a
+ * lock that actually works across contexts can live.
+ *
+ * This is intentionally a short-TTL lock, not a queue or a hard mutex: if a
+ * context dies while holding it (tab closed, background page recycled), we
+ * want the next init() call to be able to proceed after a few seconds
+ * rather than being stuck forever. The tradeoff is a small window where two
+ * contexts could still both proceed if one crashes at the exact wrong
+ * moment inside its TTL -- that's an acceptable residual risk for a race
+ * that was previously unguarded 100% of the time.
+ */
+
+const LOCK_TTL_MS = 15_000;
+
+function lockStorageKey(accountId: string): string {
+  return `tbpro-init-folder-lock:${accountId}`;
+}
+
+interface LockRecord {
+  token: string;
+  expiresAt: number;
+}
+
+function generateToken(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  // Fallback for environments without crypto.randomUUID (matches the
+  // fallback pattern already used in keychain.ts).
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+function hasExtensionStorage(): boolean {
+  return (
+    typeof browser !== 'undefined' &&
+    !!browser?.storage?.local &&
+    typeof browser.storage.local.get === 'function'
+  );
+}
+
+/**
+ * Attempt to acquire the default-folder lock for this account.
+ *
+ * Returns a token to pass to releaseDefaultFolderLock() on success, or
+ * `null` if another context currently holds an unexpired lock.
+ *
+ * In any context without `browser.storage.local` (e.g. a plain web-app tab
+ * with no sibling extension context to race against), this always
+ * "succeeds" by returning a token that release() will just no-op on --
+ * there's nothing to coordinate with, so the delete+recreate branch proceeds
+ * exactly as it did before this fix existed.
+ */
+export async function acquireDefaultFolderLock(
+  accountId: string | undefined
+): Promise<string | null> {
+  if (!accountId || !hasExtensionStorage()) {
+    return generateToken();
+  }
+
+  const key = lockStorageKey(accountId);
+  const now = Date.now();
+
+  const existing = (await browser.storage.local.get(key))?.[key] as
+    | LockRecord
+    | undefined;
+
+  if (existing && existing.expiresAt > now) {
+    // Someone else holds an unexpired lock for this account.
+    return null;
+  }
+
+  const token = generateToken();
+  const record: LockRecord = { token, expiresAt: now + LOCK_TTL_MS };
+  await browser.storage.local.set({ [key]: record });
+
+  // Guard against a rare concurrent-write race: two contexts can both pass
+  // the `existing` check above in the same tick (there's no atomic
+  // read-modify-write in the storage.local API), then both write. Re-read
+  // after writing and only proceed if OUR token is the one that stuck.
+  const confirmed = (await browser.storage.local.get(key))?.[key] as
+    | LockRecord
+    | undefined;
+
+  return confirmed?.token === token ? token : null;
+}
+
+/**
+ * Release a previously-acquired lock. Only clears the stored record if it
+ * still matches the token we were given -- if the lock already expired and
+ * a different context has since taken it over, we must not clear their
+ * lock out from under them.
+ */
+export async function releaseDefaultFolderLock(
+  accountId: string | undefined,
+  token: string
+): Promise<void> {
+  if (!accountId || !hasExtensionStorage()) {
+    return;
+  }
+
+  const key = lockStorageKey(accountId);
+  const existing = (await browser.storage.local.get(key))?.[key] as
+    | LockRecord
+    | undefined;
+
+  if (existing?.token === token) {
+    await browser.storage.local.remove(key);
+  }
+}


### PR DESCRIPTION
Depends on #1042 (and the two PRs before that).

Tracks #1038. Part of the overall test coverage effort in #1034.

## What

Adds four integration tests covering the upload popup mishandling files when things happen close together in time:

- Attaching a second batch of files while the popup is already open makes that batch vanish — it never appears, and can later surface as a confusing "popup closed prematurely" error. (#1026)
- Closing the popup window while an upload is running doesn't actually cancel the upload on the server — it can finish anyway and become an orphaned item nobody knows about. (#1027)
- Attaching files in very quick succession can open two popup windows instead of one, because the code that guards against that only sets its flag after the window finishes opening, not before. (#1028)
- Files attached while the popup is already open just get dropped instead of added to the list. (#1029)

All four tests currently assert the buggy behavior. There was zero existing test coverage of this popup/queue logic before this PR.

## Why

These are all variations of the same underlying gap: the popup's file queue and window-open logic were never designed with concurrent/rapid-fire attach events in mind, and nothing was testing that path at all. This locks in the current (broken) behavior as a baseline so fixes can be verified.

## Testing

```
cd packages/addon && VITE_TESTING=true VITE_SEND_CLIENT_URL=https://send.tb.pro VITE_SEND_SERVER_URL=https://localhost:8088 npx vitest run
```

## Next steps

This is PR 4 of the stack. Next up: the re-enable/init-guard bugs (#1039), then docs (#1040).