### PR TITLE
fix(send): require auth + share permission to cancel folder-share invitation (#1011)

### DIFF
--- a/packages/send/backend/src/routes/containers.ts
+++ b/packages/send/backend/src/routes/containers.ts
@@ -23,6 +23,7 @@ import {
   requireAdminPermission,
   requireJWT,
   requireReadPermission,
+  requireSharePermission,
   requireWritePermission,
 } from '../middleware';
 
@@ -586,6 +587,8 @@ router.post(
 // Remove invitation and group membership
 router.delete(
   '/:containerId/member/remove/:invitationId',
+  getGroupMemberPermissions,
+  requireSharePermission,
   addErrorHandling(CONTAINER_ERRORS.INVITATION_NOT_DELETED),
   wrapAsyncHandler(async (req, res) => {
     const { invitationId } = req.params;

--- a/packages/send/backend/src/test/routes/containers.invitation-auth.routes.test.ts
+++ b/packages/send/backend/src/test/routes/containers.invitation-auth.routes.test.ts
@@ -1,0 +1,110 @@
+import express from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockRemoveInvitationAndGroup } = vi.hoisted(() => ({
+  mockRemoveInvitationAndGroup: vi.fn(),
+}));
+
+// The route under test only needs removeInvitationAndGroup from the barrel;
+// stub the rest so the import resolves without a database/storage client.
+vi.mock('@send-backend/models', () => ({
+  removeInvitationAndGroup: mockRemoveInvitationAndGroup,
+  reportUpload: vi.fn(),
+  addGroupMember: vi.fn(),
+  createItem: vi.fn(),
+  deleteItem: vi.fn(),
+  getContainerInfo: vi.fn(),
+  getContainerWithDescendants: vi.fn(),
+  getContainerWithMembers: vi.fn(),
+  getSharesForContainer: vi.fn(),
+  getWrappedKeyFromId: vi.fn(),
+  removeGroupMember: vi.fn(),
+  updateAccessLinkPermissions: vi.fn(),
+  updateInvitationPermissions: vi.fn(),
+  updateItemName: vi.fn(),
+}));
+
+vi.mock('@send-backend/models/sharing', () => ({
+  burnFolder: vi.fn(),
+  createInvitation: vi.fn(),
+}));
+
+vi.mock('@send-backend/models/containers', () => ({
+  createContainer: vi.fn(),
+  getAccessLinksForContainer: vi.fn(),
+  getContainerWithAncestors: vi.fn(),
+  getItemsInContainer: vi.fn(),
+  updateContainerName: vi.fn(),
+}));
+
+vi.mock('@send-backend/auth/client', () => ({
+  getDataFromAuthenticatedRequest: vi.fn(),
+  getStorageLimit: vi.fn(),
+}));
+
+vi.mock('@send-backend/storage', () => ({
+  default: { del: vi.fn() },
+}));
+
+// Simulate an unauthenticated caller: getGroupMemberPermissions rejects with
+// 403 before reaching the handler. requireSharePermission would also reject
+// when permissions are missing. Every other middleware is a pass-through.
+const { rejectingAuth } = vi.hoisted(() => ({
+  rejectingAuth: vi.fn(),
+}));
+
+vi.mock('../../middleware', () => {
+  const passthrough = (_req, _res, next) => next();
+  return {
+    requireJWT: passthrough,
+    renameBodyProperty: () => passthrough,
+    getGroupMemberPermissions: rejectingAuth,
+    requireReadPermission: passthrough,
+    requireWritePermission: passthrough,
+    requireAdminPermission: passthrough,
+    requireSharePermission: passthrough,
+  };
+});
+
+vi.mock('@send-backend/utils', () => ({
+  addExpiryToContainer: (c: unknown) => c,
+}));
+
+import router from '../../routes/containers';
+
+const app = express();
+app.use(express.json());
+app.use('/api/containers', router);
+
+describe('DELETE /api/containers/:containerId/member/remove/:invitationId', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects an unauthenticated caller and never touches the model (issue #1011)', async () => {
+    // getGroupMemberPermissions denies the request the way requireAuth does.
+    rejectingAuth.mockImplementation((_req, res) => {
+      res.status(403).json({ message: 'Not authorized' });
+    });
+
+    const response = await request(app).delete(
+      '/api/containers/1/member/remove/1'
+    );
+
+    expect(response.status).toBe(403);
+    expect(mockRemoveInvitationAndGroup).not.toHaveBeenCalled();
+  });
+
+  it('reaches the handler once the auth/permission guards pass', async () => {
+    rejectingAuth.mockImplementation((_req, _res, next) => next());
+    mockRemoveInvitationAndGroup.mockResolvedValue({ ok: true });
+
+    const response = await request(app).delete(
+      '/api/containers/1/member/remove/42'
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockRemoveInvitationAndGroup).toHaveBeenCalledWith(42);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1011 — **Anyone can cancel any folder-share invitation without signing in.**

The `DELETE /api/containers/:containerId/member/remove/:invitationId` route had **no authentication and no permission check**, unlike every sibling member/sharing route (`member/invite`, `member`, `member/:userId`, `shares/invitation/update`, and the `sharing.ts` routes). Because invitation IDs are sequential integers, anyone who guessed a container ID + invitation ID could cancel the invitation and remove the access tied to it — completely unauthenticated.

## Fix

Add the same guards the sibling sharing/invite actions use:

- `getGroupMemberPermissions` — enforces auth (`requireAuth`) and resolves the caller's group membership/permission for the container.
- `requireSharePermission` — requires the `SHARE` (or `ADMIN`) permission, matching `member/invite` in `sharing.ts`.

```diff
 router.delete(
   '/:containerId/member/remove/:invitationId',
+  getGroupMemberPermissions,
+  requireSharePermission,
   addErrorHandling(CONTAINER_ERRORS.INVITATION_NOT_DELETED),
   wrapAsyncHandler(async (req, res) => { ... })
 );
```

## Test

Adds `containers.invitation-auth.routes.test.ts`:
- Unauthenticated caller → `403`, and `removeInvitationAndGroup` is **never** called.
- With guards satisfied → handler runs and calls the model with the parsed invitation ID.

## Verification

- `tsc --noEmit` clean on the change.
- `eslint` clean on both changed files.
- `vitest`: existing container route + middleware tests pass (78 + 3 green), new tests pass.

## Notes

- Related to #1004 (which fixes the destructive lock-out side effect); this PR closes the missing-authentication gap itself.
- The issue also suggests non-guessable IDs for invitations. That's a broader schema change affecting other routes and is left out of this focused security fix.