### PR TITLE
fix(addon): drop illegal `send-*.tb.pro` manifest match pattern

### DIFF
--- a/packages/addon/public/manifest.json
+++ b/packages/addon/public/manifest.json
@@ -145,7 +145,6 @@
       "matches": [
         "https://send.tb.pro/*",
         "https://send-stage.tb.pro/*",
-        "https://send-*.tb.pro/*",
         "http://localhost/*",
         "https://localhost/*"
       ],

--- a/packages/addon/src/test/integration/a2-origin-mismatch-logout-not-delivered.test.ts
+++ b/packages/addon/src/test/integration/a2-origin-mismatch-logout-not-delivered.test.ts
@@ -6,15 +6,15 @@
  * See ADDON-BUG-REPORTS-2026-07-22.md #A2 and
  * ADDON-SYNC-VERIFIED-FINDINGS-2026-07-21.md §A2.
  *
- * Fix: `manifest.json` content_scripts.matches now also covers:
- *   - `https://localhost/*` (HTTPS local dev/test, not just the bare
- *     `http://localhost` the manifest listed).
- *   - `https://send-*.tb.pro/*` (any preview/staging subdomain of tb.pro
- *     — e.g. `send-preview-pr123.tb.pro`).
+ * Fix: `manifest.json` content_scripts.matches now also covers
+ * `https://localhost/*` (HTTPS local dev/test, not just the bare
+ * `http://localhost` the manifest listed), so any Send page we actually
+ * ship or develop against has a token-bridge.js listener to receive
+ * UserMenu.vue's SIGN_OUT postMessage.
  *
- * With these added, the structural gap is closed: any Send page rendered
- * inside Thunderbird's embedded browser engine now actually has a
- * token-bridge.js listener to receive UserMenu.vue's SIGN_OUT postMessage.
+ * Coverage stops at the hosts we name. See
+ * manifest-match-patterns.test.ts for why a `send-*.tb.pro` wildcard
+ * can't be one of them.
  *
  * (The other half of the bug — `UserMenu.vue`'s gate only checking
  * `isRunningInsideThunderbird.value` without verifying a listener is
@@ -84,7 +84,7 @@ describe('A2: token-bridge origin mismatch means logout never reaches the add-on
     });
   }
 
-  it('CONFIRMED BUG: isThunderbirdHost is true for a Send-app origin the manifest does NOT inject token-bridge.js on', () => {
+  it('injects token-bridge.js on every Send origin we ship, and nowhere else', () => {
     // Any page rendered inside Thunderbird's embedded browser engine has
     // "Thunderbird" in its UA string, regardless of which origin it is.
     stubUserAgent(
@@ -118,21 +118,19 @@ describe('A2: token-bridge origin mismatch means logout never reaches the add-on
       matchesAnyPattern('https://localhost:5150/send/profile', matchPatterns)
     ).toBe(true);
 
-    // Likewise, any preview/staging host under tb.pro is now covered by
-    // the wildcard `https://send-*.tb.pro/*` pattern.
+    // Stage is covered by its own explicit pattern.
+    expect(
+      matchesAnyPattern('https://send-stage.tb.pro/send/profile', matchPatterns)
+    ).toBe(true);
+
+    // The bridge relays OIDC tokens and the passphrase to the privileged
+    // background, so it must only be injected on hosts we name -- never on
+    // an arbitrary `send-<anything>.tb.pro`.
     expect(
       matchesAnyPattern(
         'https://send-preview-pr123.tb.pro/send/profile',
         matchPatterns
       )
-    ).toBe(true);
-
-    // Sanity: the pre-existing explicit patterns still match.
-    expect(
-      matchesAnyPattern('https://send.tb.pro/some/path', matchPatterns)
-    ).toBe(true);
-    expect(matchesAnyPattern('http://localhost/some/path', matchPatterns)).toBe(
-      true
-    );
+    ).toBe(false);
   });
 });

