### PR TITLE
feat(send): configure the SPA at runtime, and publish images to GHCR

### DIFF
--- a/.github/workflows/build-multiarch-image.yml
+++ b/.github/workflows/build-multiarch-image.yml
@@ -199,9 +199,22 @@ jobs:
           count="$(find . -type f | wc -l)"
           [ "$count" -eq 2 ] || { echo "::error::expected 2 arch digests, found $count"; exit 1; }
           # Always publish the immutable :<sha>; add moving tags only from main.
+          #
+          # HEAD GUARD: concurrency groups are per-SHA, so two merges' runs
+          # race freely, and without this check a SLOWER run for an OLDER
+          # commit would re-point :latest / :v<version> backwards after the
+          # newer commit already tagged them. Moving tags are only applied
+          # while this run's SHA is still the head of the branch; the
+          # immutable :<sha> is published either way, so the matched-set
+          # invariant is unaffected.
           tags="-t ${IMAGE}:${SHA}"
           if [ "$MOVING_TAGS" = "true" ]; then
-            tags="$tags -t ${IMAGE}:v${VERSION} -t ${IMAGE}:latest"
+            head="$(git ls-remote "https://github.com/${GITHUB_REPOSITORY}.git" "$GITHUB_REF" | cut -f1)"
+            if [ "$head" = "$SHA" ]; then
+              tags="$tags -t ${IMAGE}:v${VERSION} -t ${IMAGE}:latest"
+            else
+              echo "::notice::skipping moving tags: $GITHUB_REF is now at ${head:-<unknown>}, not ${SHA}"
+            fi
           fi
           # imagetools create references digests already in GHCR (no rebuild/re-push).
           # shellcheck disable=SC2046,SC2086

--- a/.github/workflows/build-multiarch-image.yml
+++ b/.github/workflows/build-multiarch-image.yml
@@ -1,0 +1,201 @@
+---
+# Reusable workflow: build ONE container image for linux/amd64 and linux/arm64
+# on NATIVE runners (no QEMU), push each arch to GHCR by digest, then stitch the
+# digests into a single multi-arch manifest list tagged :<sha>, :v<version> and
+# :latest. Callers get the fully-qualified :<sha> reference back via the `image`
+# output. Invoked by publish-images.yml for the Send backend + frontend.
+#
+# Mirrors thunderbird/thunderbird-appointment's workflow of the same name. Auth is
+# GHCR + the automatic GITHUB_TOKEN (packages: write) -- no cloud credentials,
+# which keeps this pipeline fully decoupled from the existing ECR/ECS/S3 deploy
+# (merge.yml and release.yml stay untouched).
+name: build-multiarch-image
+
+on:
+  workflow_call:
+    inputs:
+      image:
+        description: Fully-qualified GHCR image name WITHOUT a tag (e.g. ghcr.io/owner/name).
+        required: true
+        type: string
+      dockerfile:
+        description: Path to the Dockerfile to build (relative to the repo root).
+        required: false
+        type: string
+        default: Dockerfile
+      context:
+        description: Build context directory (relative to the repo root).
+        required: false
+        type: string
+        default: .
+      prepare-script:
+        description: >-
+          Optional script (path relative to the repo root) run before the build,
+          for images whose Dockerfile needs a prepared context. The Send backend
+          needs this: its Dockerfile ADDs pnpm-lock.yaml, which does not live in
+          packages/send/backend, so backend/scripts/build.sh assembles
+          .docker-build first -- exactly as merge.yml does for the ECR image.
+        required: false
+        type: string
+        default: ""
+      version:
+        description: Semantic version (no leading v) published as the :v<version> tag.
+        required: true
+        type: string
+      artifact-prefix:
+        description: >-
+          Unique prefix for this image's digest artifacts. Distinct images built
+          in the same run (backend, frontend) MUST use different prefixes so
+          their per-arch digest artifacts don't collide.
+        required: true
+        type: string
+      moving-tags:
+        description: >-
+          Publish the moving tags (:latest and :v<version>) in addition to the
+          immutable :<sha>. Pass true only from the default branch; false (default)
+          publishes only :<sha> so a workflow_dispatch from a feature branch cannot
+          re-point :latest at unreviewed content.
+        required: false
+        type: boolean
+        default: false
+    outputs:
+      image:
+        description: The :<sha>-tagged multi-arch image reference that was pushed.
+        value: ${{ jobs.merge.outputs.image }}
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  # One job per architecture, each on its matching native runner. Each pushes an
+  # anonymous (tag-less) image to GHCR and records its digest as an artifact.
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            arch: amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Prepare build context
+        if: inputs.prepare-script != ''
+        env:
+          PREPARE_SCRIPT: ${{ inputs.prepare-script }}
+        run: |
+          set -euo pipefail
+          test -f "$PREPARE_SCRIPT" || { echo "::error::prepare-script not found: $PREPARE_SCRIPT"; exit 1; }
+          sh "$PREPARE_SCRIPT"
+
+      - name: Build and push image by digest
+        id: build
+        env:
+          IMAGE: ${{ inputs.image }}
+          DOCKERFILE: ${{ inputs.dockerfile }}
+          CONTEXT: ${{ inputs.context }}
+          SCOPE: ${{ inputs.artifact-prefix }}-${{ matrix.arch }}
+          PLATFORM: ${{ matrix.platform }}
+          # RELEASE_VERSION is available to both Dockerfiles; only the backend uses it.
+          RELEASE_VERSION: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          # Build this single platform and push to GHCR by digest only (no tag).
+          # push-by-digest keeps the pushed image anonymous so both arch runners
+          # push concurrently without clobbering a shared tag; the merge job
+          # assigns the real tags. --provenance=false keeps each per-arch push a
+          # single plain manifest so the merged list has exactly two entries.
+          docker buildx build \
+            -f "$DOCKERFILE" \
+            --platform "$PLATFORM" \
+            --provenance=false \
+            --build-arg "RELEASE_VERSION=$RELEASE_VERSION" \
+            --cache-from "type=gha,scope=$SCOPE" \
+            --cache-to "type=gha,mode=max,scope=$SCOPE" \
+            --output "type=image,name=$IMAGE,push-by-digest=true,name-canonical=true,push=true" \
+            --metadata-file metadata.json \
+            "$CONTEXT"
+          digest="$(jq -r '."containerimage.digest"' metadata.json)"
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+
+      - name: Export digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          mkdir -p "${{ runner.temp }}/digests"
+          touch "${{ runner.temp }}/digests/${DIGEST#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ inputs.artifact-prefix }}-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Combine the per-arch digests into one manifest list under all three tags.
+  merge:
+    needs: build
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.merge.outputs.image }}
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-${{ inputs.artifact-prefix }}-*
+          merge-multiple: true
+
+      - name: Create manifest list and push
+        id: merge
+        env:
+          IMAGE: ${{ inputs.image }}
+          VERSION: ${{ inputs.version }}
+          SHA: ${{ github.sha }}
+          MOVING_TAGS: ${{ inputs.moving-tags }}
+          DIGESTS_DIR: ${{ runner.temp }}/digests
+        run: |
+          set -euo pipefail
+          cd "$DIGESTS_DIR"
+          # arm64 guard: require exactly the two expected per-arch digests before
+          # publishing, so a single-arch manifest list can never be tagged.
+          count="$(find . -type f | wc -l)"
+          [ "$count" -eq 2 ] || { echo "::error::expected 2 arch digests, found $count"; exit 1; }
+          # Always publish the immutable :<sha>; add moving tags only from main.
+          tags="-t ${IMAGE}:${SHA}"
+          if [ "$MOVING_TAGS" = "true" ]; then
+            tags="$tags -t ${IMAGE}:v${VERSION} -t ${IMAGE}:latest"
+          fi
+          # imagetools create references digests already in GHCR (no rebuild/re-push).
+          # shellcheck disable=SC2046,SC2086
+          docker buildx imagetools create $tags $(printf "${IMAGE}@sha256:%s " *)
+          docker buildx imagetools inspect "${IMAGE}:${SHA}"
+          echo "image=${IMAGE}:${SHA}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-multiarch-image.yml
+++ b/.github/workflows/build-multiarch-image.yml
@@ -63,14 +63,15 @@ on:
         description: The :<sha>-tagged multi-arch image reference that was pushed.
         value: ${{ jobs.merge.outputs.image }}
 
-permissions:
-  contents: read
-  packages: write
-
 jobs:
   # One job per architecture, each on its matching native runner. Each pushes an
   # anonymous (tag-less) image to GHCR and records its digest as an artifact.
   build:
+    # Scoped per job rather than workflow-wide: `merge` only retags digests that
+    # are already in GHCR, so it never needs the repository contents.
+    permissions:
+      contents: read
+      packages: write
     strategy:
       fail-fast: false
       matrix:
@@ -102,6 +103,11 @@ jobs:
         run: |
           set -euo pipefail
           test -f "$PREPARE_SCRIPT" || { echo "::error::prepare-script not found: $PREPARE_SCRIPT"; exit 1; }
+          # The backend's prepare script needs rsync. It ships in both hosted
+          # runner images, but state the dependency rather than assume it: a
+          # missing binary would otherwise surface in the merge job as "expected 2
+          # arch digests, found 1" and read as an arm-runner availability problem.
+          command -v rsync >/dev/null 2>&1 || { sudo apt-get update -qq && sudo apt-get install -y -qq rsync; }
           sh "$PREPARE_SCRIPT"
 
       - name: Build and push image by digest
@@ -110,10 +116,7 @@ jobs:
           IMAGE: ${{ inputs.image }}
           DOCKERFILE: ${{ inputs.dockerfile }}
           CONTEXT: ${{ inputs.context }}
-          SCOPE: ${{ inputs.artifact-prefix }}-${{ matrix.arch }}
           PLATFORM: ${{ matrix.platform }}
-          # RELEASE_VERSION is available to both Dockerfiles; only the backend uses it.
-          RELEASE_VERSION: ${{ github.sha }}
         run: |
           set -euo pipefail
           # Build this single platform and push to GHCR by digest only (no tag).
@@ -121,13 +124,17 @@ jobs:
           # push concurrently without clobbering a shared tag; the merge job
           # assigns the real tags. --provenance=false keeps each per-arch push a
           # single plain manifest so the merged list has exactly two entries.
+          #
+          # NO `--cache-from/--cache-to type=gha` here: that backend needs
+          # ACTIONS_RUNTIME_TOKEN and ACTIONS_RESULTS_URL, which the runner exports
+          # to JS actions but NOT to `run:` steps, and buildx then silently imports
+          # and exports nothing instead of failing. Do not add the flags back
+          # without also exporting those vars (or moving to
+          # docker/build-push-action), or the workflow only looks like it caches.
           docker buildx build \
             -f "$DOCKERFILE" \
             --platform "$PLATFORM" \
             --provenance=false \
-            --build-arg "RELEASE_VERSION=$RELEASE_VERSION" \
-            --cache-from "type=gha,scope=$SCOPE" \
-            --cache-to "type=gha,mode=max,scope=$SCOPE" \
             --output "type=image,name=$IMAGE,push-by-digest=true,name-canonical=true,push=true" \
             --metadata-file metadata.json \
             "$CONTEXT"
@@ -154,6 +161,8 @@ jobs:
   merge:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     outputs:
       image: ${{ steps.merge.outputs.image }}
     steps:
@@ -185,8 +194,8 @@ jobs:
         run: |
           set -euo pipefail
           cd "$DIGESTS_DIR"
-          # arm64 guard: require exactly the two expected per-arch digests before
-          # publishing, so a single-arch manifest list can never be tagged.
+          # Require exactly the two expected per-arch digests before publishing, so
+          # a single-arch manifest list can never be tagged.
           count="$(find . -type f | wc -l)"
           [ "$count" -eq 2 ] || { echo "::error::expected 2 arch digests, found $count"; exit 1; }
           # Always publish the immutable :<sha>; add moving tags only from main.
@@ -197,5 +206,16 @@ jobs:
           # imagetools create references digests already in GHCR (no rebuild/re-push).
           # shellcheck disable=SC2046,SC2086
           docker buildx imagetools create $tags $(printf "${IMAGE}@sha256:%s " *)
-          docker buildx imagetools inspect "${IMAGE}:${SHA}"
+          # The count check above is arch-BLIND -- it cannot tell two amd64 digests
+          # from one of each. The EKS nodes are Graviton, so a list that silently
+          # lacks linux/arm64 is the exact failure this is meant to prevent. Assert
+          # both platforms are in the published list rather than just printing it.
+          inspected="$(docker buildx imagetools inspect "${IMAGE}:${SHA}")"
+          echo "$inspected"
+          for platform in linux/amd64 linux/arm64; do
+            echo "$inspected" | grep -q "$platform" || {
+              echo "::error::published manifest list is missing $platform"
+              exit 1
+            }
+          done
           echo "image=${IMAGE}:${SHA}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -15,8 +15,13 @@
 name: publish-images
 
 concurrency:
-  group: publish-images-${{ github.ref }}
-  # Serialize (don't cancel) so every merged commit's :<sha> image gets published.
+  # Keyed on the SHA, not the ref, ON PURPOSE. `cancel-in-progress: false` only
+  # protects a RUNNING run: GitHub cancels the PENDING run of a group when a newer
+  # one queues, so a ref-keyed group would drop the middle of three quick merges
+  # and never publish that commit's :<sha> images -- exactly the matched-set hole
+  # this workflow exists to close. Per-SHA groups never displace each other, and
+  # concurrent runs are safe because the per-arch pushes are by digest.
+  group: publish-images-${{ github.sha }}
   cancel-in-progress: false
 
 on:
