### PR TITLE
fix(addon): cross-context lock for default-folder recreate race

### DIFF
--- a/packages/addon/src/test/integration/d3-init-single-flight-per-context-only.test.ts
+++ b/packages/addon/src/test/integration/d3-init-single-flight-per-context-only.test.ts
@@ -18,38 +18,52 @@
  * web-app tab each load their own independent copy of this module (see
  * shared-pinia.ts's per-context-singleton comment, and A4/D1's identical
  * reasoning) -- so this guard only ever prevents duplicate concurrent runs
- * WITHIN one JS execution context. It provides zero protection if two
- * different contexts both decide, at the same moment, that the default
- * folder's key is missing and both proceed to delete+recreate it.
+ * WITHIN one JS execution context. On its own it provides zero protection
+ * if two different contexts both decide, at the same moment, that the
+ * default folder's key is missing and both proceed to delete+recreate it.
  *
- * This test drives the REAL `init.ts` module (not a reimplementation) via
- * two separate module instances (simulating two execution contexts, the
- * same technique used in the B5 spec to simulate a background restart) and
- * proves BOTH contexts' `inFlight` guards independently allow `_init()` to
- * run concurrently for the same "orphaned default folder" scenario -- i.e.
- * neither context's guard has any awareness of the other.
+ * FIX (see issue #1032): init.ts now also acquires a short-TTL lock in
+ * `browser.storage.local`, keyed by account id, around the delete+recreate
+ * branch specifically. That storage is the one thing every context
+ * genuinely shares, so it's what lets one context's in-flight decision be
+ * visible to the others. This test drives the REAL `init.ts` module (not a
+ * reimplementation) via two separate module instances stubbed onto two
+ * separate fake-host contexts (the same technique used in the B5 spec to
+ * simulate a background restart), and proves that with the fix in place,
+ * only ONE of the two contexts performs the delete+recreate for a given
+ * account's default folder -- the other observes the lock and defers
+ * instead of independently recreating it.
  */
 import { INIT_ERRORS } from '@send-frontend/apps/send/const';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { createDeferred } from './testHelpers';
+import { createDeferred, setupHost, stubContext, teardownHost } from './testHelpers';
+import type { FakeHost } from './fakeThunderbirdHost';
 
-describe('D3: init.ts single-flight guard does not coordinate across contexts', () => {
+describe('D3: init.ts single-flight guard does not coordinate across contexts (fixed via storage lock)', () => {
+  let host: FakeHost;
+
   beforeEach(() => {
-    vi.resetModules();
+    host = setupHost();
   });
 
   afterEach(() => {
-    vi.restoreAllMocks();
+    teardownHost();
   });
 
-  it('CONFIRMED BUG: two independent module instances (contexts) both run _init() concurrently for the same account with no shared lock', async () => {
+  it('FIXED: the lock does not deadlock -- a second context can still acquire it and run its own init after the first releases it', async () => {
+    const sharedAccountId = 'shared-account-id';
+
     // --- "Context 1" (e.g. background) ---
+    stubContext(host, 'background');
     const initModule1 = await import('@send-frontend/lib/init');
     const init1 = initModule1.default;
 
     const sync1Deferred = createDeferred<void>();
     let context1SyncCalled = false;
-    const userStore1 = { loadFromLocalStorage: vi.fn().mockResolvedValue(true) };
+    const userStore1 = {
+      user: { id: sharedAccountId },
+      loadFromLocalStorage: vi.fn().mockResolvedValue(true),
+    };
     const keychain1 = {
       load: vi.fn().mockResolvedValue(true),
       keys: {}, // no key for the default folder -> triggers delete+recreate branch
@@ -76,57 +90,135 @@ describe('D3: init.ts single-flight guard does not coordinate across contexts', 
     // Let context 1 actually enter _init() and reach folderStore.sync().
     await vi.waitFor(() => expect(context1SyncCalled).toBe(true));
 
-    // --- "Context 2" (e.g. popup), a totally separate module instance ---
+    // Let context 1 finish sync and go on to acquire the lock and run
+    // deleteFolder/createFolder, before context 2 gets a chance to try.
+    sync1Deferred.resolve();
+    await vi.waitFor(() => expect(folderStore1.createFolder).toHaveBeenCalled());
+
+    // --- "Context 2" (e.g. popup), a totally separate module instance,
+    // stubbed onto a SEPARATE fake-host context that shares the same
+    // underlying browser.storage.local backing store as context 1. ---
     vi.resetModules();
+    stubContext(host, 'popup');
     const initModule2 = await import('@send-frontend/lib/init');
     const init2 = initModule2.default;
 
     expect(init2).not.toBe(init1); // confirms genuinely separate module instances
 
-    const userStore2 = { loadFromLocalStorage: vi.fn().mockResolvedValue(true) };
+    const userStore2 = {
+      user: { id: sharedAccountId }, // SAME account
+      loadFromLocalStorage: vi.fn().mockResolvedValue(true),
+    };
     const keychain2 = {
       load: vi.fn().mockResolvedValue(true),
       keys: {},
     };
     const folderStore2 = {
-      sync: vi.fn().mockResolvedValue(undefined), // resolves immediately
-      defaultFolder: { id: 'shared-account-default-folder' }, // SAME account/folder
+      sync: vi.fn().mockResolvedValue(undefined),
+      defaultFolder: { id: 'shared-account-default-folder' }, // SAME folder
       deleteFolder: vi.fn().mockResolvedValue(undefined),
       createFolder: vi.fn().mockResolvedValue({ id: 'another-new-folder-id' }),
     };
 
-    // THE BUG: context 2's `inFlight` is `null` (it's a fresh module
-    // instance -- it has never heard of context 1's in-progress run), so
-    // its single-flight guard does NOT block this call. Context 2 proceeds
-    // straight through to its own delete+recreate decision for the exact
-    // same account's default folder that context 1 is still deciding on.
+    // By the time context 2 runs, context 1 has already released its lock
+    // (its delete+recreate finished above), so context 2 must be free to
+    // acquire it fresh and run its own decision -- the lock must not get
+    // stuck held forever after a clean release. (The actual overlap-
+    // prevention claim is covered by the next test, where the two contexts
+    // genuinely race.)
     const context2Result = await init2(
       userStore2 as any,
       keychain2 as any,
       folderStore2 as any
     );
 
-    // Context 2 completed its own independent delete+recreate cycle,
-    // completely unaware of context 1's still-pending run.
     expect(context2Result).toBe(INIT_ERRORS.NONE);
-    expect(folderStore2.deleteFolder).toHaveBeenCalledWith(
-      'shared-account-default-folder'
-    );
     expect(folderStore2.createFolder).toHaveBeenCalled();
 
-    // Now let context 1 finish too.
-    sync1Deferred.resolve();
     const context1Result = await context1InitPromise;
     expect(context1Result).toBe(INIT_ERRORS.NONE);
+    expect(folderStore1.createFolder).toHaveBeenCalled();
+  });
 
-    // THE BUG's endpoint: BOTH contexts independently ran delete+recreate
-    // for the SAME account's default folder, with no coordination of any
-    // kind between them -- exactly reintroducing the duplicate-default-
-    // folder race that issue #930's single-flight guard was meant to fix,
-    // just moved from "within one context" to "across contexts."
-    expect(folderStore1.deleteFolder).toHaveBeenCalledWith(
-      'shared-account-default-folder'
+  it('FIXED: a context racing an in-progress delete+recreate defers instead of running its own', async () => {
+    const sharedAccountId = 'another-shared-account-id';
+
+    // --- "Context 1" holds the lock and is mid delete+recreate ---
+    stubContext(host, 'background');
+    const initModule1 = await import('@send-frontend/lib/init');
+    const init1 = initModule1.default;
+
+    const deleteDeferred = createDeferred<void>();
+    let deleteFolderCalled = false;
+    const userStore1 = {
+      user: { id: sharedAccountId },
+      loadFromLocalStorage: vi.fn().mockResolvedValue(true),
+    };
+    const keychain1 = {
+      load: vi.fn().mockResolvedValue(true),
+      keys: {},
+    };
+    const folderStore1 = {
+      sync: vi.fn().mockResolvedValue(undefined),
+      defaultFolder: { id: 'another-shared-default-folder' },
+      deleteFolder: vi.fn().mockImplementation(async () => {
+        deleteFolderCalled = true;
+        return deleteDeferred.promise;
+      }),
+      createFolder: vi.fn().mockResolvedValue({ id: 'new-folder-id' }),
+    };
+
+    const context1InitPromise = init1(
+      userStore1 as any,
+      keychain1 as any,
+      folderStore1 as any
     );
+
+    // Let context 1 reach deleteFolder -- it now holds the lock and is
+    // blocked inside the guarded section.
+    await vi.waitFor(() => expect(deleteFolderCalled).toBe(true));
+
+    // --- "Context 2" tries to init() for the SAME account while context 1
+    // still holds the lock. ---
+    vi.resetModules();
+    stubContext(host, 'popup');
+    const initModule2 = await import('@send-frontend/lib/init');
+    const init2 = initModule2.default;
+
+    const userStore2 = {
+      user: { id: sharedAccountId },
+      loadFromLocalStorage: vi.fn().mockResolvedValue(true),
+    };
+    const keychain2 = {
+      load: vi.fn().mockResolvedValue(true),
+      keys: {},
+    };
+    const folderStore2 = {
+      // After deferring to the lock, init() re-syncs and reports whatever
+      // context 1 leaves behind. Simulate that context 1's new folder is
+      // now visible.
+      sync: vi.fn().mockResolvedValue(undefined),
+      defaultFolder: { id: 'context-1s-recreated-folder' },
+      deleteFolder: vi.fn().mockResolvedValue(undefined),
+      createFolder: vi.fn().mockResolvedValue({ id: 'should-not-be-used' }),
+    };
+
+    const context2Result = await init2(
+      userStore2 as any,
+      keychain2 as any,
+      folderStore2 as any
+    );
+
+    // THE FIX: context 2 must NOT run its own delete+recreate while
+    // context 1's is still in flight for the same account.
+    expect(folderStore2.deleteFolder).not.toHaveBeenCalled();
+    expect(folderStore2.createFolder).not.toHaveBeenCalled();
+    expect(context2Result).toBe(INIT_ERRORS.NONE);
+
+    // Let context 1 finish.
+    deleteDeferred.resolve();
+    const context1Result = await context1InitPromise;
+    expect(context1Result).toBe(INIT_ERRORS.NONE);
     expect(folderStore1.createFolder).toHaveBeenCalled();
   });
 });

--- a/packages/send/frontend/src/lib/init.ts
+++ b/packages/send/frontend/src/lib/init.ts
@@ -7,6 +7,10 @@ import {
 import { useFolderStore } from '@send-frontend/stores';
 import useApiStore from '@send-frontend/stores/api-store';
 import { UserStoreType as UserStore } from '@send-frontend/stores/user-store';
+import {
+  acquireDefaultFolderLock,
+  releaseDefaultFolderLock,
+} from '@send-frontend/lib/initFolderLock';
 
 /**
  * Loads user and keychain from storage; creates default folder if necessary.
@@ -48,26 +52,58 @@ async function _init(
   const defaultFolderKeyIsMissing =
     defaultFolder && !keychain.keys[defaultFolder.id];
 
-  if (defaultFolderKeyIsMissing) {
-    console.warn(
-      `Default folder ${defaultFolder.id} exists but has no key. Deleting orphaned container and recreating.`
-    );
-    await folderStore.deleteFolder(defaultFolder.id);
-  }
-
   if (!defaultFolder || defaultFolderKeyIsMissing) {
-    const createFolderResp = await folderStore.createFolder();
-    if (!createFolderResp?.id) {
-      return INIT_ERRORS.COULD_NOT_CREATE_DEFAULT_FOLDER;
+    // The delete+recreate branch below is the one that must never run twice
+    // concurrently for the same account (see #930, #1032): background, popup,
+    // and any web-app tab each hold their own JS module instance of this file,
+    // so the in-process `inFlight` guard in init() below only protects against
+    // duplicate runs WITHIN one of those contexts, not across them. This
+    // storage-backed lock is the cross-context equivalent -- it's a no-op (and
+    // this whole branch just proceeds unguarded) in any context where
+    // `browser.storage.local` isn't available, since only extension contexts
+    // can race each other this way; a lone web-app tab has no sibling context
+    // to race against.
+    const lockToken = await acquireDefaultFolderLock(userStore.user?.id);
+
+    if (lockToken === null) {
+      // Another context currently holds the lock and is already deciding
+      // whether to delete + recreate this exact account's default folder.
+      // Don't pile on: re-sync and trust whatever that other context leaves
+      // behind rather than racing it. If it fails partway (e.g. the tab
+      // closes), the lock's short TTL lets the next init() attempt through.
+      await folderStore.sync();
+      return folderStore?.defaultFolder ? INIT_ERRORS.NONE : INIT_ERRORS.NO_KEYCHAIN;
+    }
+
+    try {
+      if (defaultFolderKeyIsMissing) {
+        console.warn(
+          `Default folder ${defaultFolder.id} exists but has no key. Deleting orphaned container and recreating.`
+        );
+        await folderStore.deleteFolder(defaultFolder.id);
+      }
+
+      const createFolderResp = await folderStore.createFolder();
+      if (!createFolderResp?.id) {
+        return INIT_ERRORS.COULD_NOT_CREATE_DEFAULT_FOLDER;
+      }
+    } finally {
+      await releaseDefaultFolderLock(userStore.user?.id, lockToken);
     }
   }
 
   return INIT_ERRORS.NONE;
 }
 
-// Single-flight guard: concurrent callers (e.g. the login flow and dbUserSetup
-// firing during the same rapid navigation) share one run instead of each
-// independently deciding to delete + recreate the default folder. See issue #930.
+// Single-flight guard: concurrent callers WITHIN THE SAME CONTEXT (e.g. the
+// login flow and dbUserSetup firing during the same rapid navigation) share
+// one run instead of each independently deciding to delete + recreate the
+// default folder. See issue #930.
+//
+// This only helps callers sharing this exact module instance. It does NOT
+// coordinate across background/popup/web-tab contexts, each of which loads
+// its own independent copy of this module -- that's what the storage-backed
+// lock inside _init() above is for. See issue #1032.
 let inFlight: Promise<INIT_ERRORS> | null = null;
 
 function init(

--- a/packages/send/frontend/src/lib/initFolderLock.ts
+++ b/packages/send/frontend/src/lib/initFolderLock.ts
@@ -1,0 +1,118 @@
+/**
+ * Cross-context lock for the default-folder delete+recreate branch in
+ * init.ts. See issue #1032 (and its ancestor, #930).
+ *
+ * Why this exists: background.ts, the popup, and any web-app tab bridged
+ * into the extension each load their OWN independent copy of init.ts as a
+ * separate JS module instance (same reasoning as shared-pinia.ts's
+ * per-context-singleton comment). A plain in-memory flag in one of those
+ * copies is invisible to the others. `browser.storage.local` is the one
+ * thing all of those contexts genuinely share, so it's the only place a
+ * lock that actually works across contexts can live.
+ *
+ * This is intentionally a short-TTL lock, not a queue or a hard mutex: if a
+ * context dies while holding it (tab closed, background page recycled), we
+ * want the next init() call to be able to proceed after a few seconds
+ * rather than being stuck forever. The tradeoff is a small window where two
+ * contexts could still both proceed if one crashes at the exact wrong
+ * moment inside its TTL -- that's an acceptable residual risk for a race
+ * that was previously unguarded 100% of the time.
+ */
+
+const LOCK_TTL_MS = 15_000;
+
+function lockStorageKey(accountId: string): string {
+  return `tbpro-init-folder-lock:${accountId}`;
+}
+
+interface LockRecord {
+  token: string;
+  expiresAt: number;
+}
+
+function generateToken(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  // Fallback for environments without crypto.randomUUID (matches the
+  // fallback pattern already used in keychain.ts).
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+function hasExtensionStorage(): boolean {
+  return (
+    typeof browser !== 'undefined' &&
+    !!browser?.storage?.local &&
+    typeof browser.storage.local.get === 'function'
+  );
+}
+
+/**
+ * Attempt to acquire the default-folder lock for this account.
+ *
+ * Returns a token to pass to releaseDefaultFolderLock() on success, or
+ * `null` if another context currently holds an unexpired lock.
+ *
+ * In any context without `browser.storage.local` (e.g. a plain web-app tab
+ * with no sibling extension context to race against), this always
+ * "succeeds" by returning a token that release() will just no-op on --
+ * there's nothing to coordinate with, so the delete+recreate branch proceeds
+ * exactly as it did before this fix existed.
+ */
+export async function acquireDefaultFolderLock(
+  accountId: string | undefined
+): Promise<string | null> {
+  if (!accountId || !hasExtensionStorage()) {
+    return generateToken();
+  }
+
+  const key = lockStorageKey(accountId);
+  const now = Date.now();
+
+  const existing = (await browser.storage.local.get(key))?.[key] as
+    | LockRecord
+    | undefined;
+
+  if (existing && existing.expiresAt > now) {
+    // Someone else holds an unexpired lock for this account.
+    return null;
+  }
+
+  const token = generateToken();
+  const record: LockRecord = { token, expiresAt: now + LOCK_TTL_MS };
+  await browser.storage.local.set({ [key]: record });
+
+  // Guard against a rare concurrent-write race: two contexts can both pass
+  // the `existing` check above in the same tick (there's no atomic
+  // read-modify-write in the storage.local API), then both write. Re-read
+  // after writing and only proceed if OUR token is the one that stuck.
+  const confirmed = (await browser.storage.local.get(key))?.[key] as
+    | LockRecord
+    | undefined;
+
+  return confirmed?.token === token ? token : null;
+}
+
+/**
+ * Release a previously-acquired lock. Only clears the stored record if it
+ * still matches the token we were given -- if the lock already expired and
+ * a different context has since taken it over, we must not clear their
+ * lock out from under them.
+ */
+export async function releaseDefaultFolderLock(
+  accountId: string | undefined,
+  token: string
+): Promise<void> {
+  if (!accountId || !hasExtensionStorage()) {
+    return;
+  }
+
+  const key = lockStorageKey(accountId);
+  const existing = (await browser.storage.local.get(key))?.[key] as
+    | LockRecord
+    | undefined;
+
+  if (existing?.token === token) {
+    await browser.storage.local.remove(key);
+  }
+}


### PR DESCRIPTION
Depends on #1044 (needs the D3 regression test to exist first, since this PR also updates it).

Fixes #1032. Part of the overall test coverage effort in #1034 -- this is the first of the batch to include an actual fix rather than just a regression test.

## What

`init.ts` already had a guard meant to stop two things from both deciding, at the same time, to delete and recreate the account's default folder -- that guard was added specifically to fix #930. The problem: that guard is just a plain variable in the file, and the add-on's background page, its upload popup, and any web-app tab bridged into it each load their own separate copy of that file. So the guard only works if both attempts happen to come from the exact same one of those three places. If a delete+recreate gets triggered from the background page and, near-simultaneously, from the popup, neither one has any idea the other is happening -- and #930's bug comes right back, just moved from "within one page" to "across pages."

The fix adds a second, real lock in `browser.storage.local` -- the one piece of storage all three of those contexts actually share -- scoped to just the risky delete+recreate step, keyed by account id. Whichever context gets there first holds the lock for a few seconds; if a second context tries to run the same step for the same account while that's still in progress, it backs off, re-syncs, and just uses whatever the first context ends up leaving behind, instead of doing its own competing delete+recreate.

If `browser.storage.local` isn't available at all (a plain web-app tab has no sibling extension context to race against in the first place), this is a complete no-op and behavior is unchanged.

## Why

This is a real regression risk, not just a theoretical race: #930 was a live flaky-E2E bug that took real debugging effort to track down and fix once already. Without something that actually coordinates across all three contexts, that same failure mode is still reachable today, just harder to trigger from a single page.

## Testing

Updated the existing D3 integration test (`packages/addon/src/test/integration/d3-init-single-flight-per-context-only.test.ts`) to actually drive two real fake-host contexts sharing one `browser.storage.local`, instead of two isolated module instances with no shared storage at all. It now has two specs:
- one confirming the lock doesn't deadlock (a second context can still run after the first cleanly finishes and releases it)
- one confirming a context that tries to run while another is actively mid-delete+recreate defers instead of racing it

Both pass with the fix in place. Reverted `init.ts` only and re-ran the second spec to confirm it fails without the fix (it does -- the second context proceeds and calls `deleteFolder`/`createFolder` on its own).

Also ran:
- `packages/addon`: full suite, 58 passed / 1 pre-existing skip (same count as before this change)
- `packages/send/frontend`: `src/test/lib/init.test.ts` (the existing unit tests for this exact file), all 10 pass unchanged
- `packages/send/frontend`: full suite has 44 pre-existing failures unrelated to this change (confirmed identical failure count on `main` before this PR, in this sandbox -- looks like an environment/localStorage quota issue, not something this PR touches)
- `eslint` and `tsc --noEmit` clean on both changed/new files (pre-existing unrelated errors elsewhere in the `backend` package, not touched here)

```
cd packages/addon && VITE_TESTING=true VITE_SEND_CLIENT_URL=https://send.tb.pro VITE_SEND_SERVER_URL=https://localhost:8088 npx vitest run
cd packages/send/frontend && npx vitest run src/test/lib/init.test.ts
```