### PR TITLE
chore(addon): pin VITE_LOGGER_LEVEL=warn in the add-on env sample

### DIFF
--- a/packages/addon/.env.sample
+++ b/packages/addon/.env.sample
@@ -40,8 +40,10 @@ VITE_OIDC_ROOT_URL=
 VITE_OIDC_CLIENT_ID=
 
 # Console log level for the add-on's own logger (src/lib/logger.ts) and the
-# bundled Send SPA (debug | info | warn | error; default warn).
-VITE_LOGGER_LEVEL=
+# bundled Send SPA (debug | info | warn | error). Both fall back to `warn` when
+# this is unset, so it is pinned here to keep a bootstrapped .env explicit
+# rather than relying on that fallback.
+VITE_LOGGER_LEVEL=warn
 
 # Self-uninstall cutoff for the legacy AMO add-on (src/selfUninstall.ts).
 # Unset means the self-uninstall check is skipped.
@@ -54,4 +56,3 @@ VITE_SENTRY_DSN=
 # Posthog
 VITE_POSTHOG_PROJECT_KEY=
 VITE_POSTHOG_HOST=
-


### PR DESCRIPTION
## What changed?

One line in `packages/addon/.env.sample`: `VITE_LOGGER_LEVEL=` is now `VITE_LOGGER_LEVEL=warn`, with the surrounding comment reworded to say the value is pinned rather than left to the code fallback.

**AI disclosure:** Investigated and written by Claude (agentic), with the author directing the scope, re-reading the issue, and cutting the change down to the add-on after reviewing the findings. The validation below was carried out by the agent and reviewed by the author.

## Why?

The add-on's effective log level is *already* `warn` everywhere. Both loggers it loads fall back to `warn` when `VITE_LOGGER_LEVEL` is unset:

- **background script** — `packages/addon/src/background.ts` imports `./lib/logger`, whose `getConfiguredLevel()` returns `LOG_LEVELS.warn` for an unset, empty, or unrecognized value.
- **extension and management pages** — `src/apps/extension.js` and `src/apps/management.js` import `send-frontend/src/apps/send/setup`, and `setup.js` begins with `import '@send-frontend/lib/logger'`, which has the same fallback.

Nothing overrides it: neither `packages/addon/scripts/build.sh` nor the `(Addon) Create .env file from secrets` step in `.github/workflows/merge.yml` writes `VITE_LOGGER_LEVEL`, so the stage and prod XPIs already run at `warn`.

The sample was the one place that didn't say so, and it disagreed with `packages/send/frontend/.env.sample`, which pins `warn` explicitly. This aligns the two so a `.env` bootstrapped from the sample states the level outright.

## Limitations and Notes

- **No runtime behaviour change.** The effective level is `warn` before and after. This makes an existing implicit default explicit; it does not quiet anything that was previously noisy.
- **Scope was cut back deliberately.** Issue #1110 also asked for a `LOG_LEVEL` knob on the Send backend, rewriting `packages/send/backend/src/utils/logger.ts` around the same threshold map and gating `warn`/`error` on it. That is no longer wanted — the backend's existing `NODE_ENV === 'production'` gate stays as is — so this PR touches the add-on only and the backend is untouched. #1110 needs its scope amended to match, or closing in favour of a narrower issue.
- A separate, unrelated nit found while working here and **not** included: `packages/send/backend/vitest.config.js` doesn't exclude `**/.docker-build/**`, so when a local docker build has been run, `vitest` collects 14 duplicate test files from that gitignored snapshot and runs them against stale code. Worth its own one-line PR.
- Verified by `pnpm exec vitest run` in `packages/addon`: 97 passed, 1 skipped. The default is directly covered by `src/test/logger.test.ts` — "is suppressed at the default warn level" for both `debug` and `log`/`info`.

## Applicable Issues

Refs #1110 (partial — add-on portion only; see Limitations)

## Screenshots

Not applicable; no UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