@@ -27,10 +32,25 @@ on:
     # are NOT path-filtered against each other -- see the note on the jobs below.
     paths:
       - packages/send/**
+      # Workspace-level build inputs: deploy.dockerfile COPYs these and installs
+      # with --frozen-lockfile, so a lockfile-only security bump does change what
+      # is in the image. Without them here the promoted image would keep shipping
+      # the pre-bump dependency tree until the next packages/send commit.
+      - pnpm-lock.yaml
+      - pnpm-workspace.yaml
+      - package.json
+      - lerna.json
+      - nx.json
+      - .npmrc
+      - packages/addon/package.json
       - .github/workflows/publish-images.yml
       - .github/workflows/build-multiarch-image.yml
   workflow_dispatch:
 
+# MUST stay at workflow scope and MUST include packages: write. A reusable
+# workflow can only DOWNGRADE the caller's GITHUB_TOKEN permissions, so dropping
+# packages: write here would break the GHCR push inside
+# build-multiarch-image.yml no matter what that file declares.
 permissions:
   contents: read
   packages: write
@@ -42,6 +62,9 @@ jobs:
   # it, so a backend-only change still ships under the frontend's version.
   version:
     runs-on: ubuntu-latest
+    # This job publishes nothing, so it does not need packages: write.
+    permissions:
+      contents: read
     outputs:
       value: ${{ steps.read-version.outputs.value }}
     steps:
@@ -51,8 +74,15 @@ jobs:
         id: read-version
         run: |
           set -euo pipefail
+          # `jq -e` already exits non-zero on a missing or null .version, and
+          # `set -e` aborts on it; this only has to catch an empty string. Written
+          # as an if-block rather than `A && B || C`, which trips shellcheck
+          # SC2015 and fails the actionlint gate in validate-workflows.yml.
           v="$(jq -er .version packages/send/frontend/package.json)"
-          [ -n "$v" ] && [ "$v" != "null" ] || { echo "::error::empty/invalid version in packages/send/frontend/package.json"; exit 1; }
+          if [ -z "$v" ]; then
+            echo "::error::empty version in packages/send/frontend/package.json"
+            exit 1
+          fi
           echo "value=$v" >> "$GITHUB_OUTPUT"
 
   # Build BOTH images on every run so both always carry the same :<sha>. The
@@ -87,3 +117,37 @@ jobs:
       version: ${{ needs.version.outputs.value }}
       artifact-prefix: frontend
       moving-tags: ${{ github.ref == 'refs/heads/main' }}
+
+  # Assert the matched set actually landed.
+  #
+  # Tagging happens per image, in each caller's own `merge` job, and neither
+  # references the other. If one image's build fails and the other succeeds, the
+  # run publishes HALF a matched set under :<sha> -- and a Kargo Warehouse with
+  # two image subscriptions would then silently pair frontend@newSha with
+  # backend@oldSha, because both tags it picked resolve. Fail the run loudly
+  # instead, so the hole is visible here rather than in a promotion.
+  verify-matched-set:
+    needs: [backend, frontend]
+    runs-on: ubuntu-latest
+    # Read-only: this job inspects manifests, it never pushes.
+    permissions:
+      packages: read
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Both :<sha> images resolve
+        env:
+          BACKEND: ${{ needs.backend.outputs.image }}
+          FRONTEND: ${{ needs.frontend.outputs.image }}
+        run: |
+          set -euo pipefail
+          for ref in "$BACKEND" "$FRONTEND"; do
+            echo "checking $ref"
+            docker buildx imagetools inspect "$ref" >/dev/null
+          done
+          echo "matched set OK: $BACKEND + $FRONTEND"

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -1,0 +1,89 @@
+---
+# Additive image-publish pipeline for the EKS/Kargo path. On merge to main it
+# builds the Send backend and the Send frontend (nginx SPA) as native multi-arch
+# (amd64 + arm64) manifest lists and pushes them to GHCR, tagged :<sha>,
+# :v<version> and :latest.
+#
+# This is INDEPENDENT of the existing deploy pipeline (merge.yml / release.yml):
+# it uses no cloud credentials, runs no Pulumi, touches no S3/ECS/ECR/ATN, and
+# deploys nothing -- it only publishes images. The stage/prod S3 + ECS builds and
+# the XPI builds are left exactly as they were.
+#
+# The frontend image is configured at RUNTIME (window.__APP_CONFIG__ via
+# /config.js), so one built bundle runs in every environment. See
+# packages/send/frontend/src/config.ts.
+name: publish-images
+
+concurrency:
+  group: publish-images-${{ github.ref }}
+  # Serialize (don't cancel) so every merged commit's :<sha> image gets published.
+  cancel-in-progress: false
+
+on:
+  push:
+    branches:
+      - main
+    # Add-on-only commits must not publish Send images. The two images themselves
+    # are NOT path-filtered against each other -- see the note on the jobs below.
+    paths:
+      - packages/send/**
+      - .github/workflows/publish-images.yml
+      - .github/workflows/build-multiarch-image.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  # Read the version once. lerna.json is `independent` and the root package.json
+  # is 0.0.0, so neither is a usable source; packages/send/frontend/package.json
+  # is the version the backend also carries. NOTE: both images are published under
+  # it, so a backend-only change still ships under the frontend's version.
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      value: ${{ steps.read-version.outputs.value }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Read version from packages/send/frontend/package.json
+        id: read-version
+        run: |
+          set -euo pipefail
+          v="$(jq -er .version packages/send/frontend/package.json)"
+          [ -n "$v" ] && [ "$v" != "null" ] || { echo "::error::empty/invalid version in packages/send/frontend/package.json"; exit 1; }
+          echo "value=$v" >> "$GITHUB_OUTPUT"
+
+  # Build BOTH images on every run so both always carry the same :<sha>. The
+  # matched-set invariant (Kargo Freight = {backend@sha, frontend@sha} for the
+  # exact HEAD sha) requires both :<sha> refs to exist, so the images are
+  # deliberately NOT path-filtered against each other inside this workflow.
+  # Moving tags (:latest, :v<version>) are published only from the main branch.
+  backend:
+    needs: version
+    uses: ./.github/workflows/build-multiarch-image.yml
+    with:
+      image: ghcr.io/thunderbird/thunderbird-send
+      dockerfile: packages/send/backend/Dockerfile
+      # The backend Dockerfile ADDs pnpm-lock.yaml, which lives at the repo root,
+      # so it needs the assembled .docker-build context that this script creates
+      # -- the same context merge.yml builds the ECR image from.
+      prepare-script: packages/send/backend/scripts/build.sh
+      context: packages/send/backend/.docker-build
+      version: ${{ needs.version.outputs.value }}
+      artifact-prefix: backend
+      moving-tags: ${{ github.ref == 'refs/heads/main' }}
+
+  frontend:
+    needs: version
+    uses: ./.github/workflows/build-multiarch-image.yml
+    with:
+      image: ghcr.io/thunderbird/thunderbird-send-frontend
+      dockerfile: packages/send/frontend/deploy.dockerfile
+      # Repo root: the SPA build needs the pnpm workspace (lockfile + every
+      # member's package.json), not just the frontend directory.
+      context: .
+      version: ${{ needs.version.outputs.value }}
+      artifact-prefix: frontend
+      moving-tags: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -83,6 +83,14 @@ jobs:
             echo "::error::empty version in packages/send/frontend/package.json"
             exit 1
           fi
+          # The value is interpolated into an image tag and (deliberately
+          # word-split) imagetools arguments downstream, so reject anything
+          # that is not a plain semver-ish token -- a version containing a
+          # space or a leading dash could otherwise inject extra arguments.
+          if ! echo "$v" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+([-+][A-Za-z0-9.-]+)?$'; then
+            echo "::error::version '$v' in packages/send/frontend/package.json is not a plain semver string"
+            exit 1
+          fi
           echo "value=$v" >> "$GITHUB_OUTPUT"
 
   # Build BOTH images on every run so both always carry the same :<sha>. The

--- a/packages/addon/.env.sample
+++ b/packages/addon/.env.sample
@@ -17,8 +17,10 @@ VITE_SEND_CLIENT_URL=http://localhost:5150
 # Load-bearing for the add-on: src/menu.ts and src/background.ts branch on it via
 # getEnvName() / isProd, and background.ts derives THUNDERMAIL_HOST from it -- so a
 # build that reports `production` talks to PRODUCTION Thundermail.
-# scripts/build.sh derives and exports it from $ENV / $BASE_URL when unset (that
-# is how CI's stage and prod XPIs get theirs); set it here to override.
+# scripts/build.sh derives and exports it from $ENV / $BASE_URL when unset in the
+# SHELL (that is how CI's stage and prod XPIs get theirs). This file wins only
+# when $ENV / $BASE_URL are absent: a derived value is exported, and exported
+# VITE_* vars take precedence over .env.
 VITE_APP_ENV=development
 
 # Sibling Thunderbird Pro services. Optional: unset falls back to a default set
@@ -31,6 +33,19 @@ VITE_DASHBOARD_URL=https://accounts-stage.tb.pro/send/dashboard
 VITE_CONTACT_FORM_URL=https://accounts-stage.tb.pro/contact
 VITE_THUNDERMAIL_URL=https://accounts-stage.tb.pro/mail
 VITE_APPOINTMENT_URL=https://appointment-stage.tb.pro/
+
+# OIDC. CI builds bake these via the generated .env; scripts/build.sh exports
+# local-dev defaults only when ADDON_ENV=local. Unset, login is unconfigured.
+VITE_OIDC_ROOT_URL=
+VITE_OIDC_CLIENT_ID=
+
+# Console log level for the add-on's own logger (src/lib/logger.ts) and the
+# bundled Send SPA (debug | info | warn | error; default warn).
+VITE_LOGGER_LEVEL=
+
+# Self-uninstall cutoff for the legacy AMO add-on (src/selfUninstall.ts).
+# Unset means the self-uninstall check is skipped.
+VITE_DEPRECATION_VERSION=
 
 # Sentry
 VITE_SENTRY_AUTH_TOKEN=

--- a/packages/addon/.env.sample
+++ b/packages/addon/.env.sample
@@ -1,6 +1,36 @@
+# These VITE_* values are baked in at BUILD time, and for the add-on that is the
+# ONLY configuration it ever gets: an XPI has no server to fetch /config.js from,
+# so the runtime config in packages/send/frontend/src/config.ts always falls
+# through to what is baked here.
+#
+# SECURITY: everything here ends up in a public bundle. Never put a secret in a
+# VITE_* var. VITE_SENTRY_AUTH_TOKEN is the one exception -- it is consumed by the
+# Sentry vite plugin at build time and is not emitted into the bundle.
+
 VUE_BASE_URL=http://localhost:5150
 VITE_SEND_SERVER_URL=https://localhost:8088
 VITE_SEND_CLIENT_URL=http://localhost:5150
+
+# Explicit environment name, replacing the old guess-from-a-URL-substring logic.
+# Any environment can be named (development, staging, production, mzla-tb-dev...).
+#
+# Load-bearing for the add-on: src/menu.ts and src/background.ts branch on it via
+# getEnvName() / isProd, and background.ts derives THUNDERMAIL_HOST from it -- so a
+# build that reports `production` talks to PRODUCTION Thundermail.
+# scripts/build.sh derives and exports it from $ENV / $BASE_URL when unset (that
+# is how CI's stage and prod XPIs get theirs); set it here to override.
+VITE_APP_ENV=development
+
+# Sibling Thunderbird Pro services. Optional: unset falls back to a default set
+# chosen by VITE_APP_ENV -- production URLs for `production`, the `-stage` ones for
+# anything else. See SIBLING_URL_DEFAULTS in
+# packages/send/frontend/src/config.ts. Set them explicitly for any environment
+# that is neither production nor staging.
+VITE_ACCOUNTS_URL=https://accounts-stage.tb.pro
+VITE_DASHBOARD_URL=https://accounts-stage.tb.pro/send/dashboard
+VITE_CONTACT_FORM_URL=https://accounts-stage.tb.pro/contact
+VITE_THUNDERMAIL_URL=https://accounts-stage.tb.pro/mail
+VITE_APPOINTMENT_URL=https://appointment-stage.tb.pro/
 
 # Sentry
 VITE_SENTRY_AUTH_TOKEN=

--- a/packages/addon/scripts/build.sh
+++ b/packages/addon/scripts/build.sh
@@ -36,6 +36,8 @@ if [ "$ADDON_ENV" = "local" ]; then
     ### Keep local builds out of the shared Sentry / PostHog projects.
     : "${VITE_SENTRY_DSN:=}"
     : "${VITE_POSTHOG_PROJECT_KEY:=}"
+    ### Local means development, whatever the derivation below would have said.
+    : "${VITE_APP_ENV:=development}"
     export VITE_SEND_SERVER_URL VITE_SEND_CLIENT_URL \
         VITE_OIDC_CLIENT_ID VITE_OIDC_ROOT_URL \
         VITE_SENTRY_DSN VITE_POSTHOG_PROJECT_KEY
@@ -49,6 +51,49 @@ if [ "$ADDON_ENV" = "local" ]; then
     ### backend must still have SEND_BACKEND_CORS_ORIGINS set (it throws
     ### otherwise) and include $VITE_SEND_CLIENT_URL, and Thunderbird must trust
     ### the self-signed https://localhost cert (used for fetch + wss uploads).
+fi
+
+### Declare the environment this XPI is being built FOR. The Send SPA ships
+### inside this add-on and reads VITE_APP_ENV
+### (packages/send/frontend/src/config.ts) instead of guessing from a URL
+### substring. An extension has no /config.js to be configured from at runtime,
+### so the baked value is the ONLY configuration it will ever get.
+###
+### src/menu.ts and src/background.ts both branch on it (getEnvName() / isProd),
+### and background.ts derives THUNDERMAIL_HOST from it -- so leaving it
+### undeclared points a stage add-on at PRODUCTION Thundermail.
+###
+### merge.yml (frozen) passes the environment as $ENV ("stage"/"prod") plus
+### $BASE_URL. $BASE_URL is the same signal scripts/config.ts getIsEnvProd()
+### already uses to pick the XPI id, so the id and the environment name can never
+### disagree. This is a compatibility shim for that frozen workflow -- delete it
+### if merge.yml ever sets VITE_APP_ENV itself.
+###
+### Only derived when there is a real signal ($ENV or $BASE_URL). With neither,
+### VITE_APP_ENV is left ALONE rather than guessed -- an exported value would take
+### precedence over Vite's .env loading, so guessing here would silently override a
+### developer's own `VITE_APP_ENV=` in .env (which the shell cannot see).
+if [ -z "${VITE_APP_ENV:-}" ]; then
+    case "${ENV:-}" in
+        prod|production) VITE_APP_ENV=production ;;
+        stage|staging)   VITE_APP_ENV=staging ;;
+        dev|development) VITE_APP_ENV=development ;;
+        *)
+            case "${BASE_URL:-}" in
+                *https://send.tb.pro*) VITE_APP_ENV=production ;;
+                *send-stage.tb.pro*)   VITE_APP_ENV=staging ;;
+                *localhost*)           VITE_APP_ENV=development ;;
+            esac
+            ;;
+    esac
+fi
+if [ -n "${VITE_APP_ENV:-}" ]; then
+    ### Exported so Vite's loadEnv reads it from process.env, where VITE_* vars
+    ### take precedence over the .env file.
+    export VITE_APP_ENV
+    echo "  VITE_APP_ENV=$VITE_APP_ENV"
+else
+    echo "  VITE_APP_ENV not set and not derivable from \$ENV/\$BASE_URL; leaving it to .env"
 fi
 
 # Get version from package.json and replace dots with hyphens

--- a/packages/addon/scripts/build.sh
+++ b/packages/addon/scripts/build.sh
@@ -53,48 +53,12 @@ if [ "$ADDON_ENV" = "local" ]; then
     ### the self-signed https://localhost cert (used for fetch + wss uploads).
 fi
 
-### Declare the environment this XPI is being built FOR. The Send SPA ships
-### inside this add-on and reads VITE_APP_ENV
-### (packages/send/frontend/src/config.ts) instead of guessing from a URL
-### substring. An extension has no /config.js to be configured from at runtime,
-### so the baked value is the ONLY configuration it will ever get.
-###
-### src/menu.ts and src/background.ts both branch on it (getEnvName() / isProd),
-### and background.ts derives THUNDERMAIL_HOST from it -- so leaving it
-### undeclared points a stage add-on at PRODUCTION Thundermail.
-###
-### merge.yml (frozen) passes the environment as $ENV ("stage"/"prod") plus
-### $BASE_URL. $BASE_URL is the same signal scripts/config.ts getIsEnvProd()
-### already uses to pick the XPI id, so the id and the environment name can never
-### disagree. This is a compatibility shim for that frozen workflow -- delete it
-### if merge.yml ever sets VITE_APP_ENV itself.
-###
-### Only derived when there is a real signal ($ENV or $BASE_URL). With neither,
-### VITE_APP_ENV is left ALONE rather than guessed -- an exported value would take
-### precedence over Vite's .env loading, so guessing here would silently override a
-### developer's own `VITE_APP_ENV=` in .env (which the shell cannot see).
-if [ -z "${VITE_APP_ENV:-}" ]; then
-    case "${ENV:-}" in
-        prod|production) VITE_APP_ENV=production ;;
-        stage|staging)   VITE_APP_ENV=staging ;;
-        dev|development) VITE_APP_ENV=development ;;
-        *)
-            case "${BASE_URL:-}" in
-                *https://send.tb.pro*) VITE_APP_ENV=production ;;
-                *send-stage.tb.pro*)   VITE_APP_ENV=staging ;;
-                *localhost*)           VITE_APP_ENV=development ;;
-            esac
-            ;;
-    esac
-fi
-if [ -n "${VITE_APP_ENV:-}" ]; then
-    ### Exported so Vite's loadEnv reads it from process.env, where VITE_* vars
-    ### take precedence over the .env file.
-    export VITE_APP_ENV
-    echo "  VITE_APP_ENV=$VITE_APP_ENV"
-else
-    echo "  VITE_APP_ENV not set and not derivable from \$ENV/\$BASE_URL; leaving it to .env"
-fi
+### Declare the environment this XPI is being built FOR. Shared with the web
+### bundle build -- one copy so the add-on and the SPA can never map the same
+### CI signal to different environment names. See the rationale in
+### derive-app-env.sh (why it is load-bearing for menu.ts / background.ts /
+### THUNDERMAIL_HOST, and why an unset value is left to .env outside CI).
+. "$(dirname "$0")/../../send/frontend/scripts/derive-app-env.sh"
 
 # Get version from package.json and replace dots with hyphens
 VERSION=$(jq -r .version < package.json | sed 's/\./-/g')

--- a/packages/send/frontend/.env.sample
+++ b/packages/send/frontend/.env.sample
@@ -1,8 +1,10 @@
 # These VITE_* values are baked in at BUILD time. They are the fallback for the
 # runtime config in public/config.js (see src/config.ts): dev, the S3/CloudFront
 # build and the add-on XPI all rely on them. The nginx container image bakes
-# nothing and is configured entirely from APP_* env instead -- one APP_* var per
-# VITE_* var below, e.g. VITE_SEND_SERVER_URL -> APP_SEND_SERVER_URL.
+# nothing and is configured entirely from APP_* env instead -- every VITE_* var
+# that src/config.ts reads has a matching APP_* var, named the same way, e.g.
+# VITE_SEND_SERVER_URL -> APP_SEND_SERVER_URL. (VITE_TESTING, VUE_BASE_URL and
+# VITE_SENTRY_AUTH_TOKEN are build-time only and have no APP_* equivalent.)
 #
 # SECURITY: everything here ends up in a public bundle (and, on the container
 # path, in publicly-served /config.js). Never put a secret in a VITE_*/APP_* var.
@@ -13,13 +15,16 @@ VUE_BASE_URL=http://localhost:5173
 VITE_SEND_SERVER_URL=https://localhost:8088
 VITE_SEND_CLIENT_URL=http://localhost:5173
 
-# Explicit environment name. Replaces the old guess-from-the-URL logic, so any
-# environment can be named (development, staging, production, mzla-tb-dev, ...).
+# Explicit environment name. Replaces the old guess-from-a-URL-substring logic, so
+# any environment can be named (development, staging, production, mzla-tb-dev...).
+# scripts/build.sh derives and exports it from $ENV / $BASE_URL when it is unset
+# (that is how CI's stage and prod bundles get theirs); set it here to override.
 VITE_APP_ENV=development
 
-# Sibling Thunderbird Pro services. Optional: unset falls back to the PRODUCTION
-# URLs baked into src/config.ts, which is what keeps the add-on XPI working. Set
-# them for any non-production deployment.
+# Sibling Thunderbird Pro services. Optional: unset falls back to a default set
+# chosen by VITE_APP_ENV -- the production URLs for `production`, the `-stage` ones
+# for anything else (see SIBLING_URL_DEFAULTS in src/config.ts). Set them
+# explicitly for any environment that is neither production nor staging.
 VITE_ACCOUNTS_URL=https://accounts-stage.tb.pro
 VITE_DASHBOARD_URL=https://accounts-stage.tb.pro/send/dashboard
 VITE_CONTACT_FORM_URL=https://accounts-stage.tb.pro/contact

--- a/packages/send/frontend/.env.sample
+++ b/packages/send/frontend/.env.sample
@@ -1,6 +1,30 @@
+# These VITE_* values are baked in at BUILD time. They are the fallback for the
+# runtime config in public/config.js (see src/config.ts): dev, the S3/CloudFront
+# build and the add-on XPI all rely on them. The nginx container image bakes
+# nothing and is configured entirely from APP_* env instead -- one APP_* var per
+# VITE_* var below, e.g. VITE_SEND_SERVER_URL -> APP_SEND_SERVER_URL.
+#
+# SECURITY: everything here ends up in a public bundle (and, on the container
+# path, in publicly-served /config.js). Never put a secret in a VITE_*/APP_* var.
+# VITE_SENTRY_AUTH_TOKEN is the one exception: it is consumed by the Sentry vite
+# plugin at build time and never emitted into the bundle.
+
 VUE_BASE_URL=http://localhost:5173
 VITE_SEND_SERVER_URL=https://localhost:8088
 VITE_SEND_CLIENT_URL=http://localhost:5173
+
+# Explicit environment name. Replaces the old guess-from-the-URL logic, so any
+# environment can be named (development, staging, production, mzla-tb-dev, ...).
+VITE_APP_ENV=development
+
+# Sibling Thunderbird Pro services. Optional: unset falls back to the PRODUCTION
+# URLs baked into src/config.ts, which is what keeps the add-on XPI working. Set
+# them for any non-production deployment.
+VITE_ACCOUNTS_URL=https://accounts-stage.tb.pro
+VITE_DASHBOARD_URL=https://accounts-stage.tb.pro/send/dashboard
+VITE_CONTACT_FORM_URL=https://accounts-stage.tb.pro/contact
+VITE_THUNDERMAIL_URL=https://accounts-stage.tb.pro/mail
+VITE_APPOINTMENT_URL=https://appointment-stage.tb.pro/
 
 # Sentry
 VITE_SENTRY_AUTH_TOKEN=

--- a/packages/send/frontend/.env.sample
+++ b/packages/send/frontend/.env.sample
@@ -3,8 +3,11 @@
 # build and the add-on XPI all rely on them. The nginx container image bakes
 # nothing and is configured entirely from APP_* env instead -- every VITE_* var
 # that src/config.ts reads has a matching APP_* var, named the same way, e.g.
-# VITE_SEND_SERVER_URL -> APP_SEND_SERVER_URL. (VITE_TESTING, VUE_BASE_URL and
-# VITE_SENTRY_AUTH_TOKEN are build-time only and have no APP_* equivalent.)
+# VITE_SEND_SERVER_URL -> APP_SEND_SERVER_URL. ONE exception to that rule:
+# VITE_APP_ENV's runtime twin is APP_ENV (not APP_APP_ENV). (VITE_TESTING and
+# VITE_SENTRY_AUTH_TOKEN are build-time only and have no APP_* equivalent;
+# VUE_BASE_URL is legacy -- nothing reads it, it is kept only because the
+# frozen CI workflows still write it.)
 #
 # SECURITY: everything here ends up in a public bundle (and, on the container
 # path, in publicly-served /config.js). Never put a secret in a VITE_*/APP_* var.
@@ -18,7 +21,9 @@ VITE_SEND_CLIENT_URL=http://localhost:5173
 # Explicit environment name. Replaces the old guess-from-a-URL-substring logic, so
 # any environment can be named (development, staging, production, mzla-tb-dev...).
 # scripts/build.sh derives and exports it from $ENV / $BASE_URL when it is unset
-# (that is how CI's stage and prod bundles get theirs); set it here to override.
+# in the SHELL (that is how CI's stage and prod bundles get theirs). This file
+# wins only when $ENV / $BASE_URL are absent: a derived value is exported, and
+# exported VITE_* vars take precedence over .env.
 VITE_APP_ENV=development
 
 # Sibling Thunderbird Pro services. Optional: unset falls back to a default set

--- a/packages/send/frontend/deploy.dockerfile
+++ b/packages/send/frontend/deploy.dockerfile
@@ -42,7 +42,11 @@ RUN pnpm install --frozen-lockfile --filter send-frontend
 # drag in a developer's local node_modules (wrong platform, and it would clobber
 # the install above) and -- worse -- a local .env, which vite would bake into the
 # bundle and silently defeat the runtime config. Listing the inputs makes both
-# impossible.
+# impossible for the enumerated files. CAVEAT: `src` and `public` below are
+# still whole-directory copies, and everything in public/ is served verbatim
+# from the web root -- a stray local file in public/ WILL ship in a locally
+# built image (deploy.dockerfile.dockerignore catches the common cases; CI
+# builds from a clean checkout are unaffected).
 COPY packages/send/frontend/index.html ./packages/send/frontend/
 COPY packages/send/frontend/vite.config.js ./packages/send/frontend/
 COPY packages/send/frontend/sharedViteConfig.ts ./packages/send/frontend/
@@ -71,14 +75,24 @@ RUN pnpm exec vite build --config vite.config.js
 # to Sentry.
 RUN find dist-web -name '*.map' -delete \
     && find dist-web -type f -name '*.js' \
-       -exec sed -i '/^\/\/# sourceMappingURL=/d' {} +
+       -exec sed -i '/^\/\/# sourceMappingURL=/d' {} + \
+    && find dist-web -type f -name '*.css' \
+       -exec sed -i 's|/\*# sourceMappingURL=[^*]*\*/||' {} +
 
 
-FROM nginx:stable AS runtime
+# Pinned like the build stage's node:22.14.0, and for a sharper reason here:
+# `stable` jumps whole minor versions when upstream promotes one, this image
+# seds nginx.conf and relies on the base image's conf.d/docker-entrypoint.d
+# layout (which has already moved once -- see the pid-path note below), and the
+# two arches are built by independent jobs that each resolve the tag themselves,
+# so a floating tag can stitch a manifest list with two different nginx
+# versions. Bump deliberately; the sed assertions below catch layout drift.
+FROM nginx:1.28.3 AS runtime
 
 # jq: used by the runtime-config entrypoint to emit a JSON-escaped config.js.