--- a/packages/addon/src/test/manifest-match-patterns.test.ts
+++ b/packages/addon/src/test/manifest-match-patterns.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Guards `public/manifest.json` against illegal WebExtension match patterns.
+ *
+ * A `*` is legal only as the entire host or as a leading `*.` subdomain
+ * label -- `https://send-*.tb.pro/*` is not a pattern, it's a manifest
+ * error. In `content_scripts[].matches` that error is fatal: Thunderbird
+ * rejects the whole manifest rather than dropping the one entry, so the
+ * add-on fails to install. In `permissions` it degrades quietly, dropping
+ * the host permission with a warning. Both are worth catching here, since
+ * nothing else in the repo validates the manifest.
+ *
+ * Validating the source manifest covers every shipped variant: `build.sh`
+ * only strips localhost patterns from the built copy and the `set-*-id`
+ * scripts only rewrite ids and icons. No build step ever adds a pattern.
+ *
+ * See issue #1095.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const MANIFEST_PATH = resolve(__dirname, '../../public/manifest.json');
+
+/** The host component of a `scheme://host/path` match pattern. */
+function hostOf(pattern: string): string {
+  return pattern.match(/^[a-z*]+:\/\/([^/]*)\//)?.[1] ?? '';
+}
+
+/** `*`, or an optional leading `*.` label followed by a wildcard-free host. */
+const LEGAL_HOST = /^(\*|(\*\.)?[^*]+)$/;
+
+describe('manifest.json match patterns', () => {
+  const manifest = JSON.parse(readFileSync(MANIFEST_PATH, 'utf-8'));
+
+  const contentScriptPatterns: string[] = manifest.content_scripts.flatMap(
+    (cs: { matches: string[] }) => cs.matches
+  );
+  // `permissions` mixes API permissions ("storage") with host patterns.
+  const hostPermissions: string[] = manifest.permissions.filter((p: string) =>
+    p.includes('://')
+  );
+
+  it('declares patterns to check', () => {
+    expect(contentScriptPatterns.length).toBeGreaterThan(0);
+    expect(hostPermissions.length).toBeGreaterThan(0);
+  });
+
+  it.each([
+    ['content_scripts[].matches', () => contentScriptPatterns],
+    ['host permissions', () => hostPermissions],
+  ])('uses only legal wildcard placement in %s', (_label, patterns) => {
+    expect(patterns().filter((p) => !LEGAL_HOST.test(hostOf(p)))).toEqual([]);
+  });
+
+  it('rejects the mid-host wildcard that broke #1095', () => {
+    // Pin the rule itself, so a future loosening of LEGAL_HOST is visible.
+    expect(LEGAL_HOST.test(hostOf('https://send-*.tb.pro/*'))).toBe(false);
+    expect(LEGAL_HOST.test(hostOf('https://*.tb.pro/*'))).toBe(true);
+    expect(LEGAL_HOST.test(hostOf('https://send-stage.tb.pro/*'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## What changed?

The add-on's `manifest.json` listed `https://send-*.tb.pro/*` as one of the sites our content script runs on. That's not a valid pattern — Thunderbird only accepts a `*` in place of a whole domain name or as a leading `*.`, never in the middle of one. So instead of ignoring that one line, Thunderbird throws out the entire manifest and the add-on won't install.

Three changes:

1. **Deleted the bad line** from `manifest.json`. Everything else stays: production, staging, and both localhost variants still get the content script, so nothing we actually run against is affected.
2. **Fixed the test that was defending the bug.** A test asserted the bad pattern successfully matched a preview URL, so the suite was confirming the broken behavior instead of flagging it. Flipped it, and rewrote the surrounding comments — they described the invalid pattern as a fix.
3. **Added a test so this can't come back quietly** (`manifest-match-patterns.test.ts`). It reads the real manifest and fails if any site pattern uses a `*` in a place Thunderbird won't accept. We had nothing checking the manifest before, which is why a broken one made it to a release.

**AI disclosure:** I wrote the manifest fix. The test changes and this description were agent-written (Claude Code) and reviewed line by line before pushing. I also had an agent review the diff — it caught that the new test only checked half the manifest, that it was in a file nobody would find, and that its failure message didn't say which pattern was wrong. All three are fixed here. Everything claimed above was checked with the real add-on validator rather than taken on faith: it fails on the old manifest, passes on the new one, and I confirmed the new test actually fails by putting the bad pattern back temporarily.

## Why?

The add-on can't install with this in the manifest, and it's in `v2.0.8` and in the packaged `.xpi` sitting in the tree, not just on `main`.

Running the official validator against the tagged manifest:

```
JSON_INVALID "/content_scripts/0/matches/2" must match pattern
"^(https?|wss?|file|ftp|\*)://(\*|\*\.[^*/]+|[^*/]+)/.*$"
```

The bad pattern came in with #1050.

## Limitations and Notes

- **On paper this drops support for preview URLs** like `send-preview-pr123.tb.pro`, which is what #1050 was going for. In practice we don't have any: CI only ever deploys staging and production, and that hostname appears nowhere in the repo outside the old test. If we do want preview deployments later, we either list each one by name or name them `something.send-preview.tb.pro`, which *is* a shape Thunderbird accepts.
- **Running the real add-on validator in CI would be the better long-term fix.** It'd catch this plus a range of other manifest mistakes my test doesn't look for. We already install the tooling for signing but never run its linter. Left as follow-up to keep this PR focused — the new test is the cheap version.
- I didn't reformat `manifest.json`. Prettier wants to reformat the whole file, which would bury a one-line fix in 80 lines of noise.
- Full add-on test suite passes: 72 tests, 1 skipped.

## Applicable Issues

Closes #1095

## Screenshots

N/A — nothing visual changed.
