### PR TITLE
fix(addon): export Telemetry experiment API under its manifest key (#1108)

### DIFF
--- a/packages/addon/public/api/Telemetry/implementation.js
+++ b/packages/addon/public/api/Telemetry/implementation.js
@@ -86,5 +86,9 @@
     }
   }
 
-  exports.Telemetry = Telemetry;
+  // The exported symbol must match this module's `experiment_apis` key in
+  // manifest.json ("thundermailTelemetry") — Gecko resolves the module by that
+  // name off the sandbox global, and a mismatch throws "module is not a
+  // constructor" from ExtensionCommon.asyncGetAPI(). See bug 2055585.
+  exports.thundermailTelemetry = Telemetry;
 })(this);

--- a/packages/addon/src/test/manifest-experiment-apis.test.ts
+++ b/packages/addon/src/test/manifest-experiment-apis.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Guards `public/manifest.json`'s `experiment_apis` against drifting away from
+ * the implementation scripts and schemas it points at.
+ *
+ * Gecko resolves an experiment API module by its *manifest key*: `loadModule()`
+ * returns `this.global[key]` from the sandbox the script ran in, then
+ * `asyncGetAPI()` does `new module(extension)`. If the script exports a
+ * different symbol, that's `new undefined(...)` -- "module is not a
+ * constructor" at startup, and the parent-side implementation is never
+ * installed. The schema-generated stubs still appear on `browser`, so the
+ * add-on's own `?.` availability guards don't notice; calls just reject and the
+ * telemetry gate silently fails closed. That was bug 2055585, where
+ * `api/Telemetry/implementation.js` exported `Telemetry` while the manifest key
+ * was `thundermailTelemetry`.
+ *
+ * A schema namespace that isn't listed in `parent.paths` fails the same way
+ * from the other direction: nothing triggers the lazy parent load, so the
+ * namespace is dead. (A path with no matching namespace is harmless -- that's
+ * how startup-only APIs like ProTweaks, whose schema is empty, are declared.)
+ *
+ * Validating the source manifest covers every shipped variant: `build.sh` and
+ * the `set-*-id` scripts only rewrite ids, icons and localhost match patterns,
+ * never `experiment_apis`.
+ *
+ * See https://bugzilla.mozilla.org/show_bug.cgi?id=2055585, and
+ * `manifest-match-patterns.test.ts` for the sibling manifest guard.
+ */
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const PUBLIC_DIR = resolve(__dirname, '../../public');
+const MANIFEST_PATH = resolve(PUBLIC_DIR, 'manifest.json');
+
+type ExperimentApi = {
+  schema: string;
+  parent: { script: string; paths: string[][] };
+};
+
+const manifest = JSON.parse(readFileSync(MANIFEST_PATH, 'utf-8'));
+const apis: [string, ExperimentApi][] = Object.entries(
+  manifest.experiment_apis as Record<string, ExperimentApi>
+);
+
+describe('manifest.json experiment_apis', () => {
+  it('declares APIs to check', () => {
+    expect(apis.length).toBeGreaterThan(0);
+  });
+
+  describe.each(apis)('%s', (name, api) => {
+    it('points at an implementation script that exists', () => {
+      expect(existsSync(resolve(PUBLIC_DIR, api.parent.script))).toBe(true);
+    });
+
+    it('exports a symbol named after the manifest key', () => {
+      const source = readFileSync(
+        resolve(PUBLIC_DIR, api.parent.script),
+        'utf-8'
+      );
+      // `exports.Foo = Foo;` and `exports.Foo = class extends ...` both count.
+      expect(source).toMatch(new RegExp(`\\bexports\\.${name}\\s*=`));
+    });
+
+    it('points at a schema that exists', () => {
+      expect(existsSync(resolve(PUBLIC_DIR, api.schema))).toBe(true);
+    });
+
+    it('routes every schema namespace through parent.paths', () => {
+      const schema = JSON.parse(
+        readFileSync(resolve(PUBLIC_DIR, api.schema), 'utf-8')
+      ) as { namespace?: string }[];
+      const paths = api.parent.paths.map((path) => path.join('.'));
+
+      for (const { namespace } of schema) {
+        expect(paths).toContain(namespace);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## What changed?

One-line fix plus a regression test.

`packages/addon/public/api/Telemetry/implementation.js` now exports the API class as `thundermailTelemetry` instead of `Telemetry`, matching the module's `experiment_apis` key in `public/manifest.json`. Gecko resolves an experiment API module by its manifest key off the sandbox global — `SchemaAPIManager.loadModule()` returns `this.global[name]`, and `asyncGetAPI()` then does `new module(extension)` — so the mismatched export meant it was constructing `undefined`. Added a comment at the export explaining the coupling, since nothing else in the repo makes it visible.

New `packages/addon/src/test/manifest-experiment-apis.test.ts` guards the whole class of bug. For every `experiment_apis` entry it asserts the implementation script and schema exist, the script exports a symbol named after the manifest key, and each schema namespace is routed through `parent.paths`. It's modeled on the existing `manifest-match-patterns.test.ts` (same rationale, same shape: read the real manifest off disk and assert an invariant nothing else checks). The namespace assertion runs schema-namespace → `parent.paths` and not the reverse, because startup-only APIs like `ProTweaks` legitimately have an empty `schema.json`.

<details><summary>AI disclosure</summary>

Agent-written (Claude Opus 5) under my direction and review. I directed the investigation, chose the fix over the alternative (rewriting the manifest key + `paths` instead of the export), and decided the scope — specifically to add the build-time guard test rather than a runtime probe in `background.ts`. The root-cause trace was verified against the actual Gecko source (`ExtensionCommon.sys.mjs` `loadModule`/`asyncGetAPI`/`asyncLoadAPI`) rather than inferred. Two senior-review passes were run over the diff; the schema-existence check in the guard test came out of that review. Every claim below about test results was executed, not assumed.

</details>

## Why?

Every Thunderbird 153 user sees this in the Error Console at startup, on a clean profile, with no add-ons installed:

```
module is not a constructor ExtensionCommon.sys.mjs:1679:15
    asyncGetAPI resource://gre/modules/ExtensionCommon.sys.mjs:1679
    AsyncFunctionNext self-hosted:780
```

It was reported upstream as [bug 2055585](https://bugzilla.mozilla.org/show_bug.cgi?id=2055585), initially triaged as trivial, then traced to the `thundermail` built-in system add-on by Hartmut Welpmann (:welpy-cw) in [comment 16](https://bugzilla.mozilla.org/show_bug.cgi?id=2055585#c16). This change is his attached patch (attachment 9615926) plus the guard test.

**It isn't only console noise.** `CanOfAPIs.asyncLoadAPI()` throws before reaching `deepCopy(this.root, api.getAPI(context))`, so the parent-side implementation is never installed. The schema-generated stubs still exist in the child, so our own availability guards read as "present" and then fail:

- `initTelemetryListener()` passes its `?.onChanged?.addListener` check but registers nothing — runtime telemetry pref changes are never observed or broadcast.
- `GET_TELEMETRY_STATE`'s `isTelemetryEnabled()` call rejects and falls back to `enabled = false`.
- `isTelemetryAllowed()` in `telemetryConsent.ts` catches the rejection and returns `false`.

Both paths fail **closed**, so there is no privacy exposure — but Sentry and PostHog were effectively hard-off inside Thunderbird regardless of the user's data-reporting prefs, which defeats the point of #954. Introduced in 76646563 (#954), so v2.0.5 through v2.0.9 are affected.

## Limitations and Notes

- **This does not by itself reach TB 153 users.** The built-in is vendored in comm-central at `comm/mail/extensions/builtin-addons/thundermail/extension/`, so a separate Phabricator patch is needed there referencing bug 2055585. Tracked in #1108.
- Bug 2055585 still needs an update crediting :welpy-cw's diagnosis and answering the reporter, who has offered to help test.
- The guard test validates the source `public/manifest.json`, which covers every shipped variant: `build.sh` and the `set-*-id` scripts only rewrite ids, icons and localhost match patterns, never `experiment_apis`.
- Deliberately **not** included: a runtime probe in `background.ts` to make a broken experiment API loud. A CI-time guard catches this earlier and more cheaply, and the existing fail-closed runtime behavior is correct as-is.

### Verification

- `pnpm --filter addon test` → 26 files passed / 1 skipped, 97 tests passed / 1 skipped.
- The guard test is meaningful, not vacuous: reverting the one-line export rename makes it fail on the Telemetry entry (`1 failed | 18 passed`), and restoring the fix makes it pass again.
- eslint and prettier clean on both files.
- `pnpm --filter addon typecheck` reports the same 13 pre-existing errors as on `main`, all in unrelated files (`background.ts` `linkHandler`/`MailAccounts`, send-frontend, `sharedViteConfig.ts`); none in the files touched here.

Not yet done: an end-to-end check in a real client via `sync:builtin` + `mach build faster`. The console error's absence is the observable outcome and follows directly from the constructor now resolving, but a reviewer with a comm tree handy may want to confirm.

## Applicable Issues

Closes #1108

## Screenshots

N/A — no UI changes. Console output quoted above.