+# curl: used by the HEALTHCHECK below.
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends jq \
+    && apt-get install -y --no-install-recommends jq curl \
     && rm -rf /var/lib/apt/lists/*
 
 # Replace the stock server block. Keeping the filename `default.conf` matters:
@@ -106,9 +120,19 @@ RUN cp /etc/nginx/conf.d/default.conf /tmp/default.conf \
 
 # Run unprivileged. `user nginx;` is dropped because it is meaningless (and warns)
 # when the master process is not root, and the pid file has to move out of
-# root-owned /run. The entrypoint needs to write config.js into the web root and
-# sed the proxy upstream in conf.d, and nginx needs its temp dirs, hence the
-# chowns.
+# root-owned /run. nginx needs its temp dirs, hence the /var/cache/nginx chown.
+#
+# The writable surface is kept MINIMAL: the web root stays root-owned and
+# read-only to the runtime user (a compromised worker must not be able to
+# rewrite the served bundle) -- only the two files the entrypoint actually
+# rewrites are handed to nginx: config.js (written with `>`, which needs write
+# on the FILE only; it exists because dist-web ships the committed all-empty
+# public/config.js) and conf.d (`sed -i` renames a temp file, so it needs write
+# on the DIRECTORY).
+#
+# NOTE: this image does NOT support `readOnlyRootFilesystem: true` -- the
+# entrypoint writes config.js and seds conf.d in place, and mounting conf.d as
+# an emptyDir is deliberately rejected by the entrypoint's placeholder guard.
 #
 # Both rewrites are ASSERTED. The pid path is matched on the directive rather
 # than a literal path because the base image has used both /var/run/nginx.pid and
@@ -118,9 +142,17 @@ RUN sed -i '/^user  *nginx;/d' /etc/nginx/nginx.conf \
     && sed -i -E 's|^(pid[[:space:]]+).*;|\1/tmp/nginx.pid;|' /etc/nginx/nginx.conf \
     && ! grep -qE '^user[[:space:]]' /etc/nginx/nginx.conf \
     && grep -qE '^pid[[:space:]]+/tmp/nginx\.pid;' /etc/nginx/nginx.conf \
-    && chown -R nginx:nginx /usr/share/nginx/html /var/cache/nginx /etc/nginx/conf.d
+    && chown -R nginx:nginx /var/cache/nginx /etc/nginx/conf.d \
+    && chown nginx:nginx /usr/share/nginx/html/config.js
 USER nginx
 
 # 8080, not 80: an unprivileged process cannot bind below 1024. The Service /
 # target port must match (see `listen 8080` in docker/etc/nginx/conf.d/send.conf).
 EXPOSE 8080
+
+# Kubernetes ignores this (probes are configured on the Deployment -- put
+# readiness on an /api/ path, see the STARTUP ORDERING note in send.conf), but
+# the image is also published to GHCR for plain Docker/Compose consumers, who
+# otherwise get no health signal at all.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s \
+    CMD curl -fsS http://127.0.0.1:8080/ >/dev/null || exit 1

--- a/packages/send/frontend/deploy.dockerfile
+++ b/packages/send/frontend/deploy.dockerfile
@@ -1,0 +1,123 @@
+# Production nginx image for the Send web app.
+#
+# This is NOT dockerfiles/Dockerfile-frontend: that one runs `vite dev` behind
+# `pnpm --filter send-frontend run dev` and is a development server only. This
+# image builds the SPA once and serves the static bundle from nginx, proxying
+# /api, /trpc and the WebSocket endpoints to the backend so the whole app lives
+# on one origin.
+#
+# THE BUILD CONTEXT IS THE REPO ROOT, not this directory (pnpm workspace):
+#   docker build -f packages/send/frontend/deploy.dockerfile -t send-frontend .
+#
+# The build is deliberately ENV-AGNOSTIC: no `--mode`, no `.env`, nothing baked.
+# The SPA is configured at RUNTIME from /config.js (see public/config.js and
+# docker/docker-entrypoint.d/40-send-config.sh), so one built bundle is promoted
+# unchanged across every environment. Baking values back in here would break the
+# "empty string means unset" rule in src/config.ts: a runtime-empty APP_* value
+# would silently fall back to whatever was baked.
+
+# Pinned to the same Node the other Dockerfiles in this repo use.
+FROM node:22.14.0 AS build
+
+WORKDIR /app
+RUN npm install -g pnpm@10
+
+# Dependency manifests first so a source-only change does not bust the install
+# layer. Every workspace member's package.json is needed: --frozen-lockfile
+# validates the lockfile against all of them.
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml lerna.json nx.json .npmrc ./
+COPY packages/send/package.json ./packages/send/
+COPY packages/send/backend/package.json ./packages/send/backend/
+COPY packages/send/frontend/package.json ./packages/send/frontend/
+COPY packages/send/e2e/package.json ./packages/send/e2e/
+COPY packages/addon/package.json ./packages/addon/
+
+# --filter send-frontend: the backend, e2e and add-on packages are not needed to
+# build the web app (the one backend import, `AppRouter`, is type-only and is
+# elided by esbuild).
+RUN pnpm install --frozen-lockfile --filter send-frontend
+
+# Source is copied file-by-file rather than as a whole directory ON PURPOSE.
+# There is no repo-root .dockerignore, so `COPY packages/send/frontend ...` would
+# drag in a developer's local node_modules (wrong platform, and it would clobber
+# the install above) and -- worse -- a local .env, which vite would bake into the
+# bundle and silently defeat the runtime config. Listing the inputs makes both
+# impossible.
+COPY packages/send/frontend/index.html ./packages/send/frontend/
+COPY packages/send/frontend/vite.config.js ./packages/send/frontend/
+COPY packages/send/frontend/sharedViteConfig.ts ./packages/send/frontend/
+COPY packages/send/frontend/csp.config.js ./packages/send/frontend/
+COPY packages/send/frontend/postcss.config.js ./packages/send/frontend/
+COPY packages/send/frontend/tailwind.config.cjs ./packages/send/frontend/
+COPY packages/send/frontend/tsconfig.json ./packages/send/frontend/
+COPY packages/send/frontend/tsconfig.client.base.json ./packages/send/frontend/
+COPY packages/send/frontend/src ./packages/send/frontend/src
+COPY packages/send/frontend/public ./packages/send/frontend/public
+
+WORKDIR /app/packages/send/frontend
+
+# Only the web app: `pnpm build` also builds the extension/management bundles and
+# zips an XPI, which needs bun and is irrelevant to a server-side image. Note the
+# absence of `--mode`: see the env-agnostic note at the top of this file.
+RUN pnpm exec vite build --config vite.config.js
+
+# Source maps are built (vite.config.js sets sourcemap: true) but are not shipped
+# here: the ECS/S3 pipeline is what uploads them to Sentry, and serving them from
+# a public origin hands out readable source. The nginx conf 404s *.map as well.
+RUN find dist-web -name '*.map' -delete
+
+
+FROM nginx:stable AS runtime
+
+# RELEASE_VERSION is passed by the shared build workflow for the backend image.
+# Declared (and unused) here so the frontend build does not warn about it.
+ARG RELEASE_VERSION
+
+# jq: used by the runtime-config entrypoint to emit a JSON-escaped config.js.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends jq \
+    && rm -rf /var/lib/apt/lists/*
+
+# Replace the stock server block. Keeping the filename `default.conf` matters:
+# the entrypoint script rewrites the proxy upstream in that exact path.
+RUN rm /etc/nginx/conf.d/default.conf
+COPY packages/send/frontend/docker/etc/nginx/conf.d/send.conf /etc/nginx/conf.d/default.conf
+
+# Runtime config generator: nginx:stable runs /docker-entrypoint.d/*.sh at
+# startup, before nginx, writing /usr/share/nginx/html/config.js from APP_* env.
+COPY packages/send/frontend/docker/docker-entrypoint.d/40-send-config.sh /docker-entrypoint.d/40-send-config.sh
+RUN chmod +x /docker-entrypoint.d/40-send-config.sh
+
+COPY --from=build /app/packages/send/frontend/dist-web/ /usr/share/nginx/html/
+
+# Catch a broken server block here instead of in a crash-looping pod. `nginx -t`
+# resolves proxy_pass hostnames, and `send-backend` does not exist at build time,
+# so validate a copy with the upstream swapped for a literal address. (That also
+# means a pod started with APP_API_UPSTREAM unset fails loudly at boot rather than
+# 502-ing every API call, which is the behaviour we want.)
+RUN cp /etc/nginx/conf.d/default.conf /tmp/default.conf \
+    && sed -i 's|send-backend:8080|127.0.0.1:65535|g' /etc/nginx/conf.d/default.conf \
+    && nginx -t \
+    && cp /tmp/default.conf /etc/nginx/conf.d/default.conf \
+    && rm /tmp/default.conf
+
+# Run unprivileged. `user nginx;` is dropped because it is meaningless (and warns)
+# when the master process is not root, and the pid file has to move out of
+# root-owned /run. The entrypoint needs to write config.js into the web root and
+# sed the proxy upstream in conf.d, and nginx needs its temp dirs, hence the
+# chowns.
+#
+# Both rewrites are ASSERTED. The pid path is matched on the directive rather
+# than a literal path because the base image has used both /var/run/nginx.pid and
+# /run/nginx.pid; a silently-missed substitution produces an image that builds
+# fine and then dies at boot with `open() "/run/nginx.pid" failed (13)`.
+RUN sed -i '/^user  *nginx;/d' /etc/nginx/nginx.conf \
+    && sed -i -E 's|^(pid[[:space:]]+).*;|\1/tmp/nginx.pid;|' /etc/nginx/nginx.conf \
+    && ! grep -qE '^user[[:space:]]' /etc/nginx/nginx.conf \
+    && grep -qE '^pid[[:space:]]+/tmp/nginx\.pid;' /etc/nginx/nginx.conf \
+    && chown -R nginx:nginx /usr/share/nginx/html /var/cache/nginx /etc/nginx/conf.d
+USER nginx
+
+# 8080, not 80: an unprivileged process cannot bind below 1024. The Service /
+# target port must match (see `listen 8080` in docker/etc/nginx/conf.d/send.conf).
+EXPOSE 8080

--- a/packages/send/frontend/deploy.dockerfile
+++ b/packages/send/frontend/deploy.dockerfile
@@ -64,14 +64,17 @@ RUN pnpm exec vite build --config vite.config.js
 # Source maps are built (vite.config.js sets sourcemap: true) but are not shipped
 # here: the ECS/S3 pipeline is what uploads them to Sentry, and serving them from
 # a public origin hands out readable source. The nginx conf 404s *.map as well.
-RUN find dist-web -name '*.map' -delete
+#
+# The `//# sourceMappingURL=` comments have to go with them, or every devtools
+# session on the pod 404s against that guard. Do NOT set `sourcemap: false` in
+# the shared vite.config.js instead: the ECS/S3 pipeline needs the maps to upload
+# to Sentry.
+RUN find dist-web -name '*.map' -delete \
+    && find dist-web -type f -name '*.js' \
+       -exec sed -i '/^\/\/# sourceMappingURL=/d' {} +
 
 
 FROM nginx:stable AS runtime
-
-# RELEASE_VERSION is passed by the shared build workflow for the backend image.
-# Declared (and unused) here so the frontend build does not warn about it.
-ARG RELEASE_VERSION
 
 # jq: used by the runtime-config entrypoint to emit a JSON-escaped config.js.
 RUN apt-get update \

--- a/packages/send/frontend/deploy.dockerfile.dockerignore
+++ b/packages/send/frontend/deploy.dockerfile.dockerignore
@@ -1,0 +1,20 @@
+# Ignore file for deploy.dockerfile ONLY.
+#
+# BuildKit prefers `<dockerfile-path>.dockerignore` over a root .dockerignore, so
+# this narrows the context for this one build without touching merge.yml,
+# release.yml or the backend image -- none of which reads this file.
+#
+# The build context is the repo ROOT (pnpm workspace), and there is no root
+# .dockerignore, so without this every build transfers and hashes the whole tree
+# (~1.6 GB locally once node_modules exists). deploy.dockerfile already COPYs its
+# inputs file-by-file, so nothing listed here can reach the image regardless --
+# this is about context size and reproducible local builds.
+**/node_modules
+.git
+**/dist
+**/dist-web
+**/send-suite
+**/*.xpi
+**/.env
+**/.env.*
+!**/.env.sample

--- a/packages/send/frontend/deploy.dockerfile.dockerignore
+++ b/packages/send/frontend/deploy.dockerfile.dockerignore
@@ -18,3 +18,8 @@
 **/.env
 **/.env.*
 !**/.env.sample
