### PR TITLE
fix(send): prevent false "your keys are incorrect" lockout during key restore

### DIFF
--- a/packages/send/frontend/src/apps/send/composables/useBackupAndRestore.passphraseChanged.test.ts
+++ b/packages/send/frontend/src/apps/send/composables/useBackupAndRestore.passphraseChanged.test.ts
@@ -1,0 +1,213 @@
+import { mount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, h, ref } from 'vue';
+
+/**
+ * Coverage for the *trigger* that navigates the user to /passphrase-changed
+ * from the composable side.
+ *
+ * useBackupAndRestore has an onMounted hook that, when the keychain is locked,
+ * immediately pushes the user to /passphrase-changed (and skips the normal
+ * extension configuration + passphrase generation). This is one of the two
+ * runtime paths that land a user on PassphraseChanged.vue (the other being the
+ * router guard for `requiresBackedUpKeys` routes).
+ *
+ * We drive the composable through a tiny host component so onMounted fires,
+ * and flip `keychain.locked` to cover both the locked (redirect) and unlocked
+ * (no redirect) branches plus the edge cases around them.
+ */
+
+const { state } = vi.hoisted(() => ({
+  state: {
+    locked: false,
+    routerPush: vi.fn(),
+    configureExtension: vi.fn(),
+    setWords: vi.fn(),
+    words: [] as string[],
+    getPassphraseValue: null as string | null,
+    generatePassphraseCalls: 0,
+  },
+}));
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: state.routerPush }),
+}));
+
+vi.mock('@send-frontend/apps/send/stores/extension-store', () => ({
+  useExtensionStore: () => ({
+    sendMessageToBridge: vi.fn(),
+    configureExtension: state.configureExtension,
+  }),
+}));
+
+vi.mock('@send-frontend/stores/keychain-store', () => ({
+  // Real Keychain.locked is a plain assignable boolean field (keychain.ts:363,
+  // set at :369/:797), so mirror that here rather than a getter — a getter-only
+  // mock would throw if source ever did `keychain.locked = true`.
+  default: () => ({
+    keychain: {
+      locked: state.locked,
+      getPassphraseValue: () => state.getPassphraseValue,
+    },
+  }),
+}));
+
+vi.mock('@send-frontend/stores/backup-store', () => ({
+  default: () => ({
+    setWords: state.setWords,
+    setBackupCompleted: vi.fn(),
+    setErrorMessage: vi.fn(),
+    // storeToRefs targets are read from this object.
+    words: ref(state.words),
+    errorMessage: ref(''),
+    shouldUnlock: ref(false),
+    shouldReset: ref(false),
+    passphraseString: ref(''),
+  }),
+}));
+
+vi.mock('@send-frontend/stores/user-store', () => ({
+  default: () => ({
+    getBackup: vi.fn(),
+    user: { email: 'a@b.co' },
+    clearUserFromStorage: vi.fn(),
+    populateFromBackend: vi.fn(),
+  }),
+}));
+
+vi.mock('@send-frontend/apps/send/stores/folder-store', () => ({
+  default: () => ({}),
+}));
+
+vi.mock('@send-frontend/stores/api-store', () => ({
+  default: () => ({ api: {} }),
+}));
+
+vi.mock('@send-frontend/stores/metrics', () => ({
+  default: () => ({ metrics: { capture: vi.fn() } }),
+}));
+
+vi.mock('@send-frontend/lib/auth', () => ({
+  useAuth: () => ({ logOutAuth: vi.fn() }),
+}));
+
+vi.mock('@send-frontend/lib/passphrase', () => ({
+  generatePassphrase: () => {
+    state.generatePassphraseCalls += 1;
+    return ['a', 'b', 'c'];
+  },
+}));
+
+// The composable also imports these; stub to no-ops so import resolves.
+vi.mock('@send-frontend/lib/helpers', () => ({ dbUserSetup: vi.fn() }));
+vi.mock('@send-frontend/lib/keychain', () => ({
+  backupKeys: vi.fn(),
+  restoreKeys: vi.fn(),
+}));
+vi.mock('@send-frontend/lib/passphraseUtils', () => ({
+  downloadPassPhrase: vi.fn(),
+  parsePassphrase: (s: string) => s,
+}));
+vi.mock('@send-frontend/lib/trpc', () => ({
+  trpc: {
+    resetKeys: { mutate: vi.fn() },
+    deleteFiles: { mutate: vi.fn() },
+  },
+}));
+vi.mock('@tanstack/vue-query', () => ({
+  useQuery: () => ({ isLoading: ref(false), data: ref(undefined), refetch: vi.fn() }),
+  useMutation: () => ({
+    mutate: vi.fn(),
+    isSuccess: ref(false),
+    isError: ref(false),
+    reset: vi.fn(),
+  }),
+}));
+
+import { useBackupAndRestore } from './useBackupAndRestore';
+
+// Minimal host so onMounted actually runs.
+const Host = defineComponent({
+  setup() {
+    useBackupAndRestore();
+    return () => h('div');
+  },
+});
+
+const mountHost = () => mount(Host);
+
+describe('useBackupAndRestore -> /passphrase-changed trigger', () => {
+  beforeEach(() => {
+    state.locked = false;
+    state.words = [];
+    state.getPassphraseValue = null;
+    state.generatePassphraseCalls = 0;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('redirects to /passphrase-changed when the keychain is locked on mount', () => {
+    state.locked = true;
+
+    mountHost();
+
+    expect(state.routerPush).toHaveBeenCalledWith('/passphrase-changed');
+  });
+
+  it('does NOT configure the extension or generate a passphrase when locked', () => {
+    state.locked = true;
+
+    mountHost();
+
+    // The early return must short-circuit the rest of onMounted.
+    expect(state.configureExtension).not.toHaveBeenCalled();
+    expect(state.generatePassphraseCalls).toBe(0);
+  });
+
+  it('does not redirect and proceeds with normal init when the keychain is unlocked', () => {
+    state.locked = false;
+
+    mountHost();
+
+    expect(state.routerPush).not.toHaveBeenCalled();
+    expect(state.configureExtension).toHaveBeenCalledTimes(1);
+  });
+
+  it('generates a fresh passphrase on unlocked mount only when none exist yet', () => {
+    state.locked = false;
+    state.words = []; // no words yet
+
+    mountHost();
+
+    expect(state.setWords).toHaveBeenCalledWith(['a', 'b', 'c']);
+    expect(state.generatePassphraseCalls).toBe(1);
+  });
+
+  it('does NOT regenerate a passphrase on unlocked mount when words already exist', () => {
+    state.locked = false;
+    state.words = ['existing']; // a passphrase is already present
+
+    mountHost();
+
+    // onMounted must not overwrite an existing passphrase.
+    // NOTE: the stored-passphrase sync side effect (useBackupAndRestore.ts:150)
+    // is intentionally out of scope here — getPassphraseValue is null, so that
+    // branch is skipped and setWords stays untouched.
+    expect(state.setWords).not.toHaveBeenCalled();
+    expect(state.generatePassphraseCalls).toBe(0);
+  });
+
+  it('redirect wins even if a passphrase would otherwise be missing (locked short-circuits)', () => {
+    // Edge case: locked keychain with no words must still just redirect,
+    // never fall through to passphrase generation.
+    state.locked = true;
+    state.words = [];
+
+    mountHost();
+
+    expect(state.routerPush).toHaveBeenCalledWith('/passphrase-changed');
+    expect(state.setWords).not.toHaveBeenCalled();
+  });
+});

--- a/packages/send/frontend/src/apps/send/pages/PassphraseChanged.test.ts
+++ b/packages/send/frontend/src/apps/send/pages/PassphraseChanged.test.ts
@@ -1,0 +1,79 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import PassphraseChanged from './PassphraseChanged.vue';
+
+/**
+ * PassphraseChanged.vue is a purely presentational page shown when the user's
+ * encryption keys are "incorrect" / the keychain is locked.
+ *
+ * It is reached in three ways (see router.ts + useBackupAndRestore.ts):
+ *   1. Router guard: navigating to a `requiresBackedUpKeys` route (e.g. /verify)
+ *      while `keychain.locked === true` redirects to /passphrase-changed.
+ *   2. useBackupAndRestore onMounted: pushes /passphrase-changed when the
+ *      keychain is locked at mount time.
+ *   3. Direct navigation to /passphrase-changed (route has no guards of its own).
+ *
+ * These tests lock down the page's contents and the router behaviour that
+ * lands users here. Because the component is static, the "edge cases" live in
+ * the guard logic that routes here, so we cover that too.
+ */
+
+const stubs = {
+  // SupportBox pulls in external constants/links we don't care about here.
+  SupportBox: true,
+};
+
+const mountPage = () => mount(PassphraseChanged, { global: { stubs } });
+
+describe('PassphraseChanged.vue', () => {
+  it('renders the warning heading', () => {
+    const wrapper = mountPage();
+
+    const heading = wrapper.find('h2.section-title');
+    expect(heading.exists()).toBe(true);
+    expect(heading.text()).toBe('Warning');
+  });
+
+  it('explains that the keys are incorrect and how to recover', () => {
+    const wrapper = mountPage();
+
+    const text = wrapper.text();
+    expect(text).toContain('Your keys are incorrect');
+    // The recovery instruction is the whole point of the page.
+    expect(text).toContain('log out and log back in');
+    // Mentions the common cause so the user isn't alarmed.
+    expect(text).toContain('reset your passphrase on a different device');
+  });
+
+  it('renders the recovery instructions inside a KeysTemplate wrapper', () => {
+    const wrapper = mountPage();
+
+    const keysTemplate = wrapper.findComponent({ name: 'KeysTemplate' });
+    expect(keysTemplate.exists()).toBe(true);
+    // The warning copy must live inside the template, not floating in the page.
+    expect(keysTemplate.text()).toContain('Your keys are incorrect');
+  });
+
+  it('renders a SupportBox so the user has a path to help', () => {
+    const wrapper = mountPage();
+
+    expect(wrapper.findComponent({ name: 'SupportBox' }).exists()).toBe(true);
+  });
+
+  it('marks the warning heading with the red styling class', () => {
+    const wrapper = mountPage();
+
+    const heading = wrapper.find('h2.section-title');
+    // Visual severity cue; guards against silently dropping the alarming style.
+    expect(heading.classes()).toContain('text-red-700');
+  });
+
+  it('renders no interactive controls (the page is purely informational)', () => {
+    const wrapper = mountPage();
+
+    // There is no self-service "fix" button; recovery is manual log out/in.
+    expect(wrapper.find('button').exists()).toBe(false);
+    expect(wrapper.find('input').exists()).toBe(false);
+    expect(wrapper.find('form').exists()).toBe(false);
+  });
+});

--- a/packages/send/frontend/src/apps/send/router.passphraseChanged.test.ts
+++ b/packages/send/frontend/src/apps/send/router.passphraseChanged.test.ts
@@ -1,0 +1,198 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createMemoryHistory,
+  createRouter,
+  type NavigationGuardWithThis,
+  type Router,
+} from 'vue-router';
+
+/**
+ * Router-guard coverage for the /passphrase-changed redirect (trigger path #1).
+ *
+ * The real guard lives inline in router.ts via `router.beforeEach`. Its decision
+ * for this page is:
+ *
+ *   if (requiresBackedUpKeys) {
+ *     if (keychainIsLocked) return next('/passphrase-changed');
+ *     ...
+ *   }
+ *
+ * ...but ONLY after the earlier `requiresValidToken` and `requiresAdminPrivileges`
+ * checks have passed. Those run first, so a locked user on an invalid token is
+ * sent to /login, NOT /passphrase-changed — an ordering subtlety worth locking in.
+ *
+ * The router module isn't exported as a testable unit (it constructs a real
+ * router + a window listener on import), so rather than import it we reconstruct
+ * the guard's decision here from the actual source logic and drive a real
+ * memory-history router through it. This exercises the same branch order and
+ * next(...) targets a user would hit in the app.
+ */
+
+// Mirrors META_OPTIONS keys used by the real guard.
+const META = {
+  requiresValidToken: 'requiresValidToken',
+  requiresAdminPrivileges: 'requiresAdminPrivileges',
+  requiresBackedUpKeys: 'requiresBackedUpKeys',
+} as const;
+
+type World = {
+  keychainLocked: boolean;
+  tokenValid: boolean;
+  isAdmin: boolean;
+  hasBackedUpKeys: boolean;
+};
+
+let world: World;
+
+const validateToken = vi.fn(async () => world.tokenValid);
+const isAdminCall = vi.fn(async () => ({ isAdmin: world.isAdmin }));
+const validateBackedUpKeys = vi.fn(async () => world.hasBackedUpKeys);
+const captureMetric = vi.fn();
+
+const matchMeta = (to: { meta?: Record<string, unknown> }, key: string) =>
+  Boolean(to.meta?.[key]);
+
+/**
+ * A faithful transcription of the relevant slice of router.ts's beforeEach,
+ * limited to the checks that decide whether the user reaches /passphrase-changed.
+ * Order is preserved exactly as in source (token -> admin -> backed-up-keys).
+ */
+const guard: NavigationGuardWithThis<undefined> = async (to, _from, next) => {
+  const keychainIsLocked = world.keychainLocked;
+
+  const requiresValidToken = matchMeta(to, META.requiresValidToken);
+  const requiresAdminPrivileges = matchMeta(to, META.requiresAdminPrivileges);
+  const requiresBackedUpKeys = matchMeta(to, META.requiresBackedUpKeys);
+
+  if (requiresValidToken) {
+    const isTokenValid = await validateToken();
+    if (!isTokenValid) {
+      captureMetric('send.invalid.token');
+      return next('/login');
+    }
+  }
+
+  if (requiresAdminPrivileges) {
+    const adminStatus = await isAdminCall();
+    if (adminStatus?.isAdmin) return next();
+    return next('/404');
+  }
+
+  if (requiresBackedUpKeys) {
+    if (keychainIsLocked) {
+      return next('/passphrase-changed');
+    }
+    const backedUp = await validateBackedUpKeys();
+    if (!backedUp) {
+      return next('/send/profile');
+    }
+  }
+
+  return next();
+};
+
+const build = (): Router => {
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/', component: { template: '<div/>' } },
+      { path: '/login', component: { template: '<div/>' } },
+      { path: '/404', component: { template: '<div/>' } },
+      { path: '/passphrase-changed', component: { template: '<div/>' } },
+      { path: '/send/profile', component: { template: '<div/>' } },
+      {
+        // Stands in for the real /verify route: requires a valid token AND
+        // backed-up keys (router.ts:118-125).
+        path: '/verify',
+        component: { template: '<div/>' },
+        meta: {
+          [META.requiresValidToken]: true,
+          [META.requiresBackedUpKeys]: true,
+        },
+      },
+      {
+        path: '/admin/delete-data',
+        component: { template: '<div/>' },
+        meta: {
+          [META.requiresAdminPrivileges]: true,
+          [META.requiresValidToken]: true,
+        },
+      },
+    ],
+  });
+  router.beforeEach(guard);
+  return router;
+};
+
+describe('router guard -> /passphrase-changed (trigger path #1)', () => {
+  beforeEach(() => {
+    world = {
+      keychainLocked: false,
+      tokenValid: true,
+      isAdmin: false,
+      hasBackedUpKeys: true,
+    };
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('redirects to /passphrase-changed when entering a backed-up-keys route with a locked keychain', async () => {
+    world.keychainLocked = true;
+    world.tokenValid = true; // token must be valid to reach the locked check
+
+    const router = build();
+    await router.push('/verify');
+
+    expect(router.currentRoute.value.path).toBe('/passphrase-changed');
+  });
+
+  it('sends a locked user to /login first when the token is invalid (token check wins)', async () => {
+    world.keychainLocked = true;
+    world.tokenValid = false; // invalid token short-circuits before the locked check
+
+    const router = build();
+    await router.push('/verify');
+
+    // Ordering guarantee: invalid token => /login, NOT /passphrase-changed.
+    expect(router.currentRoute.value.path).toBe('/login');
+    expect(captureMetric).toHaveBeenCalledWith('send.invalid.token');
+    expect(validateBackedUpKeys).not.toHaveBeenCalled();
+  });
+
+  it('does NOT reach /passphrase-changed for an admin route (admin check wins before backed-up-keys)', async () => {
+    world.keychainLocked = true;
+    world.tokenValid = true;
+    world.isAdmin = false; // non-admin on an admin route
+
+    const router = build();
+    await router.push('/admin/delete-data');
+
+    // Admin route has no requiresBackedUpKeys, and the admin branch returns first.
+    expect(router.currentRoute.value.path).toBe('/404');
+  });
+
+  it('does not redirect to /passphrase-changed when the keychain is unlocked and keys are backed up', async () => {
+    world.keychainLocked = false;
+    world.tokenValid = true;
+    world.hasBackedUpKeys = true;
+
+    const router = build();
+    await router.push('/verify');
+
+    expect(router.currentRoute.value.path).toBe('/verify');
+  });
+
+  it('sends an unlocked user without backed-up keys to /send/profile, not /passphrase-changed', async () => {
+    world.keychainLocked = false;
+    world.tokenValid = true;
+    world.hasBackedUpKeys = false;
+
+    const router = build();
+    await router.push('/verify');
+
+    // The locked branch is skipped; the "no backup" branch takes over.
+    expect(router.currentRoute.value.path).toBe('/send/profile');
+  });
+});

--- a/packages/send/frontend/src/lib/keychain.ts
+++ b/packages/send/frontend/src/lib/keychain.ts
@@ -4,6 +4,25 @@ import { Backup as BackupUserStore } from '@send-frontend/stores/user-store.type
 
 export type JwkKeyPair = Record<'publicKey' | 'privateKey', string>;
 
+/**
+ * Thrown when a restore fails specifically because the passphrase cannot unwrap
+ * the backup content key — i.e. the passphrase is genuinely wrong/mismatched.
+ *
+ * This lets restoreKeys distinguish a real "keys are incorrect" situation (which
+ * SHOULD lock the keychain and route the user to /passphrase-changed) from a
+ * transient/incidental failure (crypto blip, storage write race, concurrent
+ * restore interleave) that must NOT produce a permanent lockout on an otherwise
+ * correct passphrase.
+ */
+export class IncorrectPassphraseError extends Error {
+  constructor(cause?: unknown) {
+    super('Passphrase is incorrect');
+    this.name = 'IncorrectPassphraseError';
+    // Preserve the underlying error for logging/debugging.
+    (this as { cause?: unknown }).cause = cause;
+  }
+}
+
 // Stored keys are always strings.
 // They are parsed as needed for encrypting/decrypting.
 export type StoredKey = {
@@ -678,11 +697,20 @@ async function decryptAll(
 ) {
   const salt = Util.base64ToArrayBuffer(saltStr);
 
-  const key = await keychainFromParams.password.unwrapContentKey(
-    passwordWrappedKeyStr,
-    password,
-    salt
-  );
+  // Unwrapping the content key with the user's password is the one step that
+  // genuinely validates the passphrase: a wrong/mismatched passphrase fails
+  // here. Tag that failure so restoreKeys can lock the keychain ONLY for a real
+  // incorrect passphrase, and treat later crypto/storage errors as transient.
+  let key: CryptoKey;
+  try {
+    key = await keychainFromParams.password.unwrapContentKey(
+      passwordWrappedKeyStr,
+      password,
+      salt
+    );
+  } catch (e) {
+    throw new IncorrectPassphraseError(e);
+  }
 
   const protectedKeypair = JSON.parse(protectedKeypairStr);
   const publicKeyCiphertext = protectedKeypair.publicKey;
@@ -735,7 +763,33 @@ export async function restoreKeysUsingLocalStorage(
   return restoreKeys(keychain, api);
 }
 
-export async function restoreKeys(
+// Single-flight guard: restoreKeys is fired from 6+ call sites (router auto-
+// restore, init.ts, background.ts, validations.ts, PopupView, the composable)
+// against one shared Keychain singleton. Without this, concurrent restores can
+// interleave on the shared state and a transient failure in one leg would flip
+// the shared `locked` flag for an otherwise-successful leg. We collapse
+// overlapping restores per keychain instance into a single in-flight promise,
+// mirroring the pattern already used in init.ts (issue #930).
+const restoreInFlight = new WeakMap<Keychain, Promise<void>>();
+
+export function restoreKeys(
+  keychain: Keychain,
+  api: ApiConnection,
+  msg?: Ref<string>,
+  passPhrase?: string
+): Promise<void> {
+  const existing = restoreInFlight.get(keychain);
+  if (existing) {
+    return existing;
+  }
+  const run = _restoreKeys(keychain, api, msg, passPhrase).finally(() => {
+    restoreInFlight.delete(keychain);
+  });
+  restoreInFlight.set(keychain, run);
+  return run;
+}
+
+async function _restoreKeys(
   keychain: Keychain,
   api: ApiConnection,
   msg?: Ref<string>,
@@ -792,15 +846,27 @@ export async function restoreKeys(
     await keychain.load(keypair, containerKeys);
     await keychain.store();
 
+    // A successful restore recovers the keychain: clear any prior lock so a
+    // single earlier blip doesn't stay sticky until a full reload.
+    keychain.locked = false;
     msg.value = '✅ Restore complete';
   } catch (e) {
-    keychain.locked = true;
-    const KEY_RESTORE_ERROR = `⛔️ Could not restore keys. Please make sure your backup phrase is correct.`;
+    // Only a genuine incorrect-passphrase failure (unwrapping the content key)
+    // should lock the keychain and route the user to /passphrase-changed.
+    // Transient failures (crypto blip, storage write race, concurrent restore
+    // interleave) must NOT permanently lock an otherwise-correct passphrase.
+    if (e instanceof IncorrectPassphraseError) {
+      keychain.locked = true;
+      const KEY_RESTORE_ERROR = `⛔️ Could not restore keys. Please make sure your backup phrase is correct.`;
+      console.error(KEY_RESTORE_ERROR, e);
+      msg.value = MSG_INCORRECT_PASSPHRASE;
+      throw new Error(KEY_RESTORE_ERROR);
+    }
 
-    console.error(KEY_RESTORE_ERROR, e);
-
-    msg.value = MSG_INCORRECT_PASSPHRASE;
-    throw new Error(KEY_RESTORE_ERROR);
+    // Transient/incidental failure: surface it for retry without locking.
+    console.error('Transient error during key restore (not locking):', e);
+    msg.value = MSG_COULD_NOT_RETRIEVE;
+    throw e;
   }
 }
 

--- a/packages/send/frontend/src/test/lib/keychain.restore-race.test.ts
+++ b/packages/send/frontend/src/test/lib/keychain.restore-race.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Reproduction tests for the passphrase-lockout race conditions in restoreKeys.
+ *
+ * These tests target the REAL `restoreKeys` (src/lib/keychain.ts) against a real
+ * `Keychain` instance, driving the actual failure paths that flip
+ * `keychain.locked = true` and land the user on PassphraseChanged.vue.
+ *
+ * They are written to FAIL against current source, documenting the bugs:
+ *
+ *   BUG 1 (over-broad catch): restoreKeys' try/catch sets locked=true on ANY
+ *          throw inside the decrypt/load/store block, including transient
+ *          non-passphrase failures (crypto blip, storage write error). A correct
+ *          passphrase should NOT produce a permanent "keys are incorrect" lock
+ *          on a transient error.
+ *
+ *   BUG 2 (no single-flight): concurrent restoreKeys calls on the shared
+ *          singleton keychain can interleave; if one leg hits a transient error
+ *          it locks the keychain for the other (successful) leg too.
+ *
+ *   BUG 3 (locked never reset): a later successful restore does not clear a
+ *          previously-set locked flag, so one blip sticks until full reload.
+ *
+ * Once keychain.ts is fixed (single-flight + narrowed catch + reset-on-success),
+ * these become the regression guard.
+ */
+import { Keychain, restoreKeys } from '@send-frontend/lib/keychain';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// A backup payload shape that restoreKeys destructures. The exact ciphertext
+// doesn't matter for these tests because we control decrypt behaviour by spying
+// on the keychain crypto methods (unwrapContentKey / decryptBackup) instead.
+const BACKUP_RESPONSE = {
+  backupContainerKeys: JSON.stringify({}),
+  backupKeypair: JSON.stringify({ publicKey: 'pub', privateKey: 'priv' }),
+  backupKeystring: 'wrapped-key',
+  backupSalt: 'c2FsdA==', // base64 "salt"
+};
+
+// Minimal ApiConnection stand-in: restoreKeys only calls api.call('users/backup').
+const makeApi = (response: unknown = BACKUP_RESPONSE) =>
+  ({
+    call: vi.fn(async () => response),
+  }) as never;
+
+/**
+ * Wire a Keychain so decryptAll succeeds deterministically:
+ *  - password.unwrapContentKey -> a dummy key
+ *  - backup.decryptBackup -> a valid JWK-ish object
+ *  - load/store -> no-op success
+ * Individual tests then override one leg to throw, simulating a transient error.
+ */
+function makeHealthyKeychain(passphrase = 'correct horse battery staple'): Keychain {
+  const kc = new Keychain();
+  // Avoid touching real localStorage (not wired up in this test env, same gap
+  // that breaks the storage.test.ts suite). restoreKeys only needs a truthy
+  // passphrase via getPassphraseValue().
+  vi.spyOn(kc, 'getPassphraseValue').mockReturnValue(passphrase);
+
+  vi.spyOn(kc.password, 'unwrapContentKey').mockResolvedValue(
+    'content-key' as never
+  );
+  vi.spyOn(kc.backup, 'decryptBackup').mockResolvedValue({
+    kty: 'RSA',
+  } as never);
+  vi.spyOn(kc, 'load').mockResolvedValue(true);
+  vi.spyOn(kc, 'store').mockResolvedValue(undefined);
+
+  return kc;
+}
+
+describe('restoreKeys lockout races', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('BUG 1: a transient storage error with a CORRECT passphrase must not permanently lock the keychain', async () => {
+    const kc = makeHealthyKeychain();
+    // Simulate a transient localStorage write failure (e.g. quota / race on
+    // the shared storage), NOT a wrong passphrase. decrypt already succeeded.
+    vi.spyOn(kc, 'store').mockRejectedValueOnce(
+      new Error('QuotaExceededError: transient write failure')
+    );
+
+    await expect(restoreKeys(kc, makeApi())).rejects.toThrow();
+
+    // DESIRED behaviour: transient/storage failures should not be reported as
+    // "your keys are incorrect". Current source flips locked=true unconditionally.
+    expect(kc.locked).toBe(false);
+  });
+
+  it('BUG 1b: a transient WebCrypto blip during decrypt must not lock a correct passphrase', async () => {
+    const kc = makeHealthyKeychain();
+    // decryptBackup throws a non-passphrase, transient-style error AFTER unwrap
+    // succeeded (so the passphrase itself was valid).
+    vi.spyOn(kc.backup, 'decryptBackup').mockRejectedValueOnce(
+      new Error('OperationError: transient subtle-crypto failure')
+    );
+
+    await expect(restoreKeys(kc, makeApi())).rejects.toThrow();
+
+    expect(kc.locked).toBe(false);
+  });
+
+  it('BUG 3: a successful restore must clear a previously-set locked flag (no sticky lock)', async () => {
+    const kc = makeHealthyKeychain();
+
+    // First attempt: transient failure sets locked=true (today's behaviour).
+    vi.spyOn(kc, 'store').mockRejectedValueOnce(new Error('transient'));
+    await expect(restoreKeys(kc, makeApi())).rejects.toThrow();
+
+    // Second attempt: everything healthy, restore succeeds.
+    await expect(restoreKeys(kc, makeApi())).resolves.not.toThrow();
+
+    // DESIRED: a successful restore recovers the keychain. Current source never
+    // resets locked=false, so it stays stuck until a fresh Keychain is built.
+    expect(kc.locked).toBe(false);
+  });
+
+  it('BUG 2: concurrent restores collapse into a single operation (single-flight)', async () => {
+    const kc = makeHealthyKeychain();
+
+    // Two callers hit restoreKeys on the SAME singleton (router auto-restore +
+    // background/init restore during a rapid login). With single-flight they
+    // must collapse into ONE underlying restore rather than each independently
+    // mutating shared keychain state and racing store().
+    const storeSpy = kc.store as unknown as ReturnType<typeof vi.fn>;
+
+    const [a, b] = [restoreKeys(kc, makeApi()), restoreKeys(kc, makeApi())];
+    // Overlapping callers share the exact same in-flight promise.
+    expect(a).toBe(b);
+
+    await Promise.all([a, b]);
+
+    // Only one real restore ran despite two callers.
+    expect(storeSpy).toHaveBeenCalledTimes(1);
+    expect(kc.locked).toBe(false);
+  });
+
+  it('BUG 2b: a transient failure during a concurrent restore does not lock, and a retry recovers', async () => {
+    const kc = makeHealthyKeychain();
+
+    // The shared in-flight operation blips transiently on its first run.
+    let storeCalls = 0;
+    vi.spyOn(kc, 'store').mockImplementation(async () => {
+      storeCalls += 1;
+      if (storeCalls === 1) {
+        throw new Error('transient write race');
+      }
+      return undefined;
+    });
+
+    // Two overlapping callers share one operation; both see the transient
+    // rejection, but the keychain must NOT be locked (valid passphrase).
+    const results = await Promise.allSettled([
+      restoreKeys(kc, makeApi()),
+      restoreKeys(kc, makeApi()),
+    ]);
+    expect(results.every((r) => r.status === 'rejected')).toBe(true);
+    expect(kc.locked).toBe(false);
+
+    // A fresh restore after the in-flight cleared recovers cleanly.
+    await expect(restoreKeys(kc, makeApi())).resolves.not.toThrow();
+    expect(kc.locked).toBe(false);
+  });
+
+  it('control: a genuinely wrong passphrase (unwrap fails) SHOULD lock the keychain', async () => {
+    const kc = new Keychain();
+    vi.spyOn(kc, 'getPassphraseValue').mockReturnValue('wrong passphrase');
+    // Unwrapping the content key with the wrong password is the real
+    // "incorrect passphrase" signal — this one is SUPPOSED to lock.
+    vi.spyOn(kc.password, 'unwrapContentKey').mockRejectedValue(
+      new Error('OperationError: unwrap failed (bad password)')
+    );
+
+    await expect(restoreKeys(kc, makeApi())).rejects.toThrow();
+
+    expect(kc.locked).toBe(true);
+  });
+});


### PR DESCRIPTION
## What changed?

When the app restores your encryption keys, it used to treat *any* hiccup during that process as a wrong passphrase — showing the "Your keys are incorrect" page and telling you to log out and back in, even when your passphrase was actually correct.

This change makes the key-restore step smarter:

- It now only shows the "incorrect passphrase" warning when the passphrase genuinely fails to unlock your keys. Temporary glitches (a momentary browser/storage hiccup, or two loads happening at once) no longer get mistaken for a bad passphrase.
- Two key-restore attempts happening at the same time now share a single operation instead of tripping over each other on shared state.
- Once a restore succeeds, the "incorrect" state is cleared, so a single earlier glitch no longer leaves you stuck until a full reload.

Key file: `packages/send/frontend/src/lib/keychain.ts`. Tests were added to reproduce the original problem and guard against it returning.

AI disclosure: This change was written by an AI assistant (OpenClaw bot) with the fix, tests, and this description agent-generated. A human reviewed and directed the work at each step and triggered the commit/PR.

## Why?

Users with a perfectly valid passphrase could be falsely told their keys were incorrect and pushed to log out and back in. It was most likely to happen right after login or while the app was loading several things at once, which made it intermittent and confusing. This removes that false alarm while still correctly catching a genuinely wrong passphrase.

## Limitations and Notes

- The internal "locked" flag is still a plain (non-reactive) value. In the current flow this is fine, but if the flag is ever flipped *after* a page has already mounted, that change won't automatically propagate. That's a possible future hardening step, not a bug in the paths this PR fixes.
- The unrelated storage-related test failures in the suite are pre-existing (a test-environment setup gap) and are not touched by this change.

## Applicable Issues

Closes #1056

## Screenshots

No UI changes. The affected screen is the existing "Your keys are incorrect" warning page; this PR changes *when* it appears, not how it looks.