### PR TITLE
fix(ci): run validation checks on pull requests from forks

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -11,6 +11,11 @@ on:
     branches:
       - "**"
       - "!main"
+  # Fork branches are never pushed to this repo, so the push trigger above never
+  # fires for them. The pull_request trigger is what gives fork PRs their checks.
+  pull_request:
+    branches:
+      - main
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -21,6 +26,12 @@ permissions:
 jobs:
   detect-changes:
     runs-on: ubuntu-latest
+    # Branches in this repo are already covered by the push trigger, so only let the
+    # pull_request event do the work for forks. Every other job needs this one, so
+    # skipping it here skips the whole duplicate run.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name != github.repository
     env:
       IS_CI_AUTOMATION: "yes"
     outputs:
@@ -55,6 +66,10 @@ jobs:
       BACKEND_IMAGE: ghcr.io/${{ github.repository }}/e2e-backend:${{ github.sha }}-fs
       FRONTEND_IMAGE: ghcr.io/${{ github.repository }}/e2e-frontend:${{ github.sha }}-fs
       PROXY_IMAGE: ghcr.io/${{ github.repository }}/e2e-reverse-proxy:${{ github.sha }}-fs
+      # A fork PR only ever gets a read-only GITHUB_TOKEN, so pushing to GHCR would
+      # fail with a 403. Build the images anyway — that they still build is the part
+      # of this workflow a fork PR can prove — and skip the push.
+      PUSH_IMAGES: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - uses: actions/checkout@v4
 
@@ -83,7 +98,7 @@ jobs:
           context: ./packages/send/backend/.docker-build
           file: ./packages/send/backend/.docker-build/Dockerfile
           build-args: BUILD_ENV=production
-          push: true
+          push: ${{ env.PUSH_IMAGES }}
           tags: ${{ env.BACKEND_IMAGE }}
           cache-from: type=gha,scope=e2e-backend-fs
           cache-to: type=gha,mode=max,scope=e2e-backend-fs
@@ -92,7 +107,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: ./packages/send/backend/tls-dev-proxy
-          push: true
+          push: ${{ env.PUSH_IMAGES }}
           tags: ${{ env.PROXY_IMAGE }}
           cache-from: type=gha,scope=e2e-reverse-proxy-fs
           cache-to: type=gha,mode=max,scope=e2e-reverse-proxy-fs
@@ -103,14 +118,22 @@ jobs:
           context: ./
           file: ./dockerfiles/Dockerfile-frontend
           build-args: BUILD_ENV=production
-          push: true
+          push: ${{ env.PUSH_IMAGES }}
           tags: ${{ env.FRONTEND_IMAGE }}
           cache-from: type=gha,scope=e2e-frontend-fs
           cache-to: type=gha,mode=max,scope=e2e-frontend-fs
 
   end-to-end-tests:
     needs: [detect-changes, build-e2e-images]