+# Everything in public/ is copied wholesale and served verbatim from the web
+# root, so keep the classic secret-material extensions out of local builds.
+**/*.pem
+**/*.key
+**/*.p12

--- a/packages/send/frontend/docker/docker-entrypoint.d/40-send-config.sh
+++ b/packages/send/frontend/docker/docker-entrypoint.d/40-send-config.sh
@@ -18,8 +18,14 @@ CONFIG_PATH="${APP_CONFIG_PATH:-/usr/share/nginx/html/config.js}"
 
 # Build config.js with jq so every value is properly JSON-escaped: a value
 # containing a quote, a backslash or a newline cannot produce invalid JS or
-# inject code into the page.
-config_json="$(jq -n \
+# inject code into the page. `-a` forces ASCII output, which also escapes raw
+# U+2028/U+2029 -- legal inside a JS string literal only since ES2019.
+#
+# A value containing `</script>` is harmless here ONLY because config.js is an
+# EXTERNAL .js file, not inline HTML: there is no HTML parser to break out of. Do
+# NOT inline this into index.html -- that would turn every APP_* var into an XSS
+# vector.
+config_json="$(jq -n -a \
   --arg appEnv "${APP_ENV:-}" \
   --arg sendServerUrl "${APP_SEND_SERVER_URL:-}" \
   --arg sendClientUrl "${APP_SEND_CLIENT_URL:-}" \
@@ -51,12 +57,20 @@ config_json="$(jq -n \
 printf 'window.__APP_CONFIG__ = %s;\n' "$config_json" > "$CONFIG_PATH"
 echo "send: wrote runtime config to $CONFIG_PATH"
 
-# APP_SEND_SERVER_URL is the one value the SPA cannot boot without -- src/config.ts
-# assertConfigured() throws in the browser if it is empty. Say so here too, while
-# there is still a container log to read it in.
-if [ -z "${APP_SEND_SERVER_URL:-}" ]; then
-  echo "send: WARNING APP_SEND_SERVER_URL is unset; the SPA will fail to boot" >&2
-fi
+# The two values the SPA cannot boot without -- src/config.ts assertConfigured()
+# throws in the browser if either is empty. Say so here too, while there is still
+# a container log to read it in.
+#
+# APP_SEND_CLIENT_URL matters as much as the server URL: it becomes BASE_URL, and
+# every share link is `${BASE_URL}/share/<id>`. Unset, nginx still answers GET /
+# with 200 -- so a readiness probe on / stays green while every copied link reads
+# `undefined/share/...`.
+for required in APP_SEND_SERVER_URL APP_SEND_CLIENT_URL; do
+  eval "value=\${${required}:-}"
+  if [ -z "$value" ]; then
+    echo "send: WARNING $required is unset; the SPA will fail to boot" >&2
+  fi
+done
 
 # Point the nginx API/tRPC proxy at the backend. On EKS the backend is a SEPARATE
 # Service, so the baked default (send-backend:8080, for a compose/sidecar
@@ -69,6 +83,30 @@ fi
 # start would find no `send-backend:8080` left to replace and silently keep the
 # first value.
 if [ -n "${APP_API_UPSTREAM:-}" ]; then
+  # Validate before substituting. This value is interpolated into an nginx config
+  # by sed, so an unvalidated one is both a config-injection point and a
+  # silent-corruption point:
+  #   * `&` in the replacement expands to the whole matched text
+  #     ("a&b:8080" -> "asend-backend:8080b:8080");
+  #   * a `}` closes the location block and everything after it is parsed as
+  #     server-scope nginx directives;
+  #   * the likeliest operator mistake, a scheme ("http://send-backend:8080"),
+  #     produces `invalid port in upstream`.
+  # All three crash-loop rather than mis-serve, but failing here names the cause.
+  case "${APP_API_UPSTREAM}" in
+    *[!A-Za-z0-9.:_-]*)
+      echo "send: FATAL APP_API_UPSTREAM must be host:port with no scheme or path: '${APP_API_UPSTREAM}'" >&2
+      exit 1
+      ;;
+  esac
+  # The substitution is one-shot against the baked default, so assert the default
+  # is still there. If it is not, /etc/nginx/conf.d is not coming from the image
+  # layer (a mounted volume?) and this would otherwise silently keep the previous
+  # start's upstream.
+  if ! grep -q 'send-backend:8080' /etc/nginx/conf.d/default.conf; then
+    echo "send: FATAL upstream placeholder already replaced; is /etc/nginx/conf.d on a persistent volume?" >&2
+    exit 1
+  fi
   sed -i "s|send-backend:8080|${APP_API_UPSTREAM}|g" /etc/nginx/conf.d/default.conf
   echo "send: set API upstream to ${APP_API_UPSTREAM}"
 else

--- a/packages/send/frontend/docker/docker-entrypoint.d/40-send-config.sh
+++ b/packages/send/frontend/docker/docker-entrypoint.d/40-send-config.sh
@@ -1,0 +1,76 @@
+#!/bin/sh
+# Generate the SPA runtime config from container environment variables, and point
+# the nginx API proxy at the backend.
+#
+# nginx:stable runs every /docker-entrypoint.d/*.sh at startup, before nginx, so
+# this writes an env-specific config.js that the app loads at boot. The built JS
+# bundle is env-agnostic (byte-identical across environments); only this file and
+# the proxy upstream differ.
+#
+# SECURITY: every value written to config.js is served publicly to browsers. Only
+# map public, client-safe values into APP_* here -- never a backend secret.
+#
+# Values come from APP_* env (ConfigMap / ExternalSecrets on EKS). Anything left
+# unset is written as an empty string, and src/config.ts treats empty as unset.
+set -eu
+
+CONFIG_PATH="${APP_CONFIG_PATH:-/usr/share/nginx/html/config.js}"
+
+# Build config.js with jq so every value is properly JSON-escaped: a value
+# containing a quote, a backslash or a newline cannot produce invalid JS or
+# inject code into the page.
+config_json="$(jq -n \
+  --arg appEnv "${APP_ENV:-}" \
+  --arg sendServerUrl "${APP_SEND_SERVER_URL:-}" \
+  --arg sendClientUrl "${APP_SEND_CLIENT_URL:-}" \
+  --arg oidcRootUrl "${APP_OIDC_ROOT_URL:-}" \
+  --arg oidcClientId "${APP_OIDC_CLIENT_ID:-}" \
+  --arg allowPublicLogin "${APP_ALLOW_PUBLIC_LOGIN:-}" \
+  --arg sentryDsn "${APP_SENTRY_DSN:-}" \
+  --arg posthogProjectKey "${APP_POSTHOG_PROJECT_KEY:-}" \
+  --arg posthogHost "${APP_POSTHOG_HOST:-}" \
+  --arg splitSizeInMb "${APP_SPLIT_SIZE_IN_MB:-}" \
+  --arg loggerLevel "${APP_LOGGER_LEVEL:-}" \
+  --arg uploadHttpRetryLimit "${APP_UPLOAD_HTTP_RETRY_LIMIT:-}" \
+  --arg uploadHttpRetryBaseDelayMs "${APP_UPLOAD_HTTP_RETRY_BASE_DELAY_MS:-}" \
+  --arg accountsUrl "${APP_ACCOUNTS_URL:-}" \
+  --arg dashboardUrl "${APP_DASHBOARD_URL:-}" \
+  --arg contactFormUrl "${APP_CONTACT_FORM_URL:-}" \
+  --arg thundermailUrl "${APP_THUNDERMAIL_URL:-}" \
+  --arg appointmentUrl "${APP_APPOINTMENT_URL:-}" \
+  '{appEnv:$appEnv, sendServerUrl:$sendServerUrl, sendClientUrl:$sendClientUrl,
+    oidcRootUrl:$oidcRootUrl, oidcClientId:$oidcClientId,
+    allowPublicLogin:$allowPublicLogin, sentryDsn:$sentryDsn,
+    posthogProjectKey:$posthogProjectKey, posthogHost:$posthogHost,
+    splitSizeInMb:$splitSizeInMb, loggerLevel:$loggerLevel,
+    uploadHttpRetryLimit:$uploadHttpRetryLimit,
+    uploadHttpRetryBaseDelayMs:$uploadHttpRetryBaseDelayMs,
+    accountsUrl:$accountsUrl, dashboardUrl:$dashboardUrl,
+    contactFormUrl:$contactFormUrl, thundermailUrl:$thundermailUrl,
+    appointmentUrl:$appointmentUrl}')"
+printf 'window.__APP_CONFIG__ = %s;\n' "$config_json" > "$CONFIG_PATH"
+echo "send: wrote runtime config to $CONFIG_PATH"
+
+# APP_SEND_SERVER_URL is the one value the SPA cannot boot without -- src/config.ts
+# assertConfigured() throws in the browser if it is empty. Say so here too, while
+# there is still a container log to read it in.
+if [ -z "${APP_SEND_SERVER_URL:-}" ]; then
+  echo "send: WARNING APP_SEND_SERVER_URL is unset; the SPA will fail to boot" >&2
+fi
+
+# Point the nginx API/tRPC proxy at the backend. On EKS the backend is a SEPARATE
+# Service, so the baked default (send-backend:8080, for a compose/sidecar
+# topology) must be overridden. Set APP_API_UPSTREAM to host:port with NO scheme,
+# e.g. send-backend.<namespace>.svc.cluster.local:8080.
+#
+# The rewrite is a one-shot against the baked default, so it is only repeatable
+# because /etc/nginx/conf.d comes from an immutable image layer and is restored on
+# every container start. Do NOT mount conf.d from a persistent volume: the second
+# start would find no `send-backend:8080` left to replace and silently keep the
+# first value.
+if [ -n "${APP_API_UPSTREAM:-}" ]; then
+  sed -i "s|send-backend:8080|${APP_API_UPSTREAM}|g" /etc/nginx/conf.d/default.conf
+  echo "send: set API upstream to ${APP_API_UPSTREAM}"
+else
+  echo "send: APP_API_UPSTREAM unset; keeping baked default send-backend:8080"
+fi

--- a/packages/send/frontend/docker/docker-entrypoint.d/40-send-config.sh
+++ b/packages/send/frontend/docker/docker-entrypoint.d/40-send-config.sh
@@ -12,6 +12,13 @@
 #
 # Values come from APP_* env (ConfigMap / ExternalSecrets on EKS). Anything left
 # unset is written as an empty string, and src/config.ts treats empty as unset.
+#
+# NAMESPACE NOTE: every APP_* var this script reads is emitted into the
+# publicly-served config.js, with exactly two exceptions -- APP_CONFIG_PATH and
+# APP_API_UPSTREAM below configure the entrypoint/nginx themselves and never
+# reach the browser. Keep it that way: a new APP_* var must be either clearly
+# public SPA config (add it to the jq object AND src/config.ts AND
+# public/config.js) or renamed out of the pattern.
 set -eu
 
 CONFIG_PATH="${APP_CONFIG_PATH:-/usr/share/nginx/html/config.js}"
@@ -71,6 +78,13 @@ for required in APP_SEND_SERVER_URL APP_SEND_CLIENT_URL; do
     echo "send: WARNING $required is unset; the SPA will fail to boot" >&2
   fi
 done
+
+# Not fatal (the SPA still boots), but an undeclared environment silently
+# resolves to the non-production fallback in src/config.ts -- staging sibling
+# URLs, environment "staging" in Sentry. Name the cause in the container log.
+if [ -z "${APP_ENV:-}" ]; then
+  echo "send: WARNING APP_ENV is unset; the SPA will report a fallback environment (staging) and use the -stage sibling-service URLs" >&2
+fi
 
 # Point the nginx API/tRPC proxy at the backend. On EKS the backend is a SEPARATE
 # Service, so the baked default (send-backend:8080, for a compose/sidecar

--- a/packages/send/frontend/docker/etc/nginx/conf.d/send.conf
+++ b/packages/send/frontend/docker/etc/nginx/conf.d/send.conf
@@ -79,6 +79,11 @@ server {
     listen  [::]:8080;
     server_name  _;
 
+    # Do not advertise the exact nginx version in the Server header and on
+    # nginx-generated error pages (404/413 are trivially provoked from outside
+    # and would otherwise hand out the version for CVE targeting).
+    server_tokens off;
+
     # MUST stay at server scope. Declared inside `location /` it would not reach
     # the sibling locations below, which would then inherit the compiled-in
     # default root and 404 everything -- while `nginx -t` still passes.
@@ -133,6 +138,12 @@ server {
         # pressure under concurrency. Off is also the right setting for the
         # WebSocket endpoints living under this prefix.
         proxy_buffering off;
+        # The request-side twin: without it, nginx spools every request body
+        # into client_body_temp in the writable layer before forwarding, so
+        # concurrent bodies up to client_max_body_size are ephemeral-storage
+        # pressure too. Streaming to the backend is also the right behaviour
+        # for the WebSocket endpoints under this prefix.
+        proxy_request_buffering off;
     }
 
     # tRPC over HTTP (/trpc) and over WebSocket (/trpc/ws).
@@ -147,6 +158,7 @@ server {
         proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
         proxy_read_timeout 3600s;
         proxy_send_timeout 3600s;
+        proxy_request_buffering off;
     }
 
     # Backend-rendered OIDC/login landing pages. They are not part of dist-web,
@@ -165,6 +177,16 @@ server {
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $http_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+    }
+    # The login pages' stylesheet. It lives in backend/public (the frontend
+    # build copies src/apps/send/style.css there), NOT in dist-web -- without
+    # this location the browser's root-relative /style.css request falls into
+    # `location /` and gets the SPA shell as text/html, leaving the OIDC
+    # landing pages unstyled (and caching that bogus 200 for 5 minutes).
+    location = /style.css {
+        proxy_pass http://send-backend:8080;
+        proxy_http_version 1.1;
+        proxy_set_header Host $http_host;
     }
 
     # Content-hashed Vite bundles: the filename changes whenever the bytes do,
@@ -213,7 +235,10 @@ server {
     # location's TTL.
     location / {
         add_header Cache-Control "public, max-age=300";
-        try_files $uri $uri/ /index.html;
+        # No `$uri/` clause: a bare directory URL (/icons/) would match the
+        # real directory, find no index file, and 403 -- SPA fallback is the
+        # right answer for those too.
+        try_files $uri /index.html;
     }
 
     error_page   500 502 503 504  /50x.html;

--- a/packages/send/frontend/docker/etc/nginx/conf.d/send.conf
+++ b/packages/send/frontend/docker/etc/nginx/conf.d/send.conf
@@ -7,7 +7,26 @@
 # NOTE: origin compression is deliberately left off (nginx:stable ships with
 # `gzip` commented out). Compression belongs at the edge; enabling it here makes
 # responses chunked, which drops Content-Length and can make a CDN cache a
-# partial object.
+# partial object. That makes `Compress: true` on the CloudFront behaviour
+# LOAD-BEARING rather than a nicety: the JS bundle is over 1 MB, so anything
+# reaching the origin hostname directly transfers it uncompressed.
+#
+# SECURITY HEADERS ARE THE EDGE'S JOB and are deliberately NOT set here.
+#
+# The S3/CloudFront path gets CSP, HSTS, X-Frame-Options, X-Content-Type-Options,
+# Referrer-Policy and COOP/COEP/CORP from `packages/send/pulumi/cloudfront.py`.
+# The equivalent for this image is a CloudFront ResponseHeadersPolicy on the
+# Pattern-C distribution, which lives in thunderbird/platform-infrastructure and
+# must be in place before this image serves user traffic.
+#
+# `csp.config.js` in this package CANNOT cover this image: it builds `connect-src`
+# from build-time VITE_SEND_SERVER_URL / VITE_OIDC_ROOT_URL / VITE_POSTHOG_HOST /
+# VITE_SENTRY_DSN, and this image deliberately bakes none of them, so it would
+# emit a `'self'`-only policy that breaks OIDC, PostHog, Sentry and B2. If a
+# policy is ever wanted at the ORIGIN instead, generate it in
+# docker-entrypoint.d/40-send-config.sh from the APP_* values that script already
+# reads -- and repeat every header in EVERY location block below, because a
+# location-level `add_header` drops all inherited ones.
 
 # Connection header for the WebSocket upgrade dance: "upgrade" when the client
 # asked for an upgrade, "close" otherwise. MUST be at http scope, which is where
@@ -18,7 +37,14 @@ map $http_upgrade $connection_upgrade {
 }
 
 # $remote_addr is the private address of whatever proxied the request (an in-VPC
-# ALB in every environment), so resolve the client from X-Forwarded-For.
+# ALB in every environment), so walk back through X-Forwarded-For to get past it.
+#
+# CORRELATING A USER: this does NOT yield the viewer's address under Pattern C.
+# With CloudFront -> ALB -> pod, the chain is `viewer, cloudfront-edge` and the
+# rightmost untrusted hop is the CloudFront edge, so $remote_addr logs a
+# CloudFront address. The viewer is the rightmost-but-one element of
+# $http_x_forwarded_for (logged in full below). To attribute properly, forward
+# CloudFront-Viewer-Address from the distribution and log that instead.
 #
 # Trust RFC1918 10/8 rather than one environment's VPC CIDR: this single image is
 # promoted unchanged across environments and there is no hook to rewrite the
@@ -71,6 +97,14 @@ server {
     # NOTE: this also shadows /api/implementation.js and /api/schema.json, which
     # `vite build` copies out of public/ -- those are WebExtension experiment
     # files for the XPI and are never fetched by the web app.
+    #
+    # STARTUP ORDERING: `send-backend` is a literal hostname with no `resolver`,
+    # so nginx resolves it once, at config load. That is deliberate -- a mistyped
+    # APP_API_UPSTREAM fails loudly at boot instead of 502-ing every API call --
+    # but it also means this pod CrashLoops (`host not found in upstream`) until
+    # the backend Service object exists, and keeps a stale ClusterIP if that
+    # Service is later deleted and recreated. Sync-wave the Service ahead of this
+    # Deployment, and put the readiness probe on an /api/ path rather than `/`.
     location ^~ /api/ {
         proxy_pass http://send-backend:8080;
         proxy_http_version 1.1;
@@ -78,12 +112,27 @@ server {
         proxy_set_header Connection $connection_upgrade;
         proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        # Pass the chain through UNMODIFIED, not $proxy_add_x_forwarded_for.
+        # `real_ip_header X-Forwarded-For` above already rewrote $remote_addr to
+        # the resolved client, so appending it would duplicate the last hop
+        # ("1.2.3.4" -> "1.2.3.4, 1.2.3.4") and fabricate a hop for anything
+        # downstream that counts them. X-Real-IP already carries the resolved
+        # address. nginx omits the header entirely when the value is empty, so a
+        # direct request sends no X-Forwarded-For rather than an empty one.
+        proxy_set_header X-Forwarded-For $http_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
         # Comfortably above the ~30s application-level ping on the tRPC socket,
         # so an idle-but-live WebSocket is never torn down by the proxy.
         proxy_read_timeout 3600s;
         proxy_send_timeout 3600s;
+        # /api/download streams a file body straight from the backend
+        # (backend/src/routes/download.ts pipes the stream to the response) when
+        # STORAGE_BACKEND is not a bucket. With buffering on, nginx spools each
+        # in-flight response into the pod's writable layer -- up to
+        # proxy_max_temp_file_size (1024m) each -- which is ephemeral-storage
+        # pressure under concurrency. Off is also the right setting for the
+        # WebSocket endpoints living under this prefix.
+        proxy_buffering off;
     }
 
     # tRPC over HTTP (/trpc) and over WebSocket (/trpc/ws).
@@ -94,7 +143,7 @@ server {
         proxy_set_header Connection $connection_upgrade;
         proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-For $http_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
         proxy_read_timeout 3600s;
         proxy_send_timeout 3600s;
@@ -107,14 +156,14 @@ server {
         proxy_pass http://send-backend:8080;
         proxy_http_version 1.1;
         proxy_set_header Host $http_host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-For $http_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
     }
     location = /login-failed.html {
         proxy_pass http://send-backend:8080;
         proxy_http_version 1.1;
         proxy_set_header Host $http_host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-For $http_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
     }
 
@@ -149,6 +198,13 @@ server {
     location = /config.js {
         add_header Cache-Control "no-store";
     }
+
+    # NOTE on the two `no-store` locations above: the intent only holds end to end
+    # if the CloudFront behaviour in front of this origin has MinTTL 0. CloudFront
+    # caches for at least MinTTL regardless of an origin `no-store`, and the
+    # managed CachingOptimized policy the existing Send distribution uses
+    # (packages/send/pulumi/cloudfront.py) has MinTTL 1. Put the SPA shell and
+    # /config.js on a CachingDisabled-equivalent behaviour.
 
     # SPA + unhashed public/ files (icons, fonts, manifest.json, bird.svg).
     # try_files falls back to the shell so client-side routes like /share/<id>

--- a/packages/send/frontend/docker/etc/nginx/conf.d/send.conf
+++ b/packages/send/frontend/docker/etc/nginx/conf.d/send.conf
@@ -1,0 +1,168 @@
+# nginx config for the production Send SPA image (deploy.dockerfile).
+#
+# Serves the built web app (dist-web) and reverse-proxies the backend API,
+# tRPC and the WebSocket endpoints, so the SPA and its API share ONE origin
+# (Pattern C: CloudFront -> ALB -> this pod -> send backend).
+#
+# NOTE: origin compression is deliberately left off (nginx:stable ships with
+# `gzip` commented out). Compression belongs at the edge; enabling it here makes
+# responses chunked, which drops Content-Length and can make a CDN cache a
+# partial object.
+
+# Connection header for the WebSocket upgrade dance: "upgrade" when the client
+# asked for an upgrade, "close" otherwise. MUST be at http scope, which is where
+# conf.d is included from.
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+# $remote_addr is the private address of whatever proxied the request (an in-VPC
+# ALB in every environment), so resolve the client from X-Forwarded-For.
+#
+# Trust RFC1918 10/8 rather than one environment's VPC CIDR: this single image is
+# promoted unchanged across environments and there is no hook to rewrite the
+# value per deploy, so a narrower literal would silently no-op everywhere but one
+# while `nginx -t` still passes. The trade-off is that any in-VPC peer that
+# reaches this pod directly can spoof X-Forwarded-For -- these fields are for
+# correlation only. Never authorize or rate-limit on them.
+set_real_ip_from 10.0.0.0/8;
+real_ip_header X-Forwarded-For;
+real_ip_recursive on;
+
+# JSON access log so the log pipeline does not have to parse combined format.
+# X-Amz-Cf-Id is the only CloudFront correlation header that reaches an origin.
+log_format send_json escape=json
+    '{'
+    '"time":"$time_iso8601",'
+    '"remote_addr":"$remote_addr",'
+    '"x_forwarded_for":"$http_x_forwarded_for",'
+    '"cf_id":"$http_x_amz_cf_id",'
+    '"request":"$request",'
+    '"status":$status,'
+    '"body_bytes_sent":$body_bytes_sent,'
+    '"request_time":$request_time,'
+    '"upstream_response_time":"$upstream_response_time",'
+    '"user_agent":"$http_user_agent"'
+    '}';
+
+server {
+    # 8080, not 80: the container runs as the unprivileged `nginx` user, which
+    # cannot bind a port below 1024. Kubernetes/ALB target port must be 8080.
+    listen       8080;
+    listen  [::]:8080;
+    server_name  _;
+
+    # MUST stay at server scope. Declared inside `location /` it would not reach
+    # the sibling locations below, which would then inherit the compiled-in
+    # default root and 404 everything -- while `nginx -t` still passes.
+    root   /usr/share/nginx/html;
+
+    access_log  /var/log/nginx/access.log  send_json;
+
+    # File bytes never traverse this proxy: uploads go over the /api/ws
+    # WebSocket or straight to B2 with a signed URL. This bound only has to
+    # clear the JSON request bodies of the REST API.
+    client_max_body_size 100m;
+
+    # Backend REST API, including the WebSocket endpoints /api/ws and
+    # /api/messagebus/<id>.
+    #
+    # NOTE: this also shadows /api/implementation.js and /api/schema.json, which
+    # `vite build` copies out of public/ -- those are WebExtension experiment
+    # files for the XPI and are never fetched by the web app.
+    location ^~ /api/ {
+        proxy_pass http://send-backend:8080;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+        # Comfortably above the ~30s application-level ping on the tRPC socket,
+        # so an idle-but-live WebSocket is never torn down by the proxy.
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+    }
+
+    # tRPC over HTTP (/trpc) and over WebSocket (/trpc/ws).
+    location ^~ /trpc {
+        proxy_pass http://send-backend:8080;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+    }
+
+    # Backend-rendered OIDC/login landing pages. They are not part of dist-web,
+    # so without these they would fall through to the SPA shell. The Vite dev
+    # server proxies exactly these two paths to the backend for the same reason.
+    location = /login-success.html {
+        proxy_pass http://send-backend:8080;
+        proxy_http_version 1.1;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+    }
+    location = /login-failed.html {
+        proxy_pass http://send-backend:8080;
+        proxy_http_version 1.1;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+    }
+
+    # Content-hashed Vite bundles: the filename changes whenever the bytes do,
+    # so these are safe to cache forever.
+    location ^~ /assets/ {
+        # Deliberately no `always`: the =404 below must not carry this header,
+        # or a missing asset gets cached for a year.
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        # 404 a missing asset instead of falling through to the SPA shell, which
+        # would otherwise be served as JS and fail with a MIME/syntax error.
+        try_files $uri =404;
+
+        # MUST be nested: the ^~ above short-circuits top-level regex locations,
+        # so a sibling .map guard would never fire. Source maps are stripped
+        # from the image too; this is the belt to that braces.
+        location ~ \.map$ {
+            return 404;
+        }
+    }
+
+    # The SPA shell is the deploy pointer -- never cache it, or a browser keeps
+    # loading a shell that references a deleted bundle. `no-store` rather than
+    # `no-cache` because it is the only directive that also keeps the shell out
+    # of shared/CDN storage.
+    location = /index.html {
+        add_header Cache-Control "no-store";
+    }
+
+    # Runtime config, rewritten by docker-entrypoint.d on every container boot.
+    # Caching this would pin an environment's config into a shared cache.
+    location = /config.js {
+        add_header Cache-Control "no-store";
+    }
+
+    # SPA + unhashed public/ files (icons, fonts, manifest.json, bird.svg).
+    # try_files falls back to the shell so client-side routes like /share/<id>
+    # and /send/profile resolve. The internal redirect re-runs location matching
+    # into `= /index.html` above, so those responses get `no-store`, not this
+    # location's TTL.
+    location / {
+        add_header Cache-Control "public, max-age=300";
+        try_files $uri $uri/ /index.html;
+    }
+
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        default_type text/html;
+        return 500 'There is a problem loading the API. Please try again later.';
+    }
+}

--- a/packages/send/frontend/index.html
+++ b/packages/send/frontend/index.html
@@ -5,6 +5,23 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Thunderbird Send</title>
+
+    <!-- Runtime config: sets window.__APP_CONFIG__ BEFORE the app bundle loads.
+         Replaced per-environment at container start (not rebuilt); the committed
+         public/config.js is all-empty so every other build path falls back to
+         its baked VITE_* values. See src/config.ts.
+
+         In <head>, and synchronous (no defer/module), so it runs before the app
+         bundle no matter where Vite injects that: `vite build` hoists the module
+         script into <head>, so a copy of this tag placed in <body> would only
+         still win by virtue of module scripts being deferred. This ordering is
+         not worth leaving implicit.
+
+         WEB APP ONLY. index.extension.html and index.management.html must NOT
+         load this: they run inside the add-on XPI, which has no server to serve
+         /config.js from, so window.__APP_CONFIG__ stays undefined there and the
+         baked VITE_* fallback is what configures the extension. -->
+    <script src="/config.js"></script>
   </head>
   <body>
     <div id="app" class="w-full min-h-screen mx-auto"></div>

--- a/packages/send/frontend/public/config.js
+++ b/packages/send/frontend/public/config.js
@@ -1,0 +1,39 @@
+// Runtime application config, loaded by index.html BEFORE the app bundle.
+//
+// SECURITY: every value here is served publicly to browsers. Never put a secret
+// in this file (or in the APP_* vars the container entrypoint reads from).
+//
+// This committed default is intentionally EMPTY: with no values set, the app
+// falls back to build-time `import.meta.env.VITE_*` (see src/config.ts), so all
+// three existing build paths keep working unchanged --
+//   - local dev, from your `.env`;
+//   - the existing S3/CloudFront + ECS deploy (merge.yml / release.yml), which
+//     still bakes VITE_* into the bundle;
+//   - the Thunderbird add-on XPI, which has no server to fetch this file from
+//     and therefore never loads it at all (only index.html has the script tag,
+//     not index.extension.html / index.management.html).
+//
+// On the EKS / container path only, this file is REGENERATED at container start
+// from APP_* pod env by docker/docker-entrypoint.d/40-send-config.sh. That
+// container bundle is env-agnostic (byte-identical across environments); the S3
+// bundle and the XPI are still built per-environment.
+window.__APP_CONFIG__ = {
+  appEnv: '',
+  sendServerUrl: '',
+  sendClientUrl: '',
+  oidcRootUrl: '',
+  oidcClientId: '',
+  allowPublicLogin: '',
+  sentryDsn: '',
+  posthogProjectKey: '',
+  posthogHost: '',
+  splitSizeInMb: '',
+  loggerLevel: '',
+  uploadHttpRetryLimit: '',
+  uploadHttpRetryBaseDelayMs: '',
+  accountsUrl: '',
+  dashboardUrl: '',
+  contactFormUrl: '',
+  thundermailUrl: '',
+  appointmentUrl: '',
+};

--- a/packages/send/frontend/scripts/build.sh
+++ b/packages/send/frontend/scripts/build.sh
@@ -7,47 +7,11 @@ else
     echo 'Starting development build 🐣'
 fi
 
-### Declare the environment the bundle is being built FOR (src/config.ts reads
-### VITE_APP_ENV; see the SIBLING_URL_DEFAULTS note there for what changes).
-###
-### The SPA no longer guesses its environment from a URL substring, so the
-### environment has to be stated. On the EKS/container path the pod states it
-### (APP_ENV -> /config.js) and nothing here applies. The S3/ECS and XPI builds
-### are driven by .github/workflows/merge.yml, which is frozen and passes the
-### environment only as $ENV ("stage"/"prod") and $BASE_URL -- so map it here,
-### once, at build time.
-###
-### $BASE_URL is the same signal scripts/config.ts getIsEnvProd() already uses to
-### pick the XPI id and display name, deliberately: the environment name and the
-### XPI id can then never disagree. This block is a compatibility shim for the
-### two frozen workflows -- delete it if they ever set VITE_APP_ENV themselves.
-###
-### Only derived when there is a real signal ($ENV or $BASE_URL). With neither,
-### VITE_APP_ENV is left ALONE rather than guessed -- an exported value would take
-### precedence over Vite's .env loading, so guessing here would silently override a
-### developer's own `VITE_APP_ENV=` in .env (which the shell cannot see).
-if [ -z "${VITE_APP_ENV:-}" ]; then
-    case "${ENV:-}" in
-        prod|production) VITE_APP_ENV=production ;;
-        stage|staging)   VITE_APP_ENV=staging ;;
-        dev|development) VITE_APP_ENV=development ;;
-        *)
-            case "${BASE_URL:-}" in
-                *https://send.tb.pro*) VITE_APP_ENV=production ;;
-                *send-stage.tb.pro*)   VITE_APP_ENV=staging ;;
-                *localhost*)           VITE_APP_ENV=development ;;
-            esac
-            ;;
-    esac
-fi
-if [ -n "${VITE_APP_ENV:-}" ]; then
-    ### Exported so Vite's loadEnv reads it from process.env, where VITE_* vars
-    ### take precedence over the .env file.
-    export VITE_APP_ENV
-    echo "  VITE_APP_ENV=$VITE_APP_ENV"
-else
-    echo "  VITE_APP_ENV not set and not derivable from \$ENV/\$BASE_URL; leaving it to .env"
-fi
+### Declare the environment the bundle is being built FOR. Shared with the
+### add-on build -- see the rationale in derive-app-env.sh. On the
+### EKS/container path the pod states the environment (APP_ENV -> /config.js)
+### and nothing here applies.
+. "$(dirname "$0")/derive-app-env.sh"
 
 # Get version from package.json and replace dots with hyphens
 VERSION=$(jq -r .version < package.json | sed 's/\./-/g')

--- a/packages/send/frontend/scripts/build.sh
+++ b/packages/send/frontend/scripts/build.sh
@@ -7,6 +7,48 @@ else
     echo 'Starting development build 🐣'
 fi
 
+### Declare the environment the bundle is being built FOR (src/config.ts reads
+### VITE_APP_ENV; see the SIBLING_URL_DEFAULTS note there for what changes).
+###
+### The SPA no longer guesses its environment from a URL substring, so the
+### environment has to be stated. On the EKS/container path the pod states it
+### (APP_ENV -> /config.js) and nothing here applies. The S3/ECS and XPI builds
+### are driven by .github/workflows/merge.yml, which is frozen and passes the
+### environment only as $ENV ("stage"/"prod") and $BASE_URL -- so map it here,
+### once, at build time.
+###
+### $BASE_URL is the same signal scripts/config.ts getIsEnvProd() already uses to
+### pick the XPI id and display name, deliberately: the environment name and the
+### XPI id can then never disagree. This block is a compatibility shim for the
+### two frozen workflows -- delete it if they ever set VITE_APP_ENV themselves.
+###
+### Only derived when there is a real signal ($ENV or $BASE_URL). With neither,
+### VITE_APP_ENV is left ALONE rather than guessed -- an exported value would take
+### precedence over Vite's .env loading, so guessing here would silently override a
+### developer's own `VITE_APP_ENV=` in .env (which the shell cannot see).
+if [ -z "${VITE_APP_ENV:-}" ]; then
+    case "${ENV:-}" in
+        prod|production) VITE_APP_ENV=production ;;
+        stage|staging)   VITE_APP_ENV=staging ;;
+        dev|development) VITE_APP_ENV=development ;;
+        *)
+            case "${BASE_URL:-}" in
+                *https://send.tb.pro*) VITE_APP_ENV=production ;;
+                *send-stage.tb.pro*)   VITE_APP_ENV=staging ;;
+                *localhost*)           VITE_APP_ENV=development ;;
+            esac
+            ;;
+    esac
+fi
+if [ -n "${VITE_APP_ENV:-}" ]; then
+    ### Exported so Vite's loadEnv reads it from process.env, where VITE_* vars
+    ### take precedence over the .env file.
+    export VITE_APP_ENV
+    echo "  VITE_APP_ENV=$VITE_APP_ENV"
+else
+    echo "  VITE_APP_ENV not set and not derivable from \$ENV/\$BASE_URL; leaving it to .env"
+fi
+
 # Get version from package.json and replace dots with hyphens
 VERSION=$(jq -r .version < package.json | sed 's/\./-/g')
 
@@ -24,6 +66,13 @@ mkdir -p dist/assets
 
 ### this should get copied automatically when compiling a page
 cp -R public/* dist/
+### config.js is the WEB APP's runtime-config hook, rewritten per-environment by
+### the nginx entrypoint. No extension entry point loads it (only index.html
+### carries the script tag), so shipping it inside the signed XPI would put a
+### file whose sole purpose is server-side rewriting in front of Thunderbird's
+### static packaged-script review for no benefit. The web app gets its own copy
+### from vite's publicDir into dist-web, which this does not touch.
+rm -f dist/config.js
 # Generate headers json
 echo 'Generating security headers 🔒'
 bun run scripts/headers.ts

--- a/packages/send/frontend/scripts/derive-app-env.sh
+++ b/packages/send/frontend/scripts/derive-app-env.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+### Derive and export VITE_APP_ENV -- the declared environment name that
+### src/config.ts reads instead of guessing from a URL substring.
+###
+### SOURCED (`.`), not executed, by BOTH:
+###   - packages/send/frontend/scripts/build.sh (the S3/ECS web bundle)
+###   - packages/addon/scripts/build.sh         (the XPI)
+### One copy on purpose: the mapping below contains the environment-name
+### vocabulary (prod/production, stage/staging) AND the magic hostnames, and a
+### second copy that drifts would make the stage add-on and the stage web
+### bundle silently report different environment names -- the add-on then
+### derives the wrong THUNDERMAIL_HOST (src/menu.ts and src/background.ts
+### branch on getEnvName() / isProd, and background.ts derives THUNDERMAIL_HOST
+### from it). An XPI has no /config.js to be configured from at runtime, so the
+### baked value is the ONLY configuration it ever gets.
+###
+### merge.yml (frozen) passes the environment as $ENV ("stage"/"prod") plus
+### $BASE_URL. $BASE_URL is the same signal scripts/config.ts getIsEnvProd()
+### already uses to pick the XPI id, so the id and the environment name can
+### never disagree. This is a compatibility shim for that frozen workflow --
+### delete this file (and both `. .../derive-app-env.sh` lines) if merge.yml
+### ever sets VITE_APP_ENV itself.
+###
+### Only derived when there is a real signal ($ENV or $BASE_URL). With neither,
+### VITE_APP_ENV is left ALONE rather than guessed -- an exported value would
+### take precedence over Vite's .env loading, so guessing here would silently
+### override a developer's own `VITE_APP_ENV=` in .env (which the shell cannot
+### see). In CI, though, an unparseable signal is a hard error: there is no
+### .env worth deferring to, and building an XPI with an undeclared
+### environment is exactly the silent failure this file exists to prevent.
+if [ -z "${VITE_APP_ENV:-}" ]; then
+    case "${ENV:-}" in
+        prod|production) VITE_APP_ENV=production ;;
+        stage|staging)   VITE_APP_ENV=staging ;;
+        dev|development) VITE_APP_ENV=development ;;
+        *)
+            case "${BASE_URL:-}" in
+                *https://send.tb.pro*) VITE_APP_ENV=production ;;
+                *send-stage.tb.pro*)   VITE_APP_ENV=staging ;;
+                *localhost*)           VITE_APP_ENV=development ;;
+            esac
+            ;;
+    esac
+fi
+if [ -n "${VITE_APP_ENV:-}" ]; then
+    ### Exported so Vite's loadEnv reads it from process.env, where VITE_* vars
+    ### take precedence over the .env file.
+    export VITE_APP_ENV
+    echo "  VITE_APP_ENV=$VITE_APP_ENV"
+elif [ -n "${IS_CI_AUTOMATION:-}" ] && { [ -n "${ENV:-}" ] || [ -n "${BASE_URL:-}" ]; }; then
+    ### CI passed a signal ($ENV/$BASE_URL) that this shim did not understand.
+    ### Neither build.sh runs under `set -e`, so exit here (sourcing makes this
+    ### exit the caller) rather than shipping an undeclared-environment build.
+    echo "ERROR: cannot derive VITE_APP_ENV from ENV='${ENV:-}' / BASE_URL='${BASE_URL:-}'" >&2
+    exit 1
+else
+    echo "  VITE_APP_ENV not set and not derivable from \$ENV/\$BASE_URL; leaving it to .env"
+fi

--- a/packages/send/frontend/src/apps/common/constants.ts
+++ b/packages/send/frontend/src/apps/common/constants.ts
@@ -1,12 +1,31 @@
-export const PHRASE_SIZE = 6;
-export const BASE_URL = import.meta.env.VITE_SEND_CLIENT_URL;
-const IS_PROD = BASE_URL.includes('send.tb.pro');
+import config from '@send-frontend/config';
 
-export const DASHBOARD_URL = 'https://accounts.tb.pro/send/dashboard';
+export const PHRASE_SIZE = 6;
+
+// The Send web app's own origin, from /config.js (container) or a baked VITE_*
+// (dev, the S3 build, the add-on XPI).
+//
+// Deliberately NOT defaulted to '': callers do `url.startsWith(BASE_URL)` --
+// including an origin check on incoming extension messages -- and an empty
+// prefix matches EVERY url, which turns those guards into no-ops. Leaving it
+// undefined keeps the previous behaviour, where such a comparison matches
+// nothing.
+export const BASE_URL = config.sendClientUrl;
+
+// Sibling Thunderbird Pro services. These were previously either hard-coded to
+// PRODUCTION (dashboard, contact form) or toggled by
+// `BASE_URL.includes('send.tb.pro')` -- a two-valued switch derived from a URL
+// substring, so it could not express a third environment and sent tb-dev users
+// to the legacy staging stack. They are now plain config values: set them per
+// environment via APP_* (runtime, EKS) or VITE_* (build time). See
+// platform-infrastructure#712 / #886.
+export const DASHBOARD_URL = config.dashboardUrl;
+export const THUNDERMAIL_URL = config.thundermailUrl;
+export const APPOINTMENT_URL = config.appointmentUrl;
+export const ACCOUNTS_URL = config.accountsUrl;
+export const CONTACT_FORM_URL = config.contactFormUrl;
+
+// Not environment-dependent: one public site, no per-environment variant.
 export const SUPPORT_URL = 'https://support.tb.pro';
 export const PRIVACY_POLICY_URL = 'https://tb.pro/privacy';
-export const THUNDERMAIL_URL = `https://accounts${!IS_PROD ? '-stage' : ''}.tb.pro/mail`;
-export const APPOINTMENT_URL = `https://appointment${!IS_PROD ? '-stage' : ''}.tb.pro/`;
-export const ACCOUNTS_URL = `https://accounts${!IS_PROD ? '-stage' : ''}.tb.pro`;
-export const CONTACT_FORM_URL = 'https://accounts.tb.pro/contact';
 export const TERMS_OF_SERVICE_URL = 'https://tb.pro/terms';

--- a/packages/send/frontend/src/apps/send/send.js
+++ b/packages/send/frontend/src/apps/send/send.js
@@ -1,3 +1,4 @@
+import { assertConfigured } from '@send-frontend/config';
 import { closeSentry, initSentry } from '@send-frontend/lib/sentry';
 import {
   isTelemetryAllowed,
@@ -8,6 +9,13 @@ import { createApp } from 'vue';
 import Send from './SendPage.vue';
 import router from './router';
 import { mountApp, setupApp } from './setup';
+
+// Web-app entry ONLY (index.html), which is the one entry point that loads
+// /config.js. Fail loud here rather than booting an SPA that renders and then
+// fails every request against `undefined/api/...`. Deliberately NOT called from
+// extension.js / management.js: those run inside the add-on XPI, which has no
+// /config.js and is configured by the baked VITE_* values instead.
+assertConfigured();
 
 const app = createApp(Send);
 

--- a/packages/send/frontend/src/apps/send/stores/config-store.ts
+++ b/packages/send/frontend/src/apps/send/stores/config-store.ts
@@ -61,7 +61,9 @@ export const useConfigStore = defineStore('config', () => {
 
     // Fallback for non-extension contexts (web app / tests) where there is no
     // runtime id available.
-    if (serverUrl.value.includes('send-backend.tb.pro')) {
+    // `?.`: sendServerUrl is `string | undefined`; an unset value must pick
+    // the stage id, not throw.
+    if (serverUrl.value?.includes('send-backend.tb.pro')) {
       return 'ext-tbpro-add-on@thunderbird.net';
     } else {
       return 'ext-tbpro-addon-stage@thunderbird.net';

--- a/packages/send/frontend/src/apps/send/stores/config-store.ts
+++ b/packages/send/frontend/src/apps/send/stores/config-store.ts
@@ -1,3 +1,4 @@
+import config from '@send-frontend/config';
 import { getEnvName } from '@send-frontend/lib/clientConfig';
 import { defineStore } from 'pinia';
 import { computed, ref } from 'vue';
@@ -30,10 +31,8 @@ export const useConfigStore = defineStore('config', () => {
     return __APP_NAME__ === 'addon';
   });
 
-  const _serverUrl = ref(import.meta.env.VITE_SEND_SERVER_URL);
-  const _isPublicLogin = ref(
-    import.meta.env.VITE_ALLOW_PUBLIC_LOGIN === 'true'
-  );
+  const _serverUrl = ref(config.sendServerUrl);
+  const _isPublicLogin = ref(config.allowPublicLogin === 'true');
 
   const serverUrl = computed(() => _serverUrl.value);
   const isPublicLogin = computed(() => _isPublicLogin.value);

--- a/packages/send/frontend/src/apps/send/stores/extension-store.ts
+++ b/packages/send/frontend/src/apps/send/stores/extension-store.ts
@@ -81,9 +81,11 @@ export const useExtensionStore = defineStore('extension', () => {
     // `serverUrl` is a plain string, NOT a ref: destructuring a Pinia store
     // unwraps its refs. It used to be read as `serverUrl.value`, which is
     // `undefined` -- so the cloudFile account was configured with no server and
-    // `setServerUrl` below wiped the store's URL. That went unnoticed because
-    // `import.meta.env.VITE_SEND_SERVER_URL` typed as `any`; moving the value
-    // behind the typed runtime config surfaced it.
+    // `setServerUrl` below wiped the store's URL. This package's own typecheck
+    // never flagged it (send-frontend has no ImportMetaEnv augmentation, so
+    // `import.meta.env.VITE_SEND_SERVER_URL` was `any` here); packages/addon,
+    // which does augment it in src/env.d.ts, has been reporting both lines for
+    // some time.
     return browser.storage.local
       .set({
         [id]: {

--- a/packages/send/frontend/src/apps/send/stores/extension-store.ts
+++ b/packages/send/frontend/src/apps/send/stores/extension-store.ts
@@ -74,14 +74,20 @@ export const useExtensionStore = defineStore('extension', () => {
 
     // accountId: ${id}
     // SERVER: ${SERVER}
-    // currentServerUrl.value: ${serverUrl.value}
+    // currentServerUrl: ${serverUrl}
 
     // `);
 
+    // `serverUrl` is a plain string, NOT a ref: destructuring a Pinia store
+    // unwraps its refs. It used to be read as `serverUrl.value`, which is
+    // `undefined` -- so the cloudFile account was configured with no server and
+    // `setServerUrl` below wiped the store's URL. That went unnoticed because
+    // `import.meta.env.VITE_SEND_SERVER_URL` typed as `any`; moving the value
+    // behind the typed runtime config surfaced it.
     return browser.storage.local
       .set({
         [id]: {
-          [SERVER]: serverUrl.value,
+          [SERVER]: serverUrl,
         },
       })
       .catch((error) => {
@@ -89,7 +95,7 @@ export const useExtensionStore = defineStore('extension', () => {
       })
       .then(() => {
         setAccountConfigured(id);
-        setServerUrl(serverUrl.value);
+        setServerUrl(serverUrl);
         // eslint-disable-next-line @typescript-eslint/no-unused-expressions
         DEBUG &&
           browser.storage.local.get(id).then((accountInfo) => {

--- a/packages/send/frontend/src/config.ts
+++ b/packages/send/frontend/src/config.ts
@@ -86,8 +86,17 @@ const runtime = (): AppConfig =>
 const pick = (
   runtimeVal: string | undefined,
   envVal: string | undefined
-): string | undefined =>
-  runtimeVal !== undefined && runtimeVal !== '' ? runtimeVal : envVal;
+): string | undefined => {
+  // config.js is an operator-editable contract, so tolerate a hand-authored
+  // non-string (e.g. an unquoted `allowPublicLogin: true` out of a Helm
+  // template) by coercing it: `String(true)` keeps the `=== 'true'` checks
+  // working, where the raw boolean would silently fail them.
+  const runtimeStr =
+    runtimeVal === undefined || runtimeVal === null
+      ? undefined
+      : String(runtimeVal);
+  return runtimeStr !== undefined && runtimeStr !== '' ? runtimeStr : envVal;
+};
 
 // Each fallback is written as a literal `import.meta.env.VITE_*` member
 // expression on purpose: that exact text is what Vite statically replaces at
@@ -113,7 +122,9 @@ const buildEnv = {
   contactFormUrl: import.meta.env.VITE_CONTACT_FORM_URL,
   thundermailUrl: import.meta.env.VITE_THUNDERMAIL_URL,
   appointmentUrl: import.meta.env.VITE_APPOINTMENT_URL,
-} as Record<keyof AppConfig, string | undefined>;
+  // `satisfies` (not `as`): a field added to AppConfig without a matching
+  // VITE_* entry here must fail to compile, not silently lose its fallback.
+} satisfies Record<keyof AppConfig, string | undefined>;
 
 /**
  * Last-resort defaults for the sibling-service URLs, selected by `appEnv`.
@@ -159,19 +170,26 @@ type SiblingUrlKey = keyof (typeof SIBLING_URL_DEFAULTS)['production'];
 /**
  * The declared environment name.
  *
- * Never inferred from a URL. When nothing is declared, the Vite build mode is
- * the most an unconfigured bundle can honestly say about itself.
+ * Never inferred from a URL. Every build path that has an environment DOES
+ * declare one: the container reads `APP_ENV` (see
+ * `docker/docker-entrypoint.d/40-send-config.sh`), and for the S3/ECS and XPI
+ * builds `scripts/build.sh` derives and exports `VITE_APP_ENV` from the
+ * environment `merge.yml` selects.
  *
- * Every build path that has an environment DOES declare one: the container reads
- * `APP_ENV` (see `docker/docker-entrypoint.d/40-send-config.sh`), and for the
- * S3/ECS and XPI builds `scripts/build.sh` derives and exports `VITE_APP_ENV`
- * from the environment `merge.yml` selects. Left undeclared this returns
- * `production`, which is why every deployment must declare it -- see the
- * SIBLING_URL_DEFAULTS note above for what silently changes if it does not.
+ * The undeclared fallback MUST be non-production, because `production` is the
+ * one value consumers act dangerously on: `packages/addon/src/background.ts`
+ * derives THUNDERMAIL_HOST from it (a token is sent to that host) and
+ * `menu.ts`/SIBLING_URL_DEFAULTS pick the production accounts stack. The old
+ * URL-sniffing code failed the same way (unknown URL -> not production), so a
+ * stale checkout whose `.env` predates VITE_APP_ENV keeps its non-production
+ * behaviour instead of silently flipping to production endpoints. `staging`
+ * also matches what the old `getEnvironmentName` returned for an undeclared
+ * non-dev build. A production deploy that forgets to declare fails safe --
+ * visibly, with `-stage` sibling links -- rather than dangerously.
  */
 const resolveAppEnv = (): Environment =>
   pick(runtime().appEnv, buildEnv.appEnv) ||
