### PR TITLE
feat(send): set up translation foundation

### DIFF
--- a/packages/send/frontend/package.json
+++ b/packages/send/frontend/package.json
@@ -51,6 +51,7 @@
     "ua-parser-js": "^1.0.41",
     "vue": "^3.5.33",
     "vue-final-modal": "^4.5.5",
+    "vue-i18n": "^11.3.2",
     "vue-router": "^4.6.4"
   },
   "devDependencies": {

--- a/packages/send/frontend/src/apps/send/setup.js
+++ b/packages/send/frontend/src/apps/send/setup.js
@@ -1,4 +1,5 @@
 import '@send-frontend/lib/logger';
+import i18n from '@send-frontend/composables/i18n';
 import posthogPlugin, {
   setPosthogConsent,
 } from '@send-frontend/plugins/posthog';
@@ -9,41 +10,7 @@ import 'floating-vue/dist/style.css';
 import { getSharedPinia } from '@send-frontend/lib/shared-pinia';
 import { createVfm } from 'vue-final-modal';
 import 'vue-final-modal/style.css';
-import { h } from 'vue';
 import './style.css';
-
-// TODO: Configure vue-i18n properly. This is a stub to make @thunderbirdops/services-ui
-// components work that use $t() and <i18n-t> in templates. The package has vue-i18n as a
-// dependency which requires a global i18n instance registered via app.use(i18n).
-const i18nStubMessages = {
-  'footer.copywrite':
-    'Thunderbird is part of {mzlaLink}, a wholly owned subsidiary of the not-for-profit Mozilla.org. Portions of this content are ©1998–{currentYear} by individual contributors. Content available under a {creativeCommonsLink}.',
-  'footer.mzlaLinkText': 'MZLA Technologies Corporation',
-  'footer.creativeCommonsLinkText': 'Creative Commons license',
-};
-
-// Stub <i18n-t> component that services-ui uses for interpolated translations
-const I18nTStub = {
-  name: 'i18n-t',
-  props: ['keypath', 'tag'],
-  render() {
-    const message = i18nStubMessages[this.keypath] || this.keypath;
-    const slots = this.$slots;
-    const tag = this.tag || 'span';
-
-    // Replace {slotName} placeholders with slot content
-    const parts = message.split(/(\{[^}]+\})/g);
-    const children = parts.map((part) => {
-      const match = part.match(/^\{(.+)\}$/);
-      if (match && slots[match[1]]) {
-        return slots[match[1]]();
-      }
-      return part;
-    });
-
-    return h(tag, null, children);
-  },
-};
 
 export function setupApp(app, telemetryAllowed = false) {
   const pinia = getSharedPinia();
@@ -51,15 +18,10 @@ export function setupApp(app, telemetryAllowed = false) {
   app.use(pinia);
   app.use(FloatingVue);
   app.use(posthogPlugin);
+  app.use(i18n);
   // Honor the Thunderbird telemetry opt-out: PostHog only initializes (and
   // sends anything) when telemetry is allowed. See issue #892.
   setPosthogConsent(telemetryAllowed);
-
-  // TODO: Remove this once proper i18n is configured, currently required for the StandardFooter component.
-  // Stub $t and i18n-t for services-ui components until proper i18n is configured
-  app.config.globalProperties.$t = (key) => i18nStubMessages[key] || key;
-  // eslint-disable-next-line vue/component-definition-name-casing
-  app.component('i18n-t', I18nTStub);
 }
 export function mountApp(app, nodeName) {
   const vfm = createVfm();

--- a/packages/send/frontend/src/apps/send/setup.test.ts
+++ b/packages/send/frontend/src/apps/send/setup.test.ts
@@ -1,0 +1,29 @@
+import { createApp } from 'vue';
+import { describe, expect, it, vi } from 'vitest';
+import { setupApp } from './setup';
+
+vi.mock('@send-frontend/lib/logger', () => ({}));
+vi.mock('@send-frontend/lib/shared-pinia', () => ({
+  getSharedPinia: vi.fn(() => ({ install: vi.fn() })),
+}));
+vi.mock('@send-frontend/plugins/posthog', () => ({
+  default: { install: vi.fn() },
+  setPosthogConsent: vi.fn(),
+}));
+vi.mock('@tanstack/vue-query', () => ({
+  VueQueryPlugin: { install: vi.fn() },
+}));
+vi.mock('floating-vue', () => ({ default: { install: vi.fn() } }));
+
+describe('setupApp', () => {
+  it('registers translation helpers and components', () => {
+    const app = createApp({ render: () => null });
+
+    setupApp(app);
+
+    expect(app.config.globalProperties.$t('footer.mzlaLinkText')).toBe(
+      'MZLA Technologies Corporation'
+    );
+    expect(app.component('i18n-t')).toBeDefined();
+  });
+});

--- a/packages/send/frontend/src/composables/i18n.test.ts
+++ b/packages/send/frontend/src/composables/i18n.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import i18n, { defaultLocale } from './i18n';
+
+describe('i18n', () => {
+  it('uses the base locale from a regional browser locale', () => {
+    expect(defaultLocale('en-US')).toBe('en');
+  });
+
+  it('keeps the browser locale and configures English as the fallback', () => {
+    expect(defaultLocale('de-DE')).toBe('de');
+    expect(i18n.global.fallbackLocale.value).toBe('en');
+  });
+
+  it('translates interpolated footer messages', () => {
+    expect(
+      i18n.global.t('footer.copywrite', {
+        mzlaLink: 'MZLA',
+        currentYear: 2026,
+        creativeCommonsLink: 'Creative Commons',
+      })
+    ).toBe(
+      'Thunderbird is part of MZLA, a wholly owned subsidiary of the not-for-profit Mozilla.org. Portions of this content are \u00a91998\u20132026 by individual contributors. Content available under a Creative Commons.'
+    );
+  });
+});

--- a/packages/send/frontend/src/composables/i18n.ts
+++ b/packages/send/frontend/src/composables/i18n.ts
@@ -2,6 +2,8 @@ import { createI18n } from 'vue-i18n';
 import en from '@send-frontend/locales/en.json';
 
 const fallbackLocale = 'en';
+// StandardFooter currently uses the catalogue bundled with services-ui. Keep
+// these messages as the starting point for Send's follow-up string migration.
 const messages = { en };
 
 export function defaultLocale(language?: string) {
@@ -21,5 +23,3 @@ const instance = createI18n({
 });
 
 export default instance;
-export const i18n = instance.global;
-export type i18nType = typeof i18n.t;

--- a/packages/send/frontend/src/composables/i18n.ts
+++ b/packages/send/frontend/src/composables/i18n.ts
@@ -1,0 +1,25 @@
+import { createI18n } from 'vue-i18n';
+import en from '@send-frontend/locales/en.json';
+
+const fallbackLocale = 'en';
+const messages = { en };
+
+export function defaultLocale(language?: string) {
+  const browserLanguage =
+    language ??
+    (typeof navigator === 'undefined' ? fallbackLocale : navigator.language);
+
+  return browserLanguage.toLowerCase().split('-')[0] || fallbackLocale;
+}
+
+const instance = createI18n({
+  legacy: false,
+  globalInjection: true,
+  locale: defaultLocale(),
+  fallbackLocale,
+  messages,
+});
+
+export default instance;
+export const i18n = instance.global;
+export type i18nType = typeof i18n.t;

--- a/packages/send/frontend/src/locales/en.json
+++ b/packages/send/frontend/src/locales/en.json
@@ -1,0 +1,7 @@
+{
+  "footer": {
+    "copywrite": "Thunderbird is part of {mzlaLink}, a wholly owned subsidiary of the not-for-profit Mozilla.org. Portions of this content are \u00a91998\u2013{currentYear} by individual contributors. Content available under a {creativeCommonsLink}.",
+    "mzlaLinkText": "MZLA Technologies Corporation",
+    "creativeCommonsLinkText": "Creative Commons license"
+  }
+}

--- a/packages/send/frontend/tsconfig.client.base.json
+++ b/packages/send/frontend/tsconfig.client.base.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "module": "es2022",
     "moduleResolution": "Node",
+    "resolveJsonModule": true,
     "declaration": true,
     "removeComments": true,
     "emitDecoratorMetadata": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -576,6 +576,9 @@ importers:
       vue-final-modal:
         specifier: ^4.5.5
         version: 4.5.5(@vueuse/core@10.11.1(vue@3.5.33(typescript@5.9.3)))(@vueuse/integrations@13.0.0(axios@1.18.1)(focus-trap@7.6.4)(jwt-decode@4.0.0)(vue@3.5.33(typescript@5.9.3)))(focus-trap@7.6.4)(vue@3.5.33(typescript@5.9.3))
+      vue-i18n:
+        specifier: ^11.3.2
+        version: 11.3.2(vue@3.5.33(typescript@5.9.3))
       vue-router:
         specifier: ^4.6.4
         version: 4.6.4(vue@3.5.33(typescript@5.9.3))
@@ -17008,6 +17011,14 @@ snapshots:
       '@intlify/shared': 11.3.2
       '@vue/devtools-api': 6.6.4
       vue: 3.5.32(typescript@5.9.3)
+
+  vue-i18n@11.3.2(vue@3.5.33(typescript@5.9.3)):
+    dependencies:
+      '@intlify/core-base': 11.3.2
+      '@intlify/devtools-types': 11.3.2
+      '@intlify/shared': 11.3.2
+      '@vue/devtools-api': 6.6.4
+      vue: 3.5.33(typescript@5.9.3)
 
   vue-resize@2.0.0-alpha.1(vue@3.5.33(typescript@5.9.3)):
     dependencies:


### PR DESCRIPTION
## What changed?

Added the translation foundation for the Send frontend using Vue I18n.

- Added an English fallback locale and browser-language detection.
- Registered Vue I18n across the Send application entry points.
- Replaced the temporary footer translation stub with the real i18n plugin.
- Added focused tests for locale selection, fallback behavior, interpolation, and application setup.

AI assistance was used to draft the implementation and tests. I directed the scope, reviewed the resulting changes and verification results, and take responsibility for the contribution.

## Why?

The Send interface currently lacks a proper localization foundation and relies on a temporary translation stub for the shared footer.

This change establishes the infrastructure needed to migrate user-facing strings into locale files in follow-up work, while preserving the current English interface.

## Limitations and Notes

This PR only establishes the translation foundation. It includes the existing footer messages in English but does not migrate the remaining interface strings or add additional languages.

## Applicable Issues

Closes #1087

## Screenshots

Not applicable. This change is not intended to alter the visible interface.

## Testing

- Frontend unit suite: 335 passed, 2 skipped
- Focused i18n tests: 4 passed
- TypeScript type checking passed
- ESLint and Prettier checks passed
- Production builds passed for the web app, management page, and Thunderbird extension
- Frozen lockfile installation passed