-    if: needs.detect-changes.outputs.backend-changed == 'true' || needs.detect-changes.outputs.frontend-changed == 'true'
+    # GitHub never exposes repository secrets to a fork-triggered run, and this job
+    # needs them for the OIDC login the dev specs go through — plus the images the
+    # build job could not push. Stop after the image build for fork PRs rather than
+    # reporting a failure the contributor cannot act on.
+    if: >-
+      (needs.detect-changes.outputs.backend-changed == 'true' ||
+       needs.detect-changes.outputs.frontend-changed == 'true') &&
+      (github.event_name != 'pull_request' ||
+       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/${{ github.repository }}/cached-devcontainer:latest

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -10,6 +10,11 @@ on:
     branches:
       - "**"
       - "!main"
+  # Fork branches are never pushed to this repo, so the push trigger above never
+  # fires for them. The pull_request trigger is what gives fork PRs their checks.
+  pull_request:
+    branches:
+      - main
 
 permissions:
   packages: read
@@ -18,6 +23,12 @@ permissions:
 jobs:
   detect-changes:
     runs-on: ubuntu-latest
+    # Branches in this repo are already covered by the push trigger, so only let the
+    # pull_request event do the work for forks. Every other job needs this one, so
+    # skipping it here skips the whole duplicate run.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name != github.repository
     env:
       IS_CI_AUTOMATION: "yes"
     outputs:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,6 +10,11 @@ on:
     branches:
       - "**"
       - "!main"
+  # Fork branches are never pushed to this repo, so the push trigger above never
+  # fires for them. The pull_request trigger is what gives fork PRs their checks.
+  pull_request:
+    branches:
+      - main
 
 permissions:
   packages: read
@@ -19,6 +24,12 @@ jobs:
   # This job detects which parts of the repo have been changed, setting future jobs up for conditional behavior.
   detect-changes:
     runs-on: ubuntu-latest
+    # Branches in this repo are already covered by the push trigger, so only let the
+    # pull_request event do the work for forks. Every other job needs this one, so
+    # skipping it here skips the whole duplicate run.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name != github.repository
     env:
       IS_CI_AUTOMATION: "yes"
     outputs:


### PR DESCRIPTION
## What changed?

Our checks only ran `on: push`. A fork's commits go to the contributor's own copy of the repo, never ours — so nothing fired, and fork PRs showed "no checks reported."

Added a `pull_request` trigger to the three workflows the issue names: `validate.yml`, `integration-test.yml`, `e2e-test.yml`.

That created two follow-on problems, both handled here:

**Internal branches would have run twice**, since a branch pushed here now matches both triggers. Each workflow's `detect-changes` job skips when the PR comes from a same-repo branch — the push already covered that commit. Every other job depends on `detect-changes`, so that one guard skips the whole duplicate run.

**e2e can only go partway from a fork.** Its build job pushes images to GHCR, which needs a write token fork PRs don't get. Those steps now push conditionally: a fork still builds all three images (proving they compile) and skips only the upload. The browser tests are skipped rather than failed — they need both those images and secrets a fork run can't have.

Net result for a fork PR: full `validate`, full `integration-tests`, and the e2e image builds.

**AI disclosure:** Agent-written (Claude Code, Opus 5) including this description, at my direction, and I reviewed the diff line by line. Mine were the calls to guard one job instead of every job, and to skip rather than fail e2e on forks. I also cut an initial rewrite of the three `concurrency` groups as unnecessary churn.

## Why?

Outside contributors get no automated signal on their PRs, and neither do reviewers — #1093 has zero checks. Merging a fork PR today means either trusting it unverified or a maintainer pushing the branch here by hand just to make CI run.

## Limitations and Notes

**Verified.** `actionlint` clean locally and green in CI. All nine runs on this branch behaved as designed: the three `push` runs passed, and the three `pull_request` runs came back *skipped* — that's the same-repo guard working.

**Not verified: the fork path itself.** This PR isn't from a fork, so its own checks only exercise the push side. The thing to watch is that every job runs inside `cached-devcontainer`, a private GHCR image, so fork runs depend on the read-only token being accepted for `packages: read`. GitHub's docs say it is; I couldn't prove it without a real fork PR. If the first fork PR dies at "Initialize containers," the answer is to make that package public — not to change anything in this diff.

**e2e will never fully run on fork PRs**, and no trigger change fixes it. Secrets are never passed to fork-triggered runs, and approval gates don't change that. The only ways around it are `pull_request_target` (runs fork code with access to our secrets) or a maintainer pushing the branch here. That's a security call I left to you; worth a follow-up issue.

**Still push-only:** `validate-workflows.yml`, `validate-devcontainer.yml`, `e2e-bucket-test.yml`. I stuck to the three workflows the issue names. Of those three, `validate-workflows.yml` (actionlint) is fork-safe and a four-line add — say the word and I'll include it. The other two need secrets or a write token, so they hit the same wall as e2e.

**No tests.** These are CI trigger definitions — no unit-testable surface, and the repo has no workflow-behavior harness. `actionlint` plus the run results above are the available coverage.

`dorny/paths-filter` needed no change: on `pull_request` it diffs base against head via the API, which is more accurate than the `before`/`after` comparison it uses on pushes.

## Applicable Issues

Closes #1098

## Screenshots

N/A — CI configuration only.