-  (import.meta.env.DEV ? 'development' : 'production');
+  (import.meta.env.DEV ? 'development' : 'staging');
 
 const siblingUrl = (key: SiblingUrlKey): string =>
   pick(runtime()[key], buildEnv[key]) ||
@@ -283,6 +301,16 @@ export const assertConfigured = (): void => {
     console.error(
       `[config] window.__APP_CONFIG__ is missing/empty (no /config.js?). The SPA is unconfigured: ${detail}`
     );
+    // The throw below leaves a blank 200 page (nginx keeps serving GET / fine,
+    // so probes stay green). Put the failure where a human can see it, not
+    // only in devtools.
+    const mount =
+      typeof document !== 'undefined' ? document.getElementById('app') : null;
+    if (mount) {
+      mount.textContent =
+        'Thunderbird Send is not configured on this server. ' +
+        'An administrator needs to check the deployment (missing runtime config).';
+    }
     throw new Error(`Send SPA is unconfigured: ${detail}. Check /config.js.`);
   }
 };

--- a/packages/send/frontend/src/config.ts
+++ b/packages/send/frontend/src/config.ts
@@ -1,0 +1,245 @@
+// Runtime application configuration for the Send SPA.
+//
+// Config is read at runtime from `window.__APP_CONFIG__`, injected by `/config.js`
+// (loaded synchronously in index.html BEFORE the app bundle), with FALLBACK to
+// build-time `import.meta.env.VITE_*`.
+//
+// WHY THE BUILD-TIME FALLBACK EXISTS -- three separate consumers, not just dev:
+//
+//   1. The EKS / container path: `docker/docker-entrypoint.d/40-send-config.sh`
+//      regenerates config.js from APP_* pod env at container start, and the image
+//      is built env-agnostic (no `--mode`, no baked .env), so config.js is the
+//      ONLY source there and MUST be present. `assertConfigured()` (called once
+//      from the web-app entry) makes a missing one fail loud.
+//   2. The existing S3/CloudFront + ECS path (merge.yml / release.yml, both
+//      deliberately untouched): those builds still bake VITE_* from a generated
+//      `.env`, and the committed all-EMPTY `public/config.js` falls through to
+//      them, so behaviour is unchanged.
+//   3. THE THUNDERBIRD ADD-ON XPI. `packages/addon` depends on `send-frontend`
+//      via `workspace:*`, so this SPA's code ships inside the extension -- and an
+//      extension has no server to fetch `/config.js` from. Only
+//      `index.html` (the web app) loads the script tag; `index.extension.html`
+//      and `index.management.html` deliberately do NOT. There
+//      `window.__APP_CONFIG__` stays `undefined`, `runtime()` returns `{}`, and
+//      every getter below resolves to the baked VITE_* value. That is what keeps
+//      a shipped add-on working with zero changes to `packages/addon`.
+//
+// NOTE: pick()'s "empty string = unset" rule means the CONTAINER build must stay
+// env-agnostic. If a baked `.env`/`--mode` were reintroduced there, a
+// runtime-empty APP_* value would silently fall back to the baked one instead of
+// failing.
+//
+// SECURITY: everything reachable through this module is shipped to browsers --
+// `/config.js` is served publicly and the bundle is public too. Never route a
+// secret through an APP_* var or a VITE_* var.
+//
+// Design: platform-infrastructure#886 (and #712 for the sibling-URL scope).
+
+/** Environment identity. Free-form: EKS environments are named e.g. `mzla-tb-dev`. */
+export type Environment =
+  | 'development'
+  | 'staging'
+  | 'production'
+  // Keeps the three well-known names as editor suggestions without pretending
+  // they are the only legal values.
+  | (string & NonNullable<unknown>);
+
+export type AppConfig = {
+  /** Explicit environment name. Replaces every URL-substring `IS_PROD` guess. */
+  appEnv?: string;
+  sendServerUrl?: string;
+  sendClientUrl?: string;
+  oidcRootUrl?: string;
+  oidcClientId?: string;
+  allowPublicLogin?: string;
+  sentryDsn?: string;
+  posthogProjectKey?: string;
+  posthogHost?: string;
+  splitSizeInMb?: string;
+  loggerLevel?: string;
+  uploadHttpRetryLimit?: string;
+  uploadHttpRetryBaseDelayMs?: string;
+  // Sibling Thunderbird Pro services. These used to be hard-coded, or derived
+  // from `BASE_URL.includes('send.tb.pro')` -- a two-valued switch that cannot
+  // express a third environment (see platform-infrastructure#712).
+  accountsUrl?: string;
+  dashboardUrl?: string;
+  contactFormUrl?: string;
+  thundermailUrl?: string;
+  appointmentUrl?: string;
+};
+
+declare global {
+  interface Window {
+    __APP_CONFIG__?: AppConfig;
+  }
+}
+
+const runtime = (): AppConfig =>
+  (typeof window !== 'undefined' && window.__APP_CONFIG__) || {};
+
+/**
+ * Prefer a non-empty runtime value; otherwise fall back to the build-time Vite
+ * env. An empty string is treated as "unset" -- that is what lets the committed
+ * all-empty `public/config.js` fall through to a baked build.
+ */
+const pick = (
+  runtimeVal: string | undefined,
+  envVal: string | undefined
+): string | undefined =>
+  runtimeVal !== undefined && runtimeVal !== '' ? runtimeVal : envVal;
+
+// Each fallback is written as a literal `import.meta.env.VITE_*` member
+// expression on purpose: that exact text is what Vite statically replaces at
+// build time and what `vitest.config.js` overrides via `define`. Reading the
+// same key off a spread copy of `import.meta.env` would defeat both.
+const buildEnv = {
+  appEnv: import.meta.env.VITE_APP_ENV,
+  sendServerUrl: import.meta.env.VITE_SEND_SERVER_URL,
+  sendClientUrl: import.meta.env.VITE_SEND_CLIENT_URL,
+  oidcRootUrl: import.meta.env.VITE_OIDC_ROOT_URL,
+  oidcClientId: import.meta.env.VITE_OIDC_CLIENT_ID,
+  allowPublicLogin: import.meta.env.VITE_ALLOW_PUBLIC_LOGIN,
+  sentryDsn: import.meta.env.VITE_SENTRY_DSN,
+  posthogProjectKey: import.meta.env.VITE_POSTHOG_PROJECT_KEY,
+  posthogHost: import.meta.env.VITE_POSTHOG_HOST,
+  splitSizeInMb: import.meta.env.VITE_SPLIT_SIZE_IN_MB,
+  loggerLevel: import.meta.env.VITE_LOGGER_LEVEL,
+  uploadHttpRetryLimit: import.meta.env.VITE_UPLOAD_HTTP_RETRY_LIMIT,
+  uploadHttpRetryBaseDelayMs: import.meta.env
+    .VITE_UPLOAD_HTTP_RETRY_BASE_DELAY_MS,
+  accountsUrl: import.meta.env.VITE_ACCOUNTS_URL,
+  dashboardUrl: import.meta.env.VITE_DASHBOARD_URL,
+  contactFormUrl: import.meta.env.VITE_CONTACT_FORM_URL,
+  thundermailUrl: import.meta.env.VITE_THUNDERMAIL_URL,
+  appointmentUrl: import.meta.env.VITE_APPOINTMENT_URL,
+} as Record<keyof AppConfig, string | undefined>;
+
+/**
+ * Last-resort defaults for the sibling-service URLs.
+ *
+ * These exist only so the Thunderbird add-on keeps rendering working links: its
+ * build bakes no sibling URLs, and `packages/addon` must not be modified. They
+ * are the PRODUCTION URLs, because the overwhelming majority of shipped XPIs are
+ * production ones and pointing a production user at a staging account page is
+ * the worse failure.
+ *
+ * Every non-production deployment MUST therefore set these explicitly -- APP_*
+ * at runtime on EKS, or VITE_* at build time elsewhere. See `.env.sample`.
+ */
+const SIBLING_URL_DEFAULTS = {
+  accountsUrl: 'https://accounts.tb.pro',
+  dashboardUrl: 'https://accounts.tb.pro/send/dashboard',
+  contactFormUrl: 'https://accounts.tb.pro/contact',
+  thundermailUrl: 'https://accounts.tb.pro/mail',
+  appointmentUrl: 'https://appointment.tb.pro/',
+} as const;
+
+const siblingUrl = (key: keyof typeof SIBLING_URL_DEFAULTS): string =>
+  pick(runtime()[key], buildEnv[key]) || SIBLING_URL_DEFAULTS[key];
+
+/**
+ * Runtime config accessor. Each getter resolves at call time, so it reflects
+ * whatever `/config.js` injected before the bundle loaded.
+ */
+export const config = {
+  /**
+   * Explicit environment name -- never inferred from a URL. Unset builds fall
+   * back to the Vite build mode, which is the best a bundle with nothing baked
+   * in can say about itself.
+   *
+   * KNOWN GAP: `merge.yml` builds both the stage and the prod bundle with
+   * `mode=production` and does not (yet) set VITE_APP_ENV, so the stage bundle
+   * currently reports `production`. Those workflows are deliberately out of
+   * scope here; adding `VITE_APP_ENV=staging` to the stage matrix entry closes
+   * it without touching this file.
+   */
+  get appEnv(): Environment {
+    return (
+      pick(runtime().appEnv, buildEnv.appEnv) ||
+      (import.meta.env.DEV ? 'development' : 'production')
+    );
+  },
+  get sendServerUrl() {
+    return pick(runtime().sendServerUrl, buildEnv.sendServerUrl);
+  },
+  get sendClientUrl() {
+    return pick(runtime().sendClientUrl, buildEnv.sendClientUrl);
+  },
+  get oidcRootUrl() {
+    return pick(runtime().oidcRootUrl, buildEnv.oidcRootUrl);
+  },
+  get oidcClientId() {
+    return pick(runtime().oidcClientId, buildEnv.oidcClientId);
+  },
+  get allowPublicLogin() {
+    return pick(runtime().allowPublicLogin, buildEnv.allowPublicLogin);
+  },
+  get sentryDsn() {
+    return pick(runtime().sentryDsn, buildEnv.sentryDsn);
+  },
+  get posthogProjectKey() {
+    return pick(runtime().posthogProjectKey, buildEnv.posthogProjectKey);
+  },
+  get posthogHost() {
+    return pick(runtime().posthogHost, buildEnv.posthogHost);
+  },
+  get splitSizeInMb() {
+    return pick(runtime().splitSizeInMb, buildEnv.splitSizeInMb);
+  },
+  get loggerLevel() {
+    return pick(runtime().loggerLevel, buildEnv.loggerLevel);
+  },
+  get uploadHttpRetryLimit() {
+    return pick(runtime().uploadHttpRetryLimit, buildEnv.uploadHttpRetryLimit);
+  },
+  get uploadHttpRetryBaseDelayMs() {
+    return pick(
+      runtime().uploadHttpRetryBaseDelayMs,
+      buildEnv.uploadHttpRetryBaseDelayMs
+    );
+  },
+  get accountsUrl() {
+    return siblingUrl('accountsUrl');
+  },
+  get dashboardUrl() {
+    return siblingUrl('dashboardUrl');
+  },
+  get contactFormUrl() {
+    return siblingUrl('contactFormUrl');
+  },
+  get thundermailUrl() {
+    return siblingUrl('thundermailUrl');
+  },
+  get appointmentUrl() {
+    return siblingUrl('appointmentUrl');
+  },
+};
+
+/**
+ * Fail loud if the app is unconfigured. On the container/EKS path there is no
+ * baked fallback, so a missing or empty `/config.js` (the entrypoint didn't run,
+ * or `APP_SEND_SERVER_URL` was unset) would otherwise boot an SPA that renders
+ * and then fails every request against `undefined/api/...`.
+ *
+ * The server URL is the one essential value: nothing in Send works without it.
+ *
+ * Call once at startup from the WEB APP entry only (`apps/send/send.js`). The
+ * extension and management entries must NOT call it -- they run inside the XPI,
+ * where there is no `/config.js` and the baked VITE_* values are the real
+ * config. Dev, unit tests and the existing S3/ECS build all resolve
+ * `sendServerUrl` through that fallback, so this only throws when it is truly
+ * unset.
+ */
+export const assertConfigured = (): void => {
+  if (!config.sendServerUrl) {
+    console.error(
+      '[config] window.__APP_CONFIG__ is missing/empty (no /config.js?). The SPA is unconfigured.'
+    );
+    throw new Error(
+      'Send SPA is unconfigured: config.sendServerUrl is empty (check /config.js).'
+    );
+  }
+};
+
+export default config;

