### PR TITLE
fix(precommit): make env sync a warning and don't block unrelated commits on pre-existing type errors

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -25,4 +25,7 @@ pnpx lint-staged
 cd ..
 
 # Run lint-staged on backend
-cd backend && pnpx lint-staged && pnpm typecheck
+cd backend && pnpx lint-staged
+# Type check the backend, but do NOT block the commit on pre-existing errors in
+# unrelated/unchanged files. Warns instead of failing so unrelated commits pass.
+pnpm typecheck:precommit

--- a/packages/send/backend/package.json
+++ b/packages/send/backend/package.json
@@ -29,6 +29,7 @@
     "test": "vitest run --silent",
     "test:watch": "vitest --watch",
     "typecheck": "tsc --noEmit",
+    "typecheck:precommit": "tsc --noEmit || (echo '⚠️  Type errors found (see above). Not blocking this commit — pre-existing errors in unrelated files should not stop unrelated changes. Run \"pnpm typecheck\" to see/fix them.' && exit 0)",
     "typecheck:watch": "tsc --noEmit --watch"
   },
   "lint-staged": {

--- a/packages/send/scripts/envs.ts
+++ b/packages/send/scripts/envs.ts
@@ -56,14 +56,17 @@ async function main() {
   console.log("👀 Comparing sample and .env files");
 
   if (backendUniqueKeys.length || frontendUniqueKeys.length) {
-    const errorMessage = `
-    Found unique keys between your .env and .env.sample files. 
+    const warningMessage = `
+    ⚠️  Found unique keys between your .env and .env.sample files.
     This may cause issues with your application.
     If this is intentional, ignore this message:\n
     Backend: ${backendUniqueKeys.join(", ")}\n
     Frontend: ${frontendUniqueKeys.join(", ")}`;
 
-    throw new Error(errorMessage);
+    // Warn only: .env is gitignored and per-developer, so a key present in the
+    // tracked .env.sample (or vice versa) should not hard-fail unrelated commits.
+    console.warn(warningMessage);
+    return;
   }
   console.log("✅ Your env files are in order!");
 }


### PR DESCRIPTION
## What changed?

This change makes two of the repo's pre-commit checks stop rejecting commits for reasons that have nothing to do with what you're actually committing.

1. **Env-file check is now a warning, not a hard stop.** The `compare_envs` script (`packages/send/scripts/envs.ts`) used to fail your commit whenever a setting existed in your personal `.env` but not in the shared `.env.sample` (or vice versa). Because `.env` is per-developer and not tracked in git, this meant one person adding a new sample setting could block everyone else's commits until they manually synced their files — even for commits that never touched any config. It now prints the same helpful message but lets the commit through.

2. **The backend type check no longer blocks on unrelated, pre-existing errors.** The pre-commit hook ran a project-wide type check, so a type error sitting in some other file (that you didn't touch) would stop you from committing your own unrelated change. A new `typecheck:precommit` script still runs the check and shows any problems, but it no longer fails the commit. The strict `typecheck` command is unchanged and still used for CI and manual runs, so type safety is preserved where it matters.

**Files changed:**
- `packages/send/scripts/envs.ts` — warn and exit successfully instead of throwing on env-key mismatches.
- `packages/send/backend/package.json` — add a non-blocking `typecheck:precommit` script (strict `typecheck` untouched).
- `.husky/pre-commit` — use the non-blocking `typecheck:precommit` for the backend pre-commit type check.

**AI-authorship disclosure:** This change was written by an AI agent (an OpenClaw subagent), acting under human direction. A human defined the problem, the intended behavior, and the constraints; the agent investigated the repo, implemented the edits, verified them locally, and opened this PR. All three code changes and this description are agent-authored.

## Why?

Developers were getting their commits rejected by hooks that were checking things unrelated to their change. That's frustrating and pushes people toward bypassing the hooks entirely (`--no-verify`), which defeats the purpose. The goal here is to keep the useful signal from both checks — you still see the warnings and type errors — while only *blocking* on things the committer can reasonably be expected to fix as part of their change. See issue #966 for the full context.

## Limitations and Notes

- The env check and the backend type check are now advisory at commit time. They still run and print output, so problems remain visible; they just won't block an unrelated commit. Enforcement of type correctness should continue to live in CI via the strict `pnpm typecheck`.
- The pre-commit type check is repo/package-wide (non-blocking) rather than scoped to staged files. Scoping `tsc --noEmit` reliably to individual staged files is fragile with path aliases and project setup, so the simpler and safer choice was to keep the full check but make it non-blocking.

## Applicable Issues

Closes #966

## Screenshots

No UI changes.

<details><summary>Before / after (env check)</summary>

Before: `bun run scripts/envs.ts` threw and exited `1`, blocking the commit.

After: same message, prefixed with a ⚠️ warning, exits `0`:

```
👀 Comparing sample and .env files
    ⚠️  Found unique keys between your .env and .env.sample files.
    This may cause issues with your application.
    If this is intentional, ignore this message:
    Backend: DISABLE_SENTRY
    Frontend:
```

</details>

<details><summary>Before / after (type check)</summary>

With a type error injected into an unrelated file, `pnpm typecheck:precommit` prints the error and a clear note, then exits `0` instead of failing the commit:

```
src/index.ts(...): error TS2322: Type 'string' is not assignable to type 'number'.
⚠️  Type errors found (see above). Not blocking this commit — pre-existing errors in unrelated files should not stop unrelated changes. Run "pnpm typecheck" to see/fix them.
```

</details>