--- a/packages/send/frontend/src/config.ts
+++ b/packages/send/frontend/src/config.ts
@@ -46,7 +46,7 @@ export type Environment =
 
 export type AppConfig = {
   /** Explicit environment name. Replaces every URL-substring `IS_PROD` guess. */
-  appEnv?: string;
+  appEnv?: Environment;
   sendServerUrl?: string;
   sendClientUrl?: string;
   oidcRootUrl?: string;
@@ -116,49 +116,77 @@ const buildEnv = {
 } as Record<keyof AppConfig, string | undefined>;
 
 /**
- * Last-resort defaults for the sibling-service URLs.
+ * Last-resort defaults for the sibling-service URLs, selected by `appEnv`.
  *
- * These exist only so the Thunderbird add-on keeps rendering working links: its
- * build bakes no sibling URLs, and `packages/addon` must not be modified. They
- * are the PRODUCTION URLs, because the overwhelming majority of shipped XPIs are
- * production ones and pointing a production user at a staging account page is
- * the worse failure.
+ * These exist because the Thunderbird add-on bakes no sibling URLs and
+ * `packages/addon` must not be modified: without a default set, an XPI would
+ * render `undefined` links.
  *
- * Every non-production deployment MUST therefore set these explicitly -- APP_*
- * at runtime on EKS, or VITE_* at build time elsewhere. See `.env.sample`.
+ * Two defaults per key, not one. Before this refactor the same choice was made
+ * by `BASE_URL.includes('send.tb.pro')`, so a non-production build got the
+ * `-stage` set -- and collapsing to a single production default would silently
+ * point the stage add-on and the stage web app at production accounts. Keying
+ * off the DECLARED environment keeps that behaviour while fixing the two things
+ * that were wrong with the old switch: the environment is now stated rather than
+ * guessed from a URL substring, and every value is individually overridable.
+ *
+ * Any environment other than `production` gets the non-production set. That is
+ * still only two sets, so an environment that is neither (e.g. `mzla-tb-dev`)
+ * MUST set these explicitly -- APP_* at runtime on EKS, or VITE_* at build time
+ * elsewhere. See `.env.sample`.
  */
-const SIBLING_URL_DEFAULTS = {
-  accountsUrl: 'https://accounts.tb.pro',
-  dashboardUrl: 'https://accounts.tb.pro/send/dashboard',
-  contactFormUrl: 'https://accounts.tb.pro/contact',
-  thundermailUrl: 'https://accounts.tb.pro/mail',
-  appointmentUrl: 'https://appointment.tb.pro/',
+/** Exported for `src/test/config.test.ts` only. */
+export const SIBLING_URL_DEFAULTS = {
+  production: {
+    accountsUrl: 'https://accounts.tb.pro',
+    dashboardUrl: 'https://accounts.tb.pro/send/dashboard',
+    contactFormUrl: 'https://accounts.tb.pro/contact',
+    thundermailUrl: 'https://accounts.tb.pro/mail',
+    appointmentUrl: 'https://appointment.tb.pro/',
+  },
+  nonProduction: {
+    accountsUrl: 'https://accounts-stage.tb.pro',
+    dashboardUrl: 'https://accounts-stage.tb.pro/send/dashboard',
+    // Was hard-coded to PRODUCTION for every environment before this change.
+    contactFormUrl: 'https://accounts-stage.tb.pro/contact',
+    thundermailUrl: 'https://accounts-stage.tb.pro/mail',
+    appointmentUrl: 'https://appointment-stage.tb.pro/',
+  },
 } as const;
 
-const siblingUrl = (key: keyof typeof SIBLING_URL_DEFAULTS): string =>
-  pick(runtime()[key], buildEnv[key]) || SIBLING_URL_DEFAULTS[key];
+type SiblingUrlKey = keyof (typeof SIBLING_URL_DEFAULTS)['production'];
+
+/**
+ * The declared environment name.
+ *
+ * Never inferred from a URL. When nothing is declared, the Vite build mode is
+ * the most an unconfigured bundle can honestly say about itself.
+ *
+ * Every build path that has an environment DOES declare one: the container reads
+ * `APP_ENV` (see `docker/docker-entrypoint.d/40-send-config.sh`), and for the
+ * S3/ECS and XPI builds `scripts/build.sh` derives and exports `VITE_APP_ENV`
+ * from the environment `merge.yml` selects. Left undeclared this returns
+ * `production`, which is why every deployment must declare it -- see the
+ * SIBLING_URL_DEFAULTS note above for what silently changes if it does not.
+ */
+const resolveAppEnv = (): Environment =>
+  pick(runtime().appEnv, buildEnv.appEnv) ||
+  (import.meta.env.DEV ? 'development' : 'production');
+
+const siblingUrl = (key: SiblingUrlKey): string =>
+  pick(runtime()[key], buildEnv[key]) ||
+  SIBLING_URL_DEFAULTS[
+    resolveAppEnv() === 'production' ? 'production' : 'nonProduction'
+  ][key];
 
 /**
  * Runtime config accessor. Each getter resolves at call time, so it reflects
  * whatever `/config.js` injected before the bundle loaded.
  */
 export const config = {
-  /**
-   * Explicit environment name -- never inferred from a URL. Unset builds fall
-   * back to the Vite build mode, which is the best a bundle with nothing baked
-   * in can say about itself.
-   *
-   * KNOWN GAP: `merge.yml` builds both the stage and the prod bundle with
-   * `mode=production` and does not (yet) set VITE_APP_ENV, so the stage bundle
-   * currently reports `production`. Those workflows are deliberately out of
-   * scope here; adding `VITE_APP_ENV=staging` to the stage matrix entry closes
-   * it without touching this file.
-   */
+  /** Explicit environment name. See `resolveAppEnv` above. */
   get appEnv(): Environment {
-    return (
-      pick(runtime().appEnv, buildEnv.appEnv) ||
-      (import.meta.env.DEV ? 'development' : 'production')
-    );
+    return resolveAppEnv();
   },
   get sendServerUrl() {
     return pick(runtime().sendServerUrl, buildEnv.sendServerUrl);
@@ -222,23 +250,40 @@ export const config = {
  * or `APP_SEND_SERVER_URL` was unset) would otherwise boot an SPA that renders
  * and then fails every request against `undefined/api/...`.
  *
- * The server URL is the one essential value: nothing in Send works without it.
+ * Two values are required, not one:
+ *
+ *   - `sendServerUrl` -- nothing in Send reaches the API without it.
+ *   - `sendClientUrl` -- `apps/common/constants.ts` exports it as `BASE_URL`,
+ *     and every share link is built as `${BASE_URL}/share/<id>`. Unset, the app
+ *     boots green (nginx keeps answering `GET /` with 200, so a readiness probe
+ *     on `/` stays happy) and hands users `undefined/share/<id>` links. The
+ *     share link IS the product, so this has to be fatal too.
+ *
+ * The OIDC pair is deliberately NOT required: `.env.sample` ships it empty, so
+ * requiring it would break `pnpm dev`.
  *
  * Call once at startup from the WEB APP entry only (`apps/send/send.js`). The
  * extension and management entries must NOT call it -- they run inside the XPI,
  * where there is no `/config.js` and the baked VITE_* values are the real
- * config. Dev, unit tests and the existing S3/ECS build all resolve
- * `sendServerUrl` through that fallback, so this only throws when it is truly
- * unset.
+ * config. Dev, unit tests and the existing S3/ECS build all resolve both values
+ * through that fallback, so this only throws when they are truly unset.
  */
 export const assertConfigured = (): void => {
-  if (!config.sendServerUrl) {
+  const missing = (
+    [
+      ['sendServerUrl', 'APP_SEND_SERVER_URL'],
+      ['sendClientUrl', 'APP_SEND_CLIENT_URL'],
+    ] as const
+  ).filter(([key]) => !config[key]);
+
+  if (missing.length > 0) {
+    const detail = missing
+      .map(([key, appVar]) => `${key} (set ${appVar})`)
+      .join(', ');
     console.error(
-      '[config] window.__APP_CONFIG__ is missing/empty (no /config.js?). The SPA is unconfigured.'
+      `[config] window.__APP_CONFIG__ is missing/empty (no /config.js?). The SPA is unconfigured: ${detail}`
     );
-    throw new Error(
-      'Send SPA is unconfigured: config.sendServerUrl is empty (check /config.js).'
-    );
+    throw new Error(`Send SPA is unconfigured: ${detail}. Check /config.js.`);
   }
 };
 

--- a/packages/send/frontend/src/lib/api.ts
+++ b/packages/send/frontend/src/lib/api.ts
@@ -1,3 +1,4 @@
+import config from '@send-frontend/config';
 import { trpc } from './trpc';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -97,12 +98,17 @@ export class ApiConnection {
     if (process.env.NODE_ENV === 'test') {
       return true;
     }
-    // In production, bucket storage is always assumed true — skip the network call.
-    if (import.meta.env.MODE === 'production') {
+    // In production, bucket storage is always assumed true — skip the network
+    // call. Keyed on the declared ENVIRONMENT, not Vite's MODE: the container
+    // image is built once in production mode and configured per environment at
+    // runtime, so a MODE check would hard-code the assumption into every
+    // runtime-configured dev/stage deployment whose backend may use
+    // filesystem storage.
+    if (config.appEnv === 'production') {
       return true;
     } else {
-      // Only in development do we query the backend,
-      // which may be configured with filesystem storage instead.
+      // Outside production, query the backend, which may be configured with
+      // filesystem storage instead.
       const { isBucketStorage } = await trpc.getStorageType.query();
       return isBucketStorage;
     }

--- a/packages/send/frontend/src/lib/clientConfig.ts
+++ b/packages/send/frontend/src/lib/clientConfig.ts
@@ -1,3 +1,5 @@
+import config from '@send-frontend/config';
+
 // Anytime we try to access import.meta.env, we need to check if it's running on the client or server
 // This function will return true if it's running on the client
 function isClientExecution(): boolean {
@@ -11,6 +13,9 @@ function isClientExecution(): boolean {
   }
 }
 
+// Build-MODE flags (Vite's own `MODE`) -- these say whether this bundle came out
+// of `vite dev` or a production build. They are NOT environment identity; for
+// "which deployment is this configured for", use getEnvName() below.
 export const IS_PROD = isClientExecution()
   ? import.meta.env.MODE === 'production'
   : false;
@@ -18,22 +23,16 @@ export const IS_DEV = isClientExecution()
   ? import.meta.env.MODE === 'development'
   : false;
 
-export const getEnvName = () => {
+/**
+ * The environment this bundle is configured for.
+ *
+ * This used to sniff `VITE_SEND_CLIENT_URL` for `send.tb.pro` /
+ * `send-stage.tb.pro` / `localhost` and return `undefined` for anything else --
+ * so tb-dev silently yielded `undefined`, and an unset client URL threw a
+ * TypeError. It now reads the explicit `APP_ENV` / `VITE_APP_ENV` value, which
+ * can name any environment and always resolves to a string.
+ */
+export const getEnvName = (): string => {
   isClientExecution();
-
-  if (!import.meta.env.BASE_URL && !IS_DEV) {
-    throw new Error('Environment variables object is required');
-  }
-
-  const base_url = import.meta.env.VITE_SEND_CLIENT_URL;
-
-  if (base_url.includes('send.tb.pro')) {
-    return 'production';
-  }
-  if (base_url.includes('send-stage.tb.pro')) {
-    return 'staging';
-  }
-  if (base_url.includes('localhost')) {
-    return 'development';
-  }
+  return config.appEnv;
 };

--- a/packages/send/frontend/src/lib/clientConfig.ts
+++ b/packages/send/frontend/src/lib/clientConfig.ts
@@ -1,4 +1,4 @@
-import config from '@send-frontend/config';
+import config, { type Environment } from '@send-frontend/config';
 
 // Anytime we try to access import.meta.env, we need to check if it's running on the client or server
 // This function will return true if it's running on the client
@@ -13,12 +13,13 @@ function isClientExecution(): boolean {
   }
 }
 
-// Build-MODE flags (Vite's own `MODE`) -- these say whether this bundle came out
-// of `vite dev` or a production build. They are NOT environment identity; for
-// "which deployment is this configured for", use getEnvName() below.
-export const IS_PROD = isClientExecution()
-  ? import.meta.env.MODE === 'production'
-  : false;
+// Build-MODE flag (Vite's own `MODE`) -- says whether this bundle came out of
+// `vite dev` or a production build. It is NOT environment identity; for "which
+// deployment is this configured for", use getEnvName() below.
+//
+// The matching IS_PROD was deleted with this refactor: it had no consumers, and
+// leaving an exported MODE-based `IS_PROD` next to an environment-based
+// `isProd` (config-store) invites reaching for the wrong one.
 export const IS_DEV = isClientExecution()
   ? import.meta.env.MODE === 'development'
   : false;
@@ -31,8 +32,8 @@ export const IS_DEV = isClientExecution()
  * so tb-dev silently yielded `undefined`, and an unset client URL threw a
  * TypeError. It now reads the explicit `APP_ENV` / `VITE_APP_ENV` value, which
  * can name any environment and always resolves to a string.
+ *
+ * Kept as a function (rather than collapsed into `config.appEnv`) only because
+ * `packages/addon` imports it and must not be modified.
  */
-export const getEnvName = (): string => {
-  isClientExecution();
-  return config.appEnv;
-};
+export const getEnvName = (): Environment => config.appEnv;

--- a/packages/send/frontend/src/lib/config.ts
+++ b/packages/send/frontend/src/lib/config.ts
@@ -18,7 +18,8 @@
  *   NOTE for the `loadEnv()` case: it returns ONLY `VITE_`-prefixed keys, so
  *   neither `NODE_ENV` nor `MODE` is in it and the mode fallback below would be
  *   unreachable. vite.config.js therefore merges `MODE` in at the call site.
- * @returns the declared environment name, or the build mode when none is declared
+ * @returns the declared environment name, or a mode-derived non-production
+ *   fallback (`development`/`staging`) when none is declared
  */
 export const getEnvironmentName = (
   envVarObject: Record<string, string | undefined>
@@ -32,12 +33,14 @@ export const getEnvironmentName = (
     return declared;
   }
 
-  // Nothing declared: the build mode is the most an un-configured bundle can
-  // honestly say about itself. Mirrors `resolveAppEnv()` in src/config.ts, so the
-  // Sentry release metadata and the runtime `environment` tag agree.
+  // Nothing declared: fall back to a NON-production name, mirroring
+  // `resolveAppEnv()` in src/config.ts (so the Sentry release metadata and the
+  // runtime `environment` tag agree) -- see the fail-safe rationale there.
+  // `staging` is also what this function returned for an undeclared non-dev
+  // build before the refactor.
   return (envVarObject.NODE_ENV || envVarObject.MODE) === 'development'
     ? 'development'
-    : 'production';
+    : 'staging';
 };
 
 export const TRPC_WS_PATH = `/trpc/ws`;

--- a/packages/send/frontend/src/lib/config.ts
+++ b/packages/send/frontend/src/lib/config.ts
@@ -1,30 +1,38 @@
-export type Environment = 'development' | 'staging' | 'production';
-
-export const getIsEnvProd = (envVarObject: Record<string, string>) => {
-  return envVarObject?.BASE_URL?.includes('https://send.tb.pro');
-};
-
 /**
- * Returns true if the environment is production
- * @param envVarObject - Object containing environment variables. You can use proces.env or import.meta.env, if executed from vite.config, use env that comes from loadEnv
- * @returns boolean indicating if environment is production
+ * Build-time environment name, for callers that run in Node and therefore cannot
+ * use `src/config.ts` (which reads `import.meta.env` and `window`). The only such
+ * caller is `vite.config.js`, which tags the Sentry release with it.
+ *
+ * At RUNTIME use `config.appEnv` from `@send-frontend/config` instead.
+ *
+ * This used to derive the answer from `BASE_URL.includes('https://send.tb.pro')`,
+ * which was wrong twice over: a substring of a URL is a two-valued switch that
+ * cannot express a third environment (e.g. tb-dev), and `import.meta.env.BASE_URL`
+ * is Vite's own base path ('/'), never a site URL -- so the production branch
+ * never actually fired. The environment is now stated explicitly, via
+ * VITE_APP_ENV / APP_ENV.
+ *
+ * @param envVarObject - env bag: `process.env`, or the `loadEnv()` result when
+ *   called from vite.config. Required, as before.
+ * @returns the declared environment name, or the build mode when none is declared
  */
 export const getEnvironmentName = (
-  envVarObject: Record<string, string>
-): Environment => {
+  envVarObject: Record<string, string | undefined>
+): string => {
   if (!envVarObject) {
     throw new Error('Environment variables object is required');
   }
-  // Development is when process.env.NODE_ENV is not set or set to 'development'
-  if ((envVarObject.NODE_ENV || envVarObject.MODE) === 'development') {
-    return 'development';
+
+  const declared = envVarObject.VITE_APP_ENV || envVarObject.APP_ENV;
+  if (declared) {
+    return declared;
   }
-  // Production is when BASE_URL is set to 'tb.pro'
-  if (getIsEnvProd(envVarObject)) {
-    return 'production';
-  }
-  // Staging is when BASE_URL is set to 'thunderbird.dev'
-  return 'staging';
+
+  // Nothing declared: the build mode is the most an un-configured bundle can
+  // honestly say about itself. See the KNOWN GAP note on `config.appEnv`.
+  return (envVarObject.NODE_ENV || envVarObject.MODE) === 'development'
+    ? 'development'
+    : 'production';
 };
 
 export const TRPC_WS_PATH = `/trpc/ws`;

--- a/packages/send/frontend/src/lib/config.ts
+++ b/packages/send/frontend/src/lib/config.ts
@@ -14,6 +14,10 @@
  *
  * @param envVarObject - env bag: `process.env`, or the `loadEnv()` result when
  *   called from vite.config. Required, as before.
+ *
+ *   NOTE for the `loadEnv()` case: it returns ONLY `VITE_`-prefixed keys, so
+ *   neither `NODE_ENV` nor `MODE` is in it and the mode fallback below would be
+ *   unreachable. vite.config.js therefore merges `MODE` in at the call site.
  * @returns the declared environment name, or the build mode when none is declared
  */
 export const getEnvironmentName = (
@@ -29,7 +33,8 @@ export const getEnvironmentName = (
   }
 
   // Nothing declared: the build mode is the most an un-configured bundle can
-  // honestly say about itself. See the KNOWN GAP note on `config.appEnv`.
+  // honestly say about itself. Mirrors `resolveAppEnv()` in src/config.ts, so the
+  // Sentry release metadata and the runtime `environment` tag agree.
   return (envVarObject.NODE_ENV || envVarObject.MODE) === 'development'
     ? 'development'
     : 'production';

--- a/packages/send/frontend/src/lib/const.ts
+++ b/packages/send/frontend/src/lib/const.ts
@@ -1,3 +1,4 @@
+import config from '@send-frontend/config';
 import prettyBytes from 'pretty-bytes';
 
 export const CONTAINER_TYPE = {
@@ -28,7 +29,7 @@ export const MAX_FILE_SIZE_HUMAN_READABLE = prettyBytes(MAX_FILE_SIZE);
 
 export const MAX_ACCESS_LINK_RETRIES = 5;
 // We set the split size to 100 MB by default, but it can be overridden by an environment variable.
-const SPLIT_SIZE_IN_MB: number = import.meta.env.VITE_SPLIT_SIZE_IN_MB || 100; // Default to 100 MB if not set
+const SPLIT_SIZE_IN_MB: number = Number(config.splitSizeInMb) || 100; // Default to 100 MB if not set
 export const SPLIT_SIZE = SPLIT_SIZE_IN_MB * ONE_MB_IN_BYTES;
 
 // Maximum number of parts of a multipart upload that are uploaded concurrently.

--- a/packages/send/frontend/src/lib/helpers.ts
+++ b/packages/send/frontend/src/lib/helpers.ts
@@ -5,6 +5,7 @@ import { ProgressTracker } from '@send-frontend/apps/send/stores/status-store';
 import { INIT_ERRORS } from '@send-frontend/apps/send/const';
 import init from '@send-frontend/lib/init';
 import { UserStoreType } from '@send-frontend/stores/user-store';
+import config from '@send-frontend/config';
 import { Canceler, JsonResponse } from '@send-frontend/types';
 
 import { RouteLocationNormalized } from 'vue-router';
@@ -28,7 +29,7 @@ export async function _download({
   progressTracker,
   id,
 }: DownloadOptions): Promise<Blob> {
-  const endpoint = `${import.meta.env.VITE_SEND_SERVER_URL}/api/download`;
+  const endpoint = `${config.sendServerUrl}/api/download`;
   const xhr = new XMLHttpRequest();
   const { setProgress } = progressTracker;
   xhr.onprogress = (event) => {
@@ -65,7 +66,7 @@ export async function _upload(
   encryptedSize: number = -1,
   { canceler = {} as Canceler, progressTracker }: Options
 ): Promise<JsonResponse> {
-  let host = import.meta.env.VITE_SEND_SERVER_URL;
+  let host = config.sendServerUrl;
   if (host) {
     host = host.split('//')[1];
   } else {
@@ -274,15 +275,17 @@ export const UPLOAD_ABORTED = 'UPLOAD_ABORTED';
 // Upload PUT retry policy. The hard B2 failures seen in production
 // (Sentry SEND-SUITE-FRONTEND-24H) are multi-minute stalls, so we retry a
 // handful of times with exponentially-growing, jittered delays to widen the
-// recovery window before giving up. Defaults are overridable via Vite env
-// vars — note these are baked in at build time, so a change still needs a
-// frontend deploy; they exist for tuning, not live runtime config.
+// recovery window before giving up. Defaults are overridable per environment
+// via APP_UPLOAD_HTTP_RETRY_* (container runtime config) or the corresponding
+// VITE_* vars (baked, for dev / the S3 build / the add-on XPI) -- note these are
+// read once at module load, so a change still needs a pod restart or a rebuild;
+// they exist for tuning, not live reconfiguration.
 // UPLOAD_HTTP_RETRY_LIMIT is the number of *retries*; total attempts is
 // limit + 1 (default 3 retries => 4 attempts).
 export const UPLOAD_HTTP_RETRY_LIMIT: number =
-  Number(import.meta.env.VITE_UPLOAD_HTTP_RETRY_LIMIT) || 3;
+  Number(config.uploadHttpRetryLimit) || 3;
 export const UPLOAD_HTTP_RETRY_BASE_DELAY_MS: number =
-  Number(import.meta.env.VITE_UPLOAD_HTTP_RETRY_BASE_DELAY_MS) || 1000;
+  Number(config.uploadHttpRetryBaseDelayMs) || 1000;
 
 /**
  * Exponential backoff with jitter for the upload PUT retry schedule:

--- a/packages/send/frontend/src/lib/logger.ts
+++ b/packages/send/frontend/src/lib/logger.ts
@@ -1,4 +1,6 @@
 // utils/console-wrapper.js
+import config from '@send-frontend/config';
+
 const version = __APP_VERSION__;
 
 type LogLevel = 'debug' | 'info' | 'warn' | 'error';
@@ -22,9 +24,10 @@ const originalLog = originalConsole.log;
 const originalWarn = originalConsole.warn;
 const originalError = originalConsole.error;
 
-// Get the configured log level from import.meta.VITE_LOGGER_LEVEL
+// Get the configured log level from runtime/build config (APP_LOGGER_LEVEL /
+// VITE_LOGGER_LEVEL). Read per call, not cached, so it reflects /config.js.
 const getConfiguredLevel = (): number => {
-  const level = import.meta.env.VITE_LOGGER_LEVEL as LogLevel | undefined;
+  const level = config.loggerLevel as LogLevel | undefined;
   return level && level in LOG_LEVELS ? LOG_LEVELS[level] : LOG_LEVELS.warn;
 };
 

--- a/packages/send/frontend/src/lib/sentry.ts
+++ b/packages/send/frontend/src/lib/sentry.ts
@@ -1,12 +1,12 @@
 import * as Sentry from '@sentry/vue';
-import { getEnvironmentName } from './config';
+import config from '@send-frontend/config';
 
 type App = ReturnType<typeof import('vue').createApp>;
 
 const TRACING_LEVELS_PROD = ['error', 'warn'];
 const TRACING_LEVELS_DEV = ['error', 'warn', 'debug'];
 
-const isProduction = import.meta.env.MODE === 'production';
+const isProduction = config.appEnv === 'production';
 
 /**
  * Drops the query string and fragment from a URL. Send access links carry the
@@ -71,7 +71,7 @@ export const initSentry = (app: App) => {
 
   Sentry.init({
     app,
-    dsn: import.meta.env.VITE_SENTRY_DSN,
+    dsn: config.sentryDsn,
     integrations: [
       Sentry.browserTracingIntegration(),
       // Session Replay is intentionally NOT enabled: it records DOM contents
@@ -87,7 +87,7 @@ export const initSentry = (app: App) => {
     tracesSampleRate: 0.5,
     // Set 'tracePropagationTargets' to control for which URLs distributed tracing should be enabled
     // tracePropagationTargets: ['localhost', /^https:\/\/yourserver\.io\/api/],
-    environment: import.meta.env.MODE,
+    environment: config.appEnv,
     // Privacy hardening: never attach default PII, scrub user identity /
     // request payloads from outgoing events, and strip access-link secrets and
     // tokens from auto-captured breadcrumb URLs.
@@ -96,7 +96,7 @@ export const initSentry = (app: App) => {
     beforeBreadcrumb: scrubBreadcrumb,
   });
 
-  Sentry.setTag('environmentName', getEnvironmentName(import.meta.env));
+  Sentry.setTag('environmentName', config.appEnv);
   initialized = true;
 };
 

--- a/packages/send/frontend/src/lib/sentry.ts
+++ b/packages/send/frontend/src/lib/sentry.ts
@@ -6,7 +6,13 @@ type App = ReturnType<typeof import('vue').createApp>;
 const TRACING_LEVELS_PROD = ['error', 'warn'];
 const TRACING_LEVELS_DEV = ['error', 'warn', 'debug'];
 
-const isProduction = config.appEnv === 'production';
+// Gates the console-capture levels on the BUILD MODE, exactly as before this
+// refactor: every deployed bundle (stage included) is a production-mode build,
+// so only `vite dev` ships debug-level console capture. Keying this on
+// `config.appEnv` instead would silently flip staging to the DEV level set and
+// start forwarding every console.debug from stage to Sentry. The environment
+// IDENTITY (tags below) does come from config.appEnv.
+const isProductionMode = !import.meta.env.DEV;
 
 /**
  * Drops the query string and fragment from a URL. Send access links carry the
@@ -80,7 +86,7 @@ export const initSentry = (app: App) => {
       // statements, not auto-captured user data. Auto-captured breadcrumbs are
       // scrubbed via beforeBreadcrumb below.
       Sentry.captureConsoleIntegration({
-        levels: isProduction ? TRACING_LEVELS_PROD : TRACING_LEVELS_DEV,
+        levels: isProductionMode ? TRACING_LEVELS_PROD : TRACING_LEVELS_DEV,
       }),
     ],
     // Performance Monitoring

--- a/packages/send/frontend/src/lib/share.ts
+++ b/packages/send/frontend/src/lib/share.ts
@@ -5,6 +5,7 @@ import {
 import { ApiConnection } from '@send-frontend/lib/api';
 import { CONTAINER_TYPE } from '@send-frontend/lib/const';
 import { Keychain, Util } from '@send-frontend/lib/keychain';
+import config from '@send-frontend/config';
 import { UserType } from '@send-frontend/types';
 
 export default class Sharer {
@@ -287,7 +288,7 @@ export default class Sharer {
     // const url = `${origin}/share/${accessLink}`;
     // TODO: need the server url from...elsewhere
     // Using `origin` works fine for web application, but not for extension
-    const url = `${import.meta.env.VITE_SEND_CLIENT_URL}/share/${accessLink}`;
+    const url = `${config.sendClientUrl}/share/${accessLink}`;
     return url;
   }
 }

--- a/packages/send/frontend/src/lib/trpc.ts
+++ b/packages/send/frontend/src/lib/trpc.ts
@@ -11,6 +11,8 @@ import {
   wsLink,
 } from '@trpc/client';
 
+import config from '@send-frontend/config';
+
 import { AppRouter } from '@send-backend/router';
 import { TRPC_WS_PATH } from './config';
 
@@ -18,7 +20,7 @@ import { TRPC_WS_PATH } from './config';
 // can override this at build/extraction time. An empty or unset value means
 // "disabled — do not connect" (e.g. in CI/automation, where any non-local
 // connection aborts the whole process).
-const serverUrl = (import.meta.env.VITE_SEND_SERVER_URL ?? '').trim();
+const serverUrl = (config.sendServerUrl ?? '').trim();
 
 const refreshUrl = `${serverUrl}/api/auth/refresh`;
 const trpcUrl = `${serverUrl}/trpc`;

--- a/packages/send/frontend/src/plugins/posthog.js
+++ b/packages/send/frontend/src/plugins/posthog.js
@@ -1,5 +1,6 @@
 //./plugins/posthog.js
 
+import config from '@send-frontend/config';
 import posthog from 'posthog-js';
 
 let initialized = false;
@@ -8,8 +9,8 @@ function initPosthog() {
   if (initialized) {
     return;
   }
-  posthog.init(import.meta.env.VITE_POSTHOG_PROJECT_KEY, {
-    api_host: import.meta.env.VITE_POSTHOG_HOST,
+  posthog.init(config.posthogProjectKey, {
+    api_host: config.posthogHost,
     persistence: 'memory',
   });
   posthog.register({

--- a/packages/send/frontend/src/stores/auth-store.ts
+++ b/packages/send/frontend/src/stores/auth-store.ts
@@ -1,5 +1,6 @@
 // stores/auth-store.js
 
+import config from '@send-frontend/config';
 import { useApiStore, useConfigStore } from '@send-frontend/stores';
 import { User, UserManager, UserManagerSettings } from 'oidc-client-ts';
 import { defineStore } from 'pinia';
@@ -17,11 +18,11 @@ import {
 import { ref, watch } from 'vue';
 
 const settings: UserManagerSettings = {
-  authority: import.meta.env?.VITE_OIDC_ROOT_URL,
-  client_id: import.meta.env?.VITE_OIDC_CLIENT_ID,
+  authority: config.oidcRootUrl,
+  client_id: config.oidcClientId,
   redirect_uri: `${window.location.origin}/post-login`,
   // We explicitly set the logout redirect to web to avoid errors with the uri since it doesn't support moz-extension:// protocols
-  post_logout_redirect_uri: `${import.meta.env?.VITE_SEND_CLIENT_URL}/logout`,
+  post_logout_redirect_uri: `${config.sendClientUrl}/logout`,
   response_type: 'code',
   scope: 'openid profile email offline_access',
   // Refresh on demand only (see refreshAccessToken). The library's background

--- a/packages/send/frontend/src/test/config.test.ts
+++ b/packages/send/frontend/src/test/config.test.ts
@@ -1,0 +1,216 @@
+import {
+  assertConfigured,
+  config,
+  SIBLING_URL_DEFAULTS,
+} from '@send-frontend/config';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// `import.meta.env` is typed with an index signature of `any`, so read it through
+// an explicit record when looking a key up by name.
+const env = import.meta.env as unknown as Record<string, string | undefined>;
+
+describe('runtime config accessor', () => {
+  afterEach(() => {
+    delete window.__APP_CONFIG__;
+  });
+
+  it('prefers window.__APP_CONFIG__ when a value is present', () => {
+    window.__APP_CONFIG__ = {
+      sendServerUrl: 'https://runtime.example.test',
+      appEnv: 'mzla-tb-dev',
+    };
+    expect(config.sendServerUrl).toBe('https://runtime.example.test');
+    expect(config.appEnv).toBe('mzla-tb-dev');
+  });
+
+  it('falls back to build-time import.meta.env when the runtime value is absent', () => {
+    delete window.__APP_CONFIG__;
+    expect(config.sendServerUrl).toBe(import.meta.env.VITE_SEND_SERVER_URL);
+  });
+
+  // Invariant: "empty string means unset". This is the single rule that lets the
+  // committed all-empty public/config.js fall through to a baked build, so the
+  // S3/ECS deploy and the add-on XPI keep working unchanged.
+  it('treats an empty runtime string as unset and falls back', () => {
+    window.__APP_CONFIG__ = { sendServerUrl: '' };
+    expect(config.sendServerUrl).toBe(import.meta.env.VITE_SEND_SERVER_URL);
+  });
+
+  it('resolves getters at call time (reflects a later window mutation)', () => {
+    delete window.__APP_CONFIG__;
+    expect(config.sendClientUrl).toBe(import.meta.env.VITE_SEND_CLIENT_URL);
+    window.__APP_CONFIG__ = { sendClientUrl: 'https://later.example.test' };
+    expect(config.sendClientUrl).toBe('https://later.example.test');
+  });
+
+  it('a partial runtime object still falls back per-key for unset keys', () => {
+    window.__APP_CONFIG__ = { sendClientUrl: 'https://later.example.test' };
+    expect(config.sendClientUrl).toBe('https://later.example.test');
+    expect(config.sendServerUrl).toBe(import.meta.env.VITE_SEND_SERVER_URL);
+  });
+
+  // Guard the near-identical getters against copy-paste / rebase errors: each key
+  // must prefer its runtime value AND fall back to its OWN VITE_* env var. A
+  // mistyped fallback would otherwise be invisible -- it would just silently
+  // resolve to the wrong value in every environment with the suite still green.
+  //
+  // This list must stay in lockstep with `buildEnv` in src/config.ts, the key list
+  // in the committed public/config.js, and the jq object in
+  // docker/docker-entrypoint.d/40-send-config.sh.
+  const PLAIN_KEYS: Array<[keyof typeof config, string]> = [
+    ['sendServerUrl', 'VITE_SEND_SERVER_URL'],
+    ['sendClientUrl', 'VITE_SEND_CLIENT_URL'],
+    ['oidcRootUrl', 'VITE_OIDC_ROOT_URL'],
+    ['oidcClientId', 'VITE_OIDC_CLIENT_ID'],
+    ['allowPublicLogin', 'VITE_ALLOW_PUBLIC_LOGIN'],
+    ['sentryDsn', 'VITE_SENTRY_DSN'],
+    ['posthogProjectKey', 'VITE_POSTHOG_PROJECT_KEY'],
+    ['posthogHost', 'VITE_POSTHOG_HOST'],
+    ['splitSizeInMb', 'VITE_SPLIT_SIZE_IN_MB'],
+    ['loggerLevel', 'VITE_LOGGER_LEVEL'],
+    ['uploadHttpRetryLimit', 'VITE_UPLOAD_HTTP_RETRY_LIMIT'],
+    ['uploadHttpRetryBaseDelayMs', 'VITE_UPLOAD_HTTP_RETRY_BASE_DELAY_MS'],
+  ];
+
+  const SIBLING_KEYS: Array<
+    [keyof typeof SIBLING_URL_DEFAULTS.production, string]
+  > = [
+    ['accountsUrl', 'VITE_ACCOUNTS_URL'],
+    ['dashboardUrl', 'VITE_DASHBOARD_URL'],
+    ['contactFormUrl', 'VITE_CONTACT_FORM_URL'],
+    ['thundermailUrl', 'VITE_THUNDERMAIL_URL'],
+    ['appointmentUrl', 'VITE_APPOINTMENT_URL'],
+  ];
+
+  const ALL_KEYS = [...PLAIN_KEYS, ...SIBLING_KEYS, ['appEnv', 'VITE_APP_ENV']];
+
+  it.each(ALL_KEYS)('runtime value wins for %s', (key) => {
+    window.__APP_CONFIG__ = { [key]: `rt-${key}` };
+    expect(config[key as keyof typeof config]).toBe(`rt-${key}`);
+  });
+
+  it.each(ALL_KEYS)(
+    'an empty runtime value for %s is treated as unset',
+    (key) => {
+      delete window.__APP_CONFIG__;
+      const withoutRuntime = config[key as keyof typeof config];
+      window.__APP_CONFIG__ = { [key]: '' };
+      expect(config[key as keyof typeof config]).toBe(withoutRuntime);
+    }
+  );
+
+  it.each(PLAIN_KEYS)(
+    '%s falls back to its own env var when runtime is unset',
+    (key, envVar) => {
+      delete window.__APP_CONFIG__;
+      expect(config[key]).toBe(env[envVar]);
+    }
+  );
+});
+
+describe('sibling service URLs', () => {
+  afterEach(() => {
+    delete window.__APP_CONFIG__;
+  });
+
+  // These have a last-resort default, so they never resolve to undefined -- that
+  // is what keeps the add-on XPI (which bakes no sibling URLs) rendering working
+  // links. `|| DEFAULT` in each expectation covers a developer whose local .env
+  // bakes the value; CI has no .env, so it is the default branch that is asserted.
+  it.each([
+    ['accountsUrl', 'VITE_ACCOUNTS_URL'],
+    ['dashboardUrl', 'VITE_DASHBOARD_URL'],
+    ['contactFormUrl', 'VITE_CONTACT_FORM_URL'],
+    ['thundermailUrl', 'VITE_THUNDERMAIL_URL'],
+    ['appointmentUrl', 'VITE_APPOINTMENT_URL'],
+  ] as Array<[keyof typeof SIBLING_URL_DEFAULTS.production, string]>)(
+    '%s uses the production default when appEnv is production',
+    (key, envVar) => {
+      window.__APP_CONFIG__ = { appEnv: 'production' };
+      expect(config[key]).toBe(
+        env[envVar] || SIBLING_URL_DEFAULTS.production[key]
+      );
+    }
+  );
+
+  // The regression this pins down: before the refactor a non-production build got
+  // the `-stage` sibling URLs via `BASE_URL.includes('send.tb.pro')`. Collapsing to
+  // a single production default would silently point stage users -- and the stage
+  // add-on -- at production accounts.
+  it.each([
+    ['accountsUrl', 'VITE_ACCOUNTS_URL'],
+    ['dashboardUrl', 'VITE_DASHBOARD_URL'],
+    ['contactFormUrl', 'VITE_CONTACT_FORM_URL'],
+    ['thundermailUrl', 'VITE_THUNDERMAIL_URL'],
+    ['appointmentUrl', 'VITE_APPOINTMENT_URL'],
+  ] as Array<[keyof typeof SIBLING_URL_DEFAULTS.production, string]>)(
+    '%s uses the non-production default for any other appEnv',
+    (key, envVar) => {
+      window.__APP_CONFIG__ = { appEnv: 'staging' };
+      expect(config[key]).toBe(
+        env[envVar] || SIBLING_URL_DEFAULTS.nonProduction[key]
+      );
+      window.__APP_CONFIG__ = { appEnv: 'mzla-tb-dev' };
+      expect(config[key]).toBe(
+        env[envVar] || SIBLING_URL_DEFAULTS.nonProduction[key]
+      );
+    }
+  );
+
+  it('an explicit value overrides the default in either direction', () => {
+    window.__APP_CONFIG__ = {
+      appEnv: 'production',
+      accountsUrl: 'https://accounts.tb-dev.example.test',
+    };
+    expect(config.accountsUrl).toBe('https://accounts.tb-dev.example.test');
+  });
+});
+
+describe('appEnv', () => {
+  afterEach(() => {
+    delete window.__APP_CONFIG__;
+  });
+
+  it('never resolves to an empty string', () => {
+    delete window.__APP_CONFIG__;
+    expect(config.appEnv).toBeTruthy();
+    window.__APP_CONFIG__ = { appEnv: '' };
+    expect(config.appEnv).toBeTruthy();
+  });
+
+  it('accepts an arbitrary environment name (not just the three well-known ones)', () => {
+    window.__APP_CONFIG__ = { appEnv: 'mzla-tb-dev' };
+    expect(config.appEnv).toBe('mzla-tb-dev');
+  });
+});
+
+describe('assertConfigured', () => {
+  afterEach(() => {
+    delete window.__APP_CONFIG__;
+  });
+
+  // Only the web-app entry calls this; it must pass whenever the baked fallbacks
+  // are present, which is the case for dev, the S3/ECS build and the tests.
+  it('passes when both required values resolve', () => {
+    delete window.__APP_CONFIG__;
+    expect(() => assertConfigured()).not.toThrow();
+  });
+
+  it('throws and names APP_SEND_SERVER_URL when the server URL is unset', () => {
+    window.__APP_CONFIG__ = { sendServerUrl: 'x' };
+    // Blank out the baked fallback for this key only.
+    const spy = vi
+      .spyOn(config, 'sendServerUrl', 'get')
+      .mockReturnValue(undefined);
+    expect(() => assertConfigured()).toThrowError(/APP_SEND_SERVER_URL/);
+    spy.mockRestore();
+  });
+
+  it('throws and names APP_SEND_CLIENT_URL when the client URL is unset', () => {
+    const spy = vi
+      .spyOn(config, 'sendClientUrl', 'get')
+      .mockReturnValue(undefined);
+    expect(() => assertConfigured()).toThrowError(/APP_SEND_CLIENT_URL/);
+    spy.mockRestore();
+  });
+});

--- a/packages/send/frontend/src/test/config.test.ts
+++ b/packages/send/frontend/src/test/config.test.ts
@@ -9,6 +9,43 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 // an explicit record when looking a key up by name.
 const env = import.meta.env as unknown as Record<string, string | undefined>;
 
+// Guard the near-identical getters against copy-paste / rebase errors: each key
+// must prefer its runtime value AND fall back to its OWN VITE_* env var (every
+// one pinned to a distinct sentinel in vitest.config.js `define`, so a crossed
+// fallback produces a mismatched value instead of `undefined === undefined`).
+//
+// This list must stay in lockstep with `buildEnv` in src/config.ts, the key list
+// in the committed public/config.js, and the jq object in
+// docker/docker-entrypoint.d/40-send-config.sh.
+const PLAIN_KEYS: Array<[keyof typeof config, string]> = [
+  ['sendServerUrl', 'VITE_SEND_SERVER_URL'],
+  ['sendClientUrl', 'VITE_SEND_CLIENT_URL'],
+  ['oidcRootUrl', 'VITE_OIDC_ROOT_URL'],
+  ['oidcClientId', 'VITE_OIDC_CLIENT_ID'],
+  ['allowPublicLogin', 'VITE_ALLOW_PUBLIC_LOGIN'],
+  ['sentryDsn', 'VITE_SENTRY_DSN'],
+  ['posthogProjectKey', 'VITE_POSTHOG_PROJECT_KEY'],
+  ['posthogHost', 'VITE_POSTHOG_HOST'],
+  ['splitSizeInMb', 'VITE_SPLIT_SIZE_IN_MB'],
+  ['loggerLevel', 'VITE_LOGGER_LEVEL'],
+  ['uploadHttpRetryLimit', 'VITE_UPLOAD_HTTP_RETRY_LIMIT'],
+  ['uploadHttpRetryBaseDelayMs', 'VITE_UPLOAD_HTTP_RETRY_BASE_DELAY_MS'],
+];
+
+// One table for all four sibling-URL test sites, so a key added to one list
+// cannot silently lose coverage in another.
+const SIBLING_KEYS: Array<
+  [keyof typeof SIBLING_URL_DEFAULTS.production, string]
+> = [
+  ['accountsUrl', 'VITE_ACCOUNTS_URL'],
+  ['dashboardUrl', 'VITE_DASHBOARD_URL'],
+  ['contactFormUrl', 'VITE_CONTACT_FORM_URL'],
+  ['thundermailUrl', 'VITE_THUNDERMAIL_URL'],
+  ['appointmentUrl', 'VITE_APPOINTMENT_URL'],
+];
+
+const ALL_KEYS = [...PLAIN_KEYS, ...SIBLING_KEYS, ['appEnv', 'VITE_APP_ENV']];
+
 describe('runtime config accessor', () => {
   afterEach(() => {
     delete window.__APP_CONFIG__;
@@ -49,41 +86,6 @@ describe('runtime config accessor', () => {
     expect(config.sendServerUrl).toBe(import.meta.env.VITE_SEND_SERVER_URL);
   });
 
-  // Guard the near-identical getters against copy-paste / rebase errors: each key
-  // must prefer its runtime value AND fall back to its OWN VITE_* env var. A
-  // mistyped fallback would otherwise be invisible -- it would just silently
-  // resolve to the wrong value in every environment with the suite still green.
-  //
-  // This list must stay in lockstep with `buildEnv` in src/config.ts, the key list
-  // in the committed public/config.js, and the jq object in
-  // docker/docker-entrypoint.d/40-send-config.sh.
-  const PLAIN_KEYS: Array<[keyof typeof config, string]> = [
-    ['sendServerUrl', 'VITE_SEND_SERVER_URL'],
-    ['sendClientUrl', 'VITE_SEND_CLIENT_URL'],
-    ['oidcRootUrl', 'VITE_OIDC_ROOT_URL'],
-    ['oidcClientId', 'VITE_OIDC_CLIENT_ID'],
-    ['allowPublicLogin', 'VITE_ALLOW_PUBLIC_LOGIN'],
-    ['sentryDsn', 'VITE_SENTRY_DSN'],
-    ['posthogProjectKey', 'VITE_POSTHOG_PROJECT_KEY'],
-    ['posthogHost', 'VITE_POSTHOG_HOST'],
-    ['splitSizeInMb', 'VITE_SPLIT_SIZE_IN_MB'],
-    ['loggerLevel', 'VITE_LOGGER_LEVEL'],
-    ['uploadHttpRetryLimit', 'VITE_UPLOAD_HTTP_RETRY_LIMIT'],
-    ['uploadHttpRetryBaseDelayMs', 'VITE_UPLOAD_HTTP_RETRY_BASE_DELAY_MS'],
-  ];
-
-  const SIBLING_KEYS: Array<
-    [keyof typeof SIBLING_URL_DEFAULTS.production, string]
-  > = [
-    ['accountsUrl', 'VITE_ACCOUNTS_URL'],
-    ['dashboardUrl', 'VITE_DASHBOARD_URL'],
-    ['contactFormUrl', 'VITE_CONTACT_FORM_URL'],
-    ['thundermailUrl', 'VITE_THUNDERMAIL_URL'],
-    ['appointmentUrl', 'VITE_APPOINTMENT_URL'],
-  ];
-
-  const ALL_KEYS = [...PLAIN_KEYS, ...SIBLING_KEYS, ['appEnv', 'VITE_APP_ENV']];
-
   it.each(ALL_KEYS)('runtime value wins for %s', (key) => {
     window.__APP_CONFIG__ = { [key]: `rt-${key}` };
     expect(config[key as keyof typeof config]).toBe(`rt-${key}`);
@@ -106,6 +108,19 @@ describe('runtime config accessor', () => {
       expect(config[key]).toBe(env[envVar]);
     }
   );
+
+  // config.js is an operator-editable contract: a hand-authored (e.g.
+  // Helm-templated) file can plausibly carry an unquoted boolean or number.
+  // pick() coerces those to strings so `=== 'true'`-style consumers keep
+  // working instead of silently failing on a raw boolean.
+  it('coerces a non-string runtime value to a string', () => {
+    window.__APP_CONFIG__ = {
+      allowPublicLogin: true,
+      splitSizeInMb: 250,
+    } as never;
+    expect(config.allowPublicLogin).toBe('true');
+    expect(config.splitSizeInMb).toBe('250');
+  });
 });
 
 describe('sibling service URLs', () => {
@@ -115,21 +130,14 @@ describe('sibling service URLs', () => {
 
   // These have a last-resort default, so they never resolve to undefined -- that
   // is what keeps the add-on XPI (which bakes no sibling URLs) rendering working
-  // links. `|| DEFAULT` in each expectation covers a developer whose local .env
-  // bakes the value; CI has no .env, so it is the default branch that is asserted.
-  it.each([
-    ['accountsUrl', 'VITE_ACCOUNTS_URL'],
-    ['dashboardUrl', 'VITE_DASHBOARD_URL'],
-    ['contactFormUrl', 'VITE_CONTACT_FORM_URL'],
-    ['thundermailUrl', 'VITE_THUNDERMAIL_URL'],
-    ['appointmentUrl', 'VITE_APPOINTMENT_URL'],
-  ] as Array<[keyof typeof SIBLING_URL_DEFAULTS.production, string]>)(
+  // links. The sibling VITE_* vars are pinned EMPTY in vitest.config.js, so these
+  // assert the literal defaults -- the assertions cannot silently degrade on a
+  // machine whose local .env bakes a value.
+  it.each(SIBLING_KEYS)(
     '%s uses the production default when appEnv is production',
-    (key, envVar) => {
+    (key) => {
       window.__APP_CONFIG__ = { appEnv: 'production' };
-      expect(config[key]).toBe(
-        env[envVar] || SIBLING_URL_DEFAULTS.production[key]
-      );
+      expect(config[key]).toBe(SIBLING_URL_DEFAULTS.production[key]);
     }
   );
 
@@ -137,23 +145,13 @@ describe('sibling service URLs', () => {
   // the `-stage` sibling URLs via `BASE_URL.includes('send.tb.pro')`. Collapsing to
   // a single production default would silently point stage users -- and the stage
   // add-on -- at production accounts.
-  it.each([
-    ['accountsUrl', 'VITE_ACCOUNTS_URL'],
-    ['dashboardUrl', 'VITE_DASHBOARD_URL'],
-    ['contactFormUrl', 'VITE_CONTACT_FORM_URL'],
-    ['thundermailUrl', 'VITE_THUNDERMAIL_URL'],
-    ['appointmentUrl', 'VITE_APPOINTMENT_URL'],
-  ] as Array<[keyof typeof SIBLING_URL_DEFAULTS.production, string]>)(
+  it.each(SIBLING_KEYS)(
     '%s uses the non-production default for any other appEnv',
-    (key, envVar) => {
+    (key) => {
       window.__APP_CONFIG__ = { appEnv: 'staging' };
-      expect(config[key]).toBe(
-        env[envVar] || SIBLING_URL_DEFAULTS.nonProduction[key]
-      );
+      expect(config[key]).toBe(SIBLING_URL_DEFAULTS.nonProduction[key]);
       window.__APP_CONFIG__ = { appEnv: 'mzla-tb-dev' };
-      expect(config[key]).toBe(
-        env[envVar] || SIBLING_URL_DEFAULTS.nonProduction[key]
-      );
+      expect(config[key]).toBe(SIBLING_URL_DEFAULTS.nonProduction[key]);
     }
   );
 
@@ -182,6 +180,16 @@ describe('appEnv', () => {
     window.__APP_CONFIG__ = { appEnv: 'mzla-tb-dev' };
     expect(config.appEnv).toBe('mzla-tb-dev');
   });
+
+  // FAIL-SAFE INVARIANT: an undeclared environment must NEVER resolve to
+  // `production` -- background.ts derives THUNDERMAIL_HOST from it and the
+  // sibling defaults pick the production accounts stack. See resolveAppEnv().
+  it('never resolves to production when nothing is declared', () => {
+    delete window.__APP_CONFIG__;
+    expect(config.appEnv).not.toBe('production');
+    window.__APP_CONFIG__ = { appEnv: '' };
+    expect(config.appEnv).not.toBe('production');
+  });
 });
 
 describe('assertConfigured', () => {
@@ -196,9 +204,10 @@ describe('assertConfigured', () => {
     expect(() => assertConfigured()).not.toThrow();
   });
 
+  // The getter is replaced wholesale (runtime AND baked fallback), so these
+  // exercise only assertConfigured's own filter -- pick()'s resolution is
+  // covered by the accessor tests above.
   it('throws and names APP_SEND_SERVER_URL when the server URL is unset', () => {
-    window.__APP_CONFIG__ = { sendServerUrl: 'x' };
-    // Blank out the baked fallback for this key only.
     const spy = vi
       .spyOn(config, 'sendServerUrl', 'get')
       .mockReturnValue(undefined);
@@ -212,5 +221,19 @@ describe('assertConfigured', () => {
       .mockReturnValue(undefined);
     expect(() => assertConfigured()).toThrowError(/APP_SEND_CLIENT_URL/);
     spy.mockRestore();
+  });
+
+  it('names BOTH APP_ vars when both required values are missing', () => {
+    const serverSpy = vi
+      .spyOn(config, 'sendServerUrl', 'get')
+      .mockReturnValue(undefined);
+    const clientSpy = vi
+      .spyOn(config, 'sendClientUrl', 'get')
+      .mockReturnValue(undefined);
+    expect(() => assertConfigured()).toThrowError(
+      /APP_SEND_SERVER_URL.*APP_SEND_CLIENT_URL/
+    );
+    serverSpy.mockRestore();
+    clientSpy.mockRestore();
   });
 });

--- a/packages/send/frontend/vite.config.js
+++ b/packages/send/frontend/vite.config.js
@@ -3,7 +3,11 @@ import vue from '@vitejs/plugin-vue';
 import path from 'path';
 import { defineConfig, loadEnv } from 'vite';
 import { getHeadersForEnvironment } from './csp.config.js';
-import { packageJson, sharedViteConfig, removeEmptySourcemapsPlugin } from './sharedViteConfig';
+import {
+  packageJson,
+  sharedViteConfig,
+  removeEmptySourcemapsPlugin,
+} from './sharedViteConfig';
 import { getEnvironmentName } from './src/lib/config';
 
 // https://vitejs.dev/config/
@@ -30,7 +34,10 @@ export default defineConfig(({ mode }) => {
         release: packageJson.version,
         moduleMetadata: {
           version: packageJson.version,
-          environment: getEnvironmentName(env),
+          // `loadEnv` returns VITE_-prefixed keys only, so MODE has to be merged
+          // in for getEnvironmentName's mode fallback to be reachable. Declared
+          // VITE_APP_ENV still wins.
+          environment: getEnvironmentName({ ...env, MODE: mode }),
         },
       }),
     ],

--- a/packages/send/frontend/vitest.config.js
+++ b/packages/send/frontend/vitest.config.js
@@ -27,5 +27,35 @@ export default defineConfig({
     // from it degenerates into comparing 'undefined/...' with itself (see
     // src/test/lib/share.test.ts) -- green even if the wiring breaks entirely.
     'import.meta.env.VITE_SEND_CLIENT_URL': '"http://localhost:5173"',
+    // Every remaining plain config key gets a DISTINCT sentinel. Without them
+    // these vars are undefined in tests, and config.test.ts's per-key
+    // "falls back to its own env var" guard degenerates into
+    // `undefined === undefined` -- green even when a copy-paste error crosses
+    // two keys' fallbacks. The sentinels are deliberately non-numeric /
+    // non-'true' so consumers that coerce (Number(...) || default,
+    // === 'true') still resolve to their defaults, exactly as with unset vars.
+    'import.meta.env.VITE_OIDC_ROOT_URL': '"sentinel-VITE_OIDC_ROOT_URL"',
+    'import.meta.env.VITE_OIDC_CLIENT_ID': '"sentinel-VITE_OIDC_CLIENT_ID"',
+    'import.meta.env.VITE_ALLOW_PUBLIC_LOGIN':
+      '"sentinel-VITE_ALLOW_PUBLIC_LOGIN"',
+    'import.meta.env.VITE_SENTRY_DSN': '"sentinel-VITE_SENTRY_DSN"',
+    'import.meta.env.VITE_POSTHOG_PROJECT_KEY':
+      '"sentinel-VITE_POSTHOG_PROJECT_KEY"',
+    'import.meta.env.VITE_POSTHOG_HOST': '"sentinel-VITE_POSTHOG_HOST"',
+    'import.meta.env.VITE_SPLIT_SIZE_IN_MB': '"sentinel-VITE_SPLIT_SIZE_IN_MB"',
+    'import.meta.env.VITE_LOGGER_LEVEL': '"sentinel-VITE_LOGGER_LEVEL"',
+    'import.meta.env.VITE_UPLOAD_HTTP_RETRY_LIMIT':
+      '"sentinel-VITE_UPLOAD_HTTP_RETRY_LIMIT"',
+    'import.meta.env.VITE_UPLOAD_HTTP_RETRY_BASE_DELAY_MS':
+      '"sentinel-VITE_UPLOAD_HTTP_RETRY_BASE_DELAY_MS"',
+    // The sibling URLs are pinned EMPTY so the SIBLING_URL_DEFAULTS branch is
+    // what the sibling-URL tests exercise, independent of any local .env.
+    'import.meta.env.VITE_ACCOUNTS_URL': '""',
+    'import.meta.env.VITE_DASHBOARD_URL': '""',
+    'import.meta.env.VITE_CONTACT_FORM_URL': '""',
+    'import.meta.env.VITE_THUNDERMAIL_URL': '""',
+    'import.meta.env.VITE_APPOINTMENT_URL': '""',
+    // VITE_APP_ENV is deliberately NOT defined: the appEnv tests exercise the
+    // undeclared fallback path.
   },
 });

--- a/packages/send/frontend/vitest.config.js
+++ b/packages/send/frontend/vitest.config.js
@@ -18,8 +18,14 @@ export default defineConfig({
     globals: true,
     mockReset: false,
   },
+  // src/config.ts reads each fallback as a literal `import.meta.env.VITE_*` member
+  // expression precisely so these overrides reach it.
   define: {
     'import.meta.env.VITE_TESTING': '"true"',
     'import.meta.env.VITE_SEND_SERVER_URL': '"https://localhost:8088"',
+    // Without this, config.sendClientUrl is undefined and every assertion built
+    // from it degenerates into comparing 'undefined/...' with itself (see
+    // src/test/lib/share.test.ts) -- green even if the wiring breaks entirely.
+    'import.meta.env.VITE_SEND_CLIENT_URL': '"http://localhost:5173"',
   },
 });


### PR DESCRIPTION
Send's SPA can now be configured at **runtime**, so one built bundle runs in any environment instead of one bundle per environment. This is groundwork for running Send on Kubernetes; **nothing about how you ship Send today changes.**

## What this adds

- `src/config.ts` — a config accessor reading `window.__APP_CONFIG__` (injected by `/config.js`), falling back to the baked `VITE_*` when a runtime value is absent.
- `public/config.js` — committed **all-empty**, so every existing build falls through to `VITE_*`.
- `deploy.dockerfile` — a production nginx image serving the built SPA and proxying `/api`, `/trpc`, the WebSocket upgrades and the backend-rendered login pages (`/login-*.html`, `/style.css`) to the backend. Its entrypoint regenerates `config.js` from `APP_*` env at container start. (`dockerfiles/Dockerfile-frontend` is the dev server and is untouched.)
- `publish-images.yml` + `build-multiarch-image.yml` — publish the Send backend and frontend images to GHCR as multi-arch manifest lists. No cloud credentials, no ECR/S3/ECS, deploys nothing. Moving tags (`:latest`, `:v<version>`) are applied only while the run's SHA is still the head of main, so a slow older run cannot re-point them backwards.
- An explicit `VITE_APP_ENV` / `APP_ENV`, replacing three separate URL-substring environment guesses (`lib/config.ts`, `lib/clientConfig.ts`, `apps/common/constants.ts`). An environment is now named rather than inferred from a hostname. **Fail-safe fallback:** an *undeclared* environment resolves to a non-production name (`development` in dev, `staging` in a built bundle) — never `production`, because `production` is the one value consumers act dangerously on (`background.ts` derives the Thundermail host from it). This matches the old sniffing code's failure mode, so a stale checkout whose `.env` predates `VITE_APP_ENV` keeps its non-production behaviour. The derivation shim lives once, in `scripts/derive-app-env.sh`, sourced by both build scripts; in CI an unparseable `$ENV`/`$BASE_URL` signal fails the build.
- The five sibling-service URLs are configurable. Two of them (`DASHBOARD_URL`, `CONTACT_FORM_URL`) were pinned to **production** even in stage builds; they now follow the environment.

## What does not change

- **The stage/prod deploy.** `merge.yml` and `release.yml` are not modified. Stage and prod keep reporting `staging` and `production` — `scripts/build.sh` derives `VITE_APP_ENV` from the `$ENV`/`$BASE_URL` those workflows already pass.
- **The add-on XPI (almost).** `packages/addon/src` has **zero** changes. The `/config.js` script tag is added to `packages/send/frontend/index.html` only, so on the extension entrypoints `window.__APP_CONFIG__` stays undefined and the baked `VITE_*` fallback applies as today.
  Two non-source files there do change: `scripts/build.sh` (sources the shared `VITE_APP_ENV` derivation, because `menu.ts` and `background.ts` branch on the environment — without it a stage add-on would point at production Thundermail) and `.env.sample` (documents the new vars).

## Behavior changes to be aware of

- **`extension-store.ts` bug fix (shipped XPI behavior changes):** `serverUrl.value` → `serverUrl`. Destructuring a Pinia store unwraps its refs, so the old code stored `undefined` as the cloudFile account's server URL and then wiped the config store's URL via `setServerUrl(undefined)`. The account is now configured with the real baked URL.
- **Sentry environment values are corrected.** The `environment` tag was Vite's `MODE` (`production` for *both* stage and prod), and `environmentName` was derived from a check that never fired (both were `staging`). Both now report the declared environment. Any saved Sentry search or alert keyed on the old (wrong) values needs updating at deploy time. Console-capture levels stay keyed on build mode, exactly as before — stage does **not** start shipping `console.debug` to Sentry.
- `api.ts getStorageType()` now keys on the declared environment instead of build mode, so a runtime-configured non-production container can talk to a filesystem-storage backend.

## Review notes

Worth your eyes on the `APP_ENV` naming, the non-production fallback decision, and the nginx image. `src/test/config.test.ts` (72 cases) covers the runtime-wins / empty-is-unset fallback in both directions, per-key fallback integrity (every `VITE_*` pinned to a distinct sentinel in vitest), the literal sibling-URL defaults, and the never-production fallback invariant.

A 20-lens review pass has been applied on top (commit `cd78088`): nginx hardening (`server_tokens off`, request-side unbuffering, `/style.css` proxying, pinned `nginx:1.28.3` base, minimal writable surface, HEALTHCHECK), publish-pipeline hardening (moving-tag head guard, semver validation), and the doc/test fixes above. Known accepted risks, documented in-file: a failed sibling image still publishes half a matched set under `:<sha>` (verify-matched-set makes it loud, not impossible), and `no-store` on `/config.js` + `index.html` depends on a CachingDisabled-equivalent CloudFront behaviour in platform-infrastructure.

**@aatchison has raised one security item from this area privately — please check with him before merging.**

Refs thunderbird/platform-infrastructure#886

🤖 Generated with [Claude Code](https://claude.com/claude-code)
