### PR TITLE
fix(addon): stop rebuilding the Pro menu on every login check

### DIFF
--- a/packages/addon/public/api/TBProMenu/implementation.js
+++ b/packages/addon/public/api/TBProMenu/implementation.js
@@ -129,7 +129,13 @@
       }
     });
 
+    // We hang the button off a node owned by Thunderbird's app menu. If that
+    // node ever moves or is renamed we have nowhere to put the button, so bail
+    // out instead of throwing from a window listener.
     const banner = window.document.getElementById('appMenu-addon-banners');
+    if (!banner) {
+      return null;
+    }
     banner.parentNode.insertBefore(toolbarButton, banner.nextSibling);
 
     return toolbarButton;
@@ -175,6 +181,12 @@
       const parentToolbarItem = document.getElementById(
         'tbpro-menu-id-' + parentId
       );
+      // The caller validated the parent against gMenuItems, which is global,
+      // while this lookup is per window. A window that never got the parent
+      // rendered simply has nothing to attach to.
+      if (!parentToolbarItem) {
+        return;
+      }
 
       let submenu;
       if (!parentToolbarItem.classList.contains('subviewbutton-nav')) {
@@ -214,6 +226,9 @@
       }
     } else {
       const menuItem = _getRootButton(window, extension, id);
+      if (!menuItem) {
+        return;
+      }
       menuItem.querySelector('.tbpro-menu-item-text').textContent = title;
       menuItem.querySelector('.tbpro-menu-item-bold-text').textContent =
         secondaryTitle;
@@ -234,8 +249,12 @@
   function _updateMenuItem(window, id, { title, secondaryTitle, tooltip }) {
     const document = window.document;
     const menuItem = document.getElementById('tbpro-menu-id-' + id);
+    // Callers reach this once per open mail window, and the public update() has
+    // already rejected ids it does not know about. A window that has not
+    // rendered the item is skipped -- throwing here would abandon the windows
+    // further down the list half updated.
     if (!menuItem) {
-      throw new ExtensionError('Could not find item ' + id);
+      return;
     }
 
     if (menuItem.classList.contains('tbpro-header-button')) {
@@ -405,7 +424,10 @@
       });
     }
 
-    window.document.querySelector(`#${menuId} vbox`).appendChild(button);
+    const container = window.document.querySelector(`#${menuId} vbox`);
+    if (container) {
+      container.appendChild(button);
+    }
   }
 
   /**
@@ -522,10 +544,6 @@
           }
         }
       }
-
-      // Flush all caches. Enable this only for debugging
-      // TODO disable
-      Services.obs.notifyObservers(null, 'startupcache-invalidate');
     }
 
     getAPI(context) {
@@ -605,18 +623,23 @@
                 menu.parentNode.querySelectorAll('.tbpro-menu-button').length <
                 2
               ) {
+                // Last item in the submenu: turn its parent back into a plain
+                // button. If we cannot identify that parent there is nothing to
+                // turn back, so leave it alone.
                 const subview = menu.parentNode.closest('.tbpro-panel-subview');
                 const parentId = subview?.id.substring(22);
-                const parentButton = document.getElementById(
-                  'tbpro-menu-id-' + parentId
-                );
-                parentButton.classList.remove('subviewbutton-nav');
-                parentButton.setAttribute('closemenu', '');
-                parentButton.removeAttribute('oncommand');
+                const parentButton = parentId
+                  ? document.getElementById('tbpro-menu-id-' + parentId)
+                  : null;
+                if (parentButton) {
+                  parentButton.classList.remove('subviewbutton-nav');
+                  parentButton.setAttribute('closemenu', '');
+                  parentButton.removeAttribute('oncommand');
+                }
               }
 
               menu.remove();
-              document.querySelector('#appMenu-multiView').goBack?.();
+              document.querySelector('#appMenu-multiView')?.goBack?.();
             });
           },
 
@@ -631,9 +654,13 @@
             item.children = [];
 
             _applyForWindows((window, document) => {
+              // Reached on every sign-out, so it must not throw for a window
+              // that never rendered the item.
               const parent = document.getElementById('tbpro-menu-id-' + id);
-              parent.classList.remove('subviewbutton-nav');
-              parent.removeAttribute('oncommand');
+              if (parent) {
+                parent.classList.remove('subviewbutton-nav');
+                parent.removeAttribute('oncommand');
+              }
               document.getElementById('appMenu-tbpro-submenu-' + id)?.remove();
             });
           },

--- a/packages/addon/public/api/TBProMenu/implementation.js
+++ b/packages/addon/public/api/TBProMenu/implementation.js
@@ -129,11 +129,14 @@
       }
     });
 
-    // We hang the button off a node owned by Thunderbird's app menu. If that
-    // node ever moves or is renamed we have nowhere to put the button, so bail
-    // out instead of throwing from a window listener.
+    // We hang the button off a node owned by Thunderbird's app menu. Losing that
+    // node means we cannot render the Pro menu at all, so say so -- silence here
+    // would look identical to the add-on simply not being installed.
     const banner = window.document.getElementById('appMenu-addon-banners');
     if (!banner) {
+      console.warn(
+        'TBProMenu: no #appMenu-addon-banners to anchor to; the Thunderbird Pro menu will not appear in this window.'
+      );
       return null;
     }
     banner.parentNode.insertBefore(toolbarButton, banner.nextSibling);
@@ -424,10 +427,7 @@
       });
     }
 
-    const container = window.document.querySelector(`#${menuId} vbox`);
-    if (container) {
-      container.appendChild(button);
-    }
+    window.document.querySelector(`#${menuId} vbox`).appendChild(button);
   }
 
   /**
@@ -628,9 +628,9 @@
                 // turn back, so leave it alone.
                 const subview = menu.parentNode.closest('.tbpro-panel-subview');
                 const parentId = subview?.id.substring(22);
-                const parentButton = parentId
-                  ? document.getElementById('tbpro-menu-id-' + parentId)
-                  : null;
+                const parentButton = document.getElementById(
+                  'tbpro-menu-id-' + parentId
+                );
                 if (parentButton) {
                   parentButton.classList.remove('subviewbutton-nav');
                   parentButton.setAttribute('closemenu', '');
@@ -639,7 +639,7 @@
               }
 
               menu.remove();
-              document.querySelector('#appMenu-multiView')?.goBack?.();
+              document.querySelector('#appMenu-multiView').goBack?.();
             });
           },
 
@@ -654,8 +654,6 @@
             item.children = [];
 
             _applyForWindows((window, document) => {
-              // Reached on every sign-out, so it must not throw for a window
-              // that never rendered the item.
               const parent = document.getElementById('tbpro-menu-id-' + id);
               if (parent) {
                 parent.classList.remove('subviewbutton-nav');

--- a/packages/addon/src/menu.ts
+++ b/packages/addon/src/menu.ts
@@ -27,6 +27,31 @@ export type MenuAction = (typeof MENU_ACTIONS)[keyof typeof MENU_ACTIONS];
 let loginTabId = null;
 
 /**
+ * The username the app menu is currently rendered for, or null when the menu is
+ * in its signed-out state.
+ *
+ * getLoginState() runs every 60 seconds (and on every Send route change), and it
+ * calls menuLoggedIn() to keep the menu in step with the stored session.
+ * TBProMenu.create() rejects an id that already exists, so rebuilding the
+ * submenu on every tick threw "Menu item manageDashboard already exists" once a
+ * minute -- which getLoginState() then mistook for a failed session read and
+ * reported as signed out (see #1120). Tracking what the menu already shows means
+ * we only touch it when the signed-in state actually changed.
+ */
+let menuUsername: string | null = null;
+
+/**
+ * The menu rebuild currently in flight, or null when none is running.
+ *
+ * Sign-in arrives from several directions at once -- init() starts a login check
+ * without waiting for it while background's main() awaits its own, and the
+ * sign-in message handlers call menuLoggedIn() directly -- so two callers can
+ * find the menu unbuilt at the same moment. They share one rebuild rather than
+ * both adding the same items and colliding.
+ */
+let menuBuild: Promise<void> | null = null;
+
+/**
  * Opens the login page in a new tab when user clicks the root menu item.
  * Includes extension flag to enable proper authentication flow.
  */
@@ -67,12 +92,33 @@ type Args = {
  * Shows username and adds menu items for managing dashboard, Send, and logout.
  */
 export async function menuLoggedIn({ username }: Args) {
+  // The menu already shows this user; there is nothing to rebuild.
+  if (menuUsername === username) {
+    return;
+  }
+
+  if (!menuBuild) {
+    menuBuild = buildSignedInMenu(username).finally(() => {
+      menuBuild = null;
+    });
+  }
+
+  await menuBuild;
+}
+
+async function buildSignedInMenu(username: string) {
   // Update root menu to display username instead of sign-in prompt
   await browser.TBProMenu.update(MENU_ACTIONS.ROOT, {
     title: '',
     secondaryTitle: username,
     tooltip: browser.i18n.getMessage('menuSignedInTooltip'),
   });
+
+  // Start from an empty submenu. The items below belong to whoever is signed in,
+  // so anything left over -- from a different account, or from a rebuild that
+  // failed part way through -- has to go before we re-add them. clear() on a
+  // root with no children is a no-op, so this is safe on a first sign-in too.
+  await browser.TBProMenu.clear(MENU_ACTIONS.ROOT);
 
   // Add submenu item to access Thunderbird Pro account dashboard
   await browser.TBProMenu.create(MENU_ACTIONS.MANAGE_DASHBOARD, {
@@ -96,6 +142,10 @@ export async function menuLoggedIn({ username }: Args) {
     title: browser.i18n.getMessage('menuSignout'),
     parentId: MENU_ACTIONS.ROOT,
   });
+
+  // Only claim the menu is built once every item is in place, so a failure part
+  // way through is retried on the next check rather than left half-finished.
+  menuUsername = username;
 }
 
 /**
@@ -114,6 +164,10 @@ export async function menuLogout() {
   // Clear menu items
   console.log('🧹 Clearing menu items and storage');
   await browser.TBProMenu.clear('root');
+
+  // The menu is back to its signed-out state, so the next sign-in has to rebuild
+  // the submenu from scratch.
+  menuUsername = null;
 
   // Full wipe of the add-on's storage to a clean, logged-out state.
   //
@@ -185,28 +239,40 @@ async function closeAllAddOnTabs() {
   SIGN_OUT message path, which calls menuLogout().
  */
 export async function getLoginState() {
+  let auth;
   try {
     // Get the auth token from browser storage (this is a copy of the auth token stored in the web context, used to determine login state in the add-on context)
     const authStorageData = await browser.storage.local.get(STORAGE_KEY_AUTH);
-    const auth = authStorageData[STORAGE_KEY_AUTH];
-    if (!auth) {
-      return { isLoggedIn: false, username: null };
-    }
-
-    const username = auth?.profile?.preferred_username || auth?.profile?.email;
-
-    // A stored session with a refresh_token is logged in, even if the access
-    // token's expires_at has lapsed — the web app will silently refresh it.
-    if (auth.refresh_token && username) {
-      await menuLoggedIn({ username });
-      return { isLoggedIn: true, username };
-    }
-
-    return { isLoggedIn: false, username: null };
+    auth = authStorageData[STORAGE_KEY_AUTH];
   } catch (error) {
     console.error('Error retrieving auth state from storage:', error);
     return { isLoggedIn: false, username: null };
   }
+
+  if (!auth) {
+    return { isLoggedIn: false, username: null };
+  }
+
+  const username = auth?.profile?.preferred_username || auth?.profile?.email;
+
+  // A stored session with a refresh_token is logged in, even if the access
+  // token's expires_at has lapsed — the web app will silently refresh it.
+  if (!auth.refresh_token || !username) {
+    return { isLoggedIn: false, username: null };
+  }
+
+  // Keeping the app menu in step is a display concern, and it is deliberately
+  // outside the try/catch above: a menu that fails to update does not end the
+  // session, so callers (the Send route guard) must never be told we are signed
+  // out because of it. Reporting a live session as signed out was the visible
+  // half of #1120.
+  try {
+    await menuLoggedIn({ username });
+  } catch (error) {
+    console.error('Could not update the Thunderbird Pro menu:', error);
+  }
+
+  return { isLoggedIn: true, username };
 }
 
 export async function closeLoginTab() {

--- a/packages/addon/src/menu.ts
+++ b/packages/addon/src/menu.ts
@@ -41,15 +41,26 @@ let loginTabId = null;
 let menuUsername: string | null = null;
 
 /**
- * The menu rebuild currently in flight, or null when none is running.
+ * Tail of the menu work queue.
  *
- * Sign-in arrives from several directions at once -- init() starts a login check
- * without waiting for it while background's main() awaits its own, and the
- * sign-in message handlers call menuLoggedIn() directly -- so two callers can
- * find the menu unbuilt at the same moment. They share one rebuild rather than
- * both adding the same items and colliding.
+ * Sign-in and sign-out both arrive from several directions at once: init() starts
+ * a login check without waiting for it while background's main() awaits its own,
+ * the sign-in message handlers call menuLoggedIn() directly, and the user can
+ * click Log out at any moment. Letting those overlap meant a sign-out could
+ * finish in the middle of a sign-in rebuild -- leaving a menu that showed the
+ * sign-in prompt above a fully populated signed-in submenu, with menuUsername
+ * claiming a user who was no longer signed in. Serializing every menu update
+ * through this queue keeps the menu and menuUsername in step.
  */
-let menuBuild: Promise<void> | null = null;
+let menuQueue: Promise<unknown> = Promise.resolve();
+
+function queueMenuWork<T>(work: () => Promise<T>): Promise<T> {
+  const run = menuQueue.then(work);
+  // The tail must never be a rejected promise, or one failed update would block
+  // every menu update after it. Callers still see their own rejection via `run`.
+  menuQueue = run.catch(() => {});
+  return run;
+}
 
 /**
  * Opens the login page in a new tab when user clicks the root menu item.
@@ -92,18 +103,15 @@ type Args = {
  * Shows username and adds menu items for managing dashboard, Send, and logout.
  */
 export async function menuLoggedIn({ username }: Args) {
-  // The menu already shows this user; there is nothing to rebuild.
-  if (menuUsername === username) {
-    return;
-  }
+  await queueMenuWork(async () => {
+    // Checked inside the queue, not before it: by the time our turn comes an
+    // earlier caller may have already rendered this user, or signed them out.
+    if (menuUsername === username) {
+      return;
+    }
 
-  if (!menuBuild) {
-    menuBuild = buildSignedInMenu(username).finally(() => {
-      menuBuild = null;
-    });
-  }
-
-  await menuBuild;
+    await buildSignedInMenu(username);
+  });
 }
 
 async function buildSignedInMenu(username: string) {
@@ -154,20 +162,21 @@ async function buildSignedInMenu(username: string) {
  * Also clears all localStorage and extension storage data.
  */
 export async function menuLogout() {
-  // Reset menu to display sign-in prompt
-  await browser.TBProMenu.update(MENU_ACTIONS.ROOT, {
-    title: browser.i18n.getMessage('menuSignInTo'),
-    secondaryTitle: browser.i18n.getMessage('thunderbirdPro'),
-    tooltip: '',
-  });
-
-  // Clear menu items
   console.log('🧹 Clearing menu items and storage');
-  await browser.TBProMenu.clear('root');
+  await queueMenuWork(async () => {
+    // Dropped before the teardown, the mirror of buildSignedInMenu() committing
+    // it after the build: if either call below fails the menu is in an unknown
+    // state, and the next sign-in has to rebuild it rather than trust it.
+    menuUsername = null;
 
-  // The menu is back to its signed-out state, so the next sign-in has to rebuild
-  // the submenu from scratch.
-  menuUsername = null;
+    // Reset menu to display sign-in prompt, then clear the submenu items.
+    await browser.TBProMenu.update(MENU_ACTIONS.ROOT, {
+      title: browser.i18n.getMessage('menuSignInTo'),
+      secondaryTitle: browser.i18n.getMessage('thunderbirdPro'),
+      tooltip: '',
+    });
+    await browser.TBProMenu.clear(MENU_ACTIONS.ROOT);
+  });
 
   // Full wipe of the add-on's storage to a clean, logged-out state.
   //

--- a/packages/addon/src/test/integration/c2-reenable-trusts-stale-auth.test.ts
+++ b/packages/addon/src/test/integration/c2-reenable-trusts-stale-auth.test.ts
@@ -60,17 +60,13 @@ describe('C2: add-on re-enable trusts stale STORAGE_KEY_AUTH without backend rev
     // the add-on's background page re-runs main() from scratch.
     await import('../../background');
 
-    // Let main()'s async IIFE (checkAndUninstallIfDeprecated -> initMenu ->
-    // getLoginState -> initCloudFile chain) fully settle. Yielding to a timer
-    // drains every pending microtask, so this does not have to be kept in step
-    // with how many awaits that chain happens to contain.
-    await new Promise((resolve) => setTimeout(resolve, 0));
-
     // THE BUG: getLoginState() trusted the stale refresh_token's mere
     // presence and returned isLoggedIn: true purely from local storage, so
     // shouldInitCloudFileOnStartup() green-lit initCloudFile(), which:
     //   1. re-registered the cloud file provider,
-    expect(ctx.browser.CloudFileAccounts.registerProvider).toHaveBeenCalled();
+    await vi.waitFor(() =>
+      expect(ctx.browser.CloudFileAccounts.registerProvider).toHaveBeenCalled()
+    );
     //   2. created/reactivated a cloud file account,
     expect(ctx.browser.CloudFileAccounts.createAccount).toHaveBeenCalled();
 

--- a/packages/addon/src/test/integration/c2-reenable-trusts-stale-auth.test.ts
+++ b/packages/addon/src/test/integration/c2-reenable-trusts-stale-auth.test.ts
@@ -61,11 +61,10 @@ describe('C2: add-on re-enable trusts stale STORAGE_KEY_AUTH without backend rev
     await import('../../background');
 
     // Let main()'s async IIFE (checkAndUninstallIfDeprecated -> initMenu ->
-    // getLoginState -> initCloudFile chain) fully settle.
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
+    // getLoginState -> initCloudFile chain) fully settle. Yielding to a timer
+    // drains every pending microtask, so this does not have to be kept in step
+    // with how many awaits that chain happens to contain.
+    await new Promise((resolve) => setTimeout(resolve, 0));
 
     // THE BUG: getLoginState() trusted the stale refresh_token's mere
     // presence and returned isLoggedIn: true purely from local storage, so

--- a/packages/addon/src/test/integration/fakeThunderbirdHost.ts
+++ b/packages/addon/src/test/integration/fakeThunderbirdHost.ts
@@ -299,12 +299,33 @@ export function createFakeThunderbirdHost(): FakeHost {
         unregisterProvider: vi.fn(async () => {}),
         createAccount: vi.fn(async () => ({ accountId: 'acct-1' })),
       },
-      TBProMenu: {
-        create: vi.fn(async () => {}),
-        update: vi.fn(async () => {}),
-        clear: vi.fn(async () => {}),
-        onClicked: { addListener: vi.fn() },
-      },
+      // The one piece of real behavior these spies need: the experiment API
+      // rejects a create() for an id that already exists, and that rejection is
+      // what #1120 was made of. Spies that always resolved could not reproduce
+      // it, so any caller that re-adds a menu item now fails here too.
+      TBProMenu: (() => {
+        const parents = new Map<string, string | undefined>();
+        return {
+          create: vi.fn(async (id: string, props?: { parentId?: string }) => {
+            if (parents.has(id)) {
+              throw new Error(`Menu item ${id} already exists`);
+            }
+            parents.set(id, props?.parentId);
+          }),
+          update: vi.fn(async () => {}),
+          // clear() drops an item's children and keeps the item itself. Unknown
+          // ids are tolerated: specs that drive menuLogout() directly never ran
+          // init(), so they have no root registered here.
+          clear: vi.fn(async (id: string) => {
+            for (const [child, parentId] of parents) {
+              if (parentId === id) {
+                parents.delete(child);
+              }
+            }
+          }),
+          onClicked: { addListener: vi.fn() },
+        };
+      })(),
       MailAccounts: {
         createAccount: vi.fn(async () => ({ success: true })),
         setToken: vi.fn(async () => ({ success: true })),
@@ -336,9 +357,7 @@ export function createFakeThunderbirdHost(): FakeHost {
       onWindowRemovedListeners,
       onStorageChangedListeners,
       deliverMessage: async (message: any, sender?: any) => {
-        return Promise.all(
-          onMessageListeners.map((fn) => fn(message, sender))
-        );
+        return Promise.all(onMessageListeners.map((fn) => fn(message, sender)));
       },
       triggerFileUpload: async (fileInfo) => {
         const results = onFileUploadListeners.map((fn) =>

--- a/packages/addon/src/test/menu.test.ts
+++ b/packages/addon/src/test/menu.test.ts
@@ -2,6 +2,8 @@ import { BASE_URL } from '@send-frontend/apps/common/constants';
 import { STORAGE_KEY_AUTH } from '@send-frontend/lib/const';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+// Safe to import statically: MENU_ACTIONS is frozen string constants, so it
+// carries none of the module state that loadMenu() exists to reset.
 import { MENU_ACTIONS } from '../menu';
 
 /**
@@ -15,6 +17,30 @@ async function loadMenu() {
 }
 
 const mockOf = (fn: unknown) => fn as ReturnType<typeof vi.fn>;
+
+/**
+ * Holds the menu's first update() call open, so a test can land a second caller
+ * squarely in the middle of a rebuild.
+ */
+function holdFirstMenuUpdate() {
+  let release: () => void;
+  const held = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  mockOf(browser.TBProMenu.update).mockImplementationOnce(() => held);
+  return () => release();
+}
+
+// Array.prototype.at is outside this package's TS lib target, hence the indexing.
+const lastCallProps = (fn: unknown) => {
+  const { calls } = mockOf(fn).mock;
+  return calls[calls.length - 1]?.[1];
+};
+
+const lastCallOrder = (fn: unknown) => {
+  const { invocationCallOrder } = mockOf(fn).mock;
+  return invocationCallOrder[invocationCallOrder.length - 1];
+};
 
 /**
  * Regression guard: getLoginState() is a read-only probe (called by the Send
@@ -326,6 +352,77 @@ describe('menu upkeep during repeated login checks', () => {
     // Signing out empties the submenu, so the next sign-in has to put it back.
     expect(browser.TBProMenu.create).toHaveBeenCalledTimes(
       SIGNED_IN_MENU_ITEMS
+    );
+  });
+});
+
+/**
+ * Sign-in and sign-out reach the menu from several directions at once -- the 60s
+ * timer, the Send route guard, background's sign-in message handlers, and the
+ * Logout menu item -- so they can interleave. Whatever order they arrive in, the
+ * menu and the "who is this rendered for?" bookkeeping have to agree afterwards,
+ * because a mismatch is not self-correcting: getLoginState() stops touching the
+ * menu once it believes the user is signed out.
+ */
+describe('overlapping sign-in and sign-out', () => {
+  it('ends up signed out when a sign-out lands mid-rebuild', async () => {
+    setupBrowserMock(authWith());
+    const { menuLoggedIn, menuLogout } = await loadMenu();
+    const release = holdFirstMenuUpdate();
+
+    const signIn = menuLoggedIn({ username: USERNAME });
+    const signOut = menuLogout();
+    release();
+    await Promise.all([signIn, signOut]);
+
+    // The sign-out came last, so the menu must be left showing the sign-in
+    // prompt -- not that prompt sitting above a populated signed-in submenu.
+    expect(lastCallProps(browser.TBProMenu.update)).toMatchObject({
+      secondaryTitle: 'thunderbirdPro',
+    });
+    expect(lastCallOrder(browser.TBProMenu.clear)).toBeGreaterThan(
+      lastCallOrder(browser.TBProMenu.create)
+    );
+  });
+
+  it('still rebuilds when the same user signs back in after that', async () => {
+    setupBrowserMock(authWith());
+    const { menuLoggedIn, menuLogout } = await loadMenu();
+    const release = holdFirstMenuUpdate();
+
+    const signIn = menuLoggedIn({ username: USERNAME });
+    const signOut = menuLogout();
+    release();
+    await Promise.all([signIn, signOut]);
+    mockOf(browser.TBProMenu.create).mockClear();
+
+    await menuLoggedIn({ username: USERNAME });
+
+    // The interleaved sign-out must not leave the menu convinced it is already
+    // rendered for this user; that would strand it in the signed-out state until
+    // Thunderbird restarted.
+    expect(browser.TBProMenu.create).toHaveBeenCalledTimes(
+      SIGNED_IN_MENU_ITEMS
+    );
+  });
+
+  it('shows the second account when two different sign-ins overlap', async () => {
+    setupBrowserMock(authWith());
+    const { menuLoggedIn } = await loadMenu();
+    const release = holdFirstMenuUpdate();
+
+    const alice = menuLoggedIn({ username: 'alice@example.com' });
+    const bob = menuLoggedIn({ username: 'bob@example.com' });
+    release();
+    await Promise.all([alice, bob]);
+
+    // Bob's caller must not piggyback on Alice's rebuild and report success
+    // while the menu still shows Alice.
+    expect(lastCallProps(browser.TBProMenu.update)).toMatchObject({
+      secondaryTitle: 'bob@example.com',
+    });
+    expect(browser.TBProMenu.create).toHaveBeenCalledTimes(
+      SIGNED_IN_MENU_ITEMS * 2
     );
   });
 });

--- a/packages/addon/src/test/menu.test.ts
+++ b/packages/addon/src/test/menu.test.ts
@@ -2,7 +2,19 @@ import { BASE_URL } from '@send-frontend/apps/common/constants';
 import { STORAGE_KEY_AUTH } from '@send-frontend/lib/const';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { getLoginState, menuLogout } from '../menu';
+import { MENU_ACTIONS } from '../menu';
+
+/**
+ * menu.ts remembers which user the app menu is currently rendered for, so each
+ * test needs a module with that state freshly zeroed rather than whatever the
+ * previous test left behind.
+ */
+async function loadMenu() {
+  vi.resetModules();
+  return import('../menu');
+}
+
+const mockOf = (fn: unknown) => fn as ReturnType<typeof vi.fn>;
 
 /**
  * Regression guard: getLoginState() is a read-only probe (called by the Send
@@ -70,6 +82,8 @@ describe('getLoginState', () => {
   it('reports logged out and closes no tabs when no auth is stored', async () => {
     setupBrowserMock(undefined);
 
+    const { getLoginState } = await loadMenu();
+
     const state = await getLoginState();
 
     expect(state).toEqual({ isLoggedIn: false, username: null });
@@ -78,6 +92,8 @@ describe('getLoginState', () => {
 
   it('stays logged in WITHOUT closing tabs when the access token has expired', async () => {
     setupBrowserMock(authWith({ expires_at: PAST }));
+
+    const { getLoginState } = await loadMenu();
 
     const state = await getLoginState();
 
@@ -90,6 +106,8 @@ describe('getLoginState', () => {
   it('reports logged in for a stored session with a valid token', async () => {
     setupBrowserMock(authWith());
 
+    const { getLoginState } = await loadMenu();
+
     const state = await getLoginState();
 
     expect(state).toEqual({ isLoggedIn: true, username: USERNAME });
@@ -101,6 +119,8 @@ describe('getLoginState', () => {
       authWith({ profile: { email: USERNAME }, expires_at: PAST })
     );
 
+    const { getLoginState } = await loadMenu();
+
     const state = await getLoginState();
 
     expect(state).toEqual({ isLoggedIn: true, username: USERNAME });
@@ -108,6 +128,8 @@ describe('getLoginState', () => {
 
   it('reports logged out when the stored session has no refresh_token', async () => {
     setupBrowserMock(authWith({ refresh_token: undefined }));
+
+    const { getLoginState } = await loadMenu();
 
     const state = await getLoginState();
 
@@ -132,6 +154,8 @@ describe('menuLogout', () => {
       { id: 5, url: undefined },
     ]);
 
+    const { menuLogout } = await loadMenu();
+
     await menuLogout();
 
     expect(browser.tabs.remove).toHaveBeenCalledWith(1);
@@ -143,6 +167,8 @@ describe('menuLogout', () => {
 
   it('opens the logout page and clears storage after closing tabs', async () => {
     setupBrowserMock(undefined, [{ id: 1, url: `${BASE_URL}/send` }]);
+
+    const { menuLogout } = await loadMenu();
 
     await menuLogout();
 
@@ -158,10 +184,8 @@ describe('menuLogout', () => {
     // Order is load-bearing: the freshly opened /logout tab also matches
     // startsWith(BASE_URL), so tabs must be closed BEFORE it is created or it
     // would be swept up and logout would break.
-    const removeOrder = (browser.tabs.remove as ReturnType<typeof vi.fn>).mock
-      .invocationCallOrder[0];
-    const createOrder = (browser.tabs.create as ReturnType<typeof vi.fn>).mock
-      .invocationCallOrder[0];
+    const removeOrder = mockOf(browser.tabs.remove).mock.invocationCallOrder[0];
+    const createOrder = mockOf(browser.tabs.create).mock.invocationCallOrder[0];
     expect(removeOrder).toBeLessThan(createOrder);
   });
 
@@ -170,9 +194,11 @@ describe('menuLogout', () => {
       { id: 1, url: `${BASE_URL}/a` },
       { id: 2, url: `${BASE_URL}/b` },
     ]);
-    (browser.tabs.remove as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+    mockOf(browser.tabs.remove).mockRejectedValueOnce(
       new Error('cannot remove')
     );
+
+    const { menuLogout } = await loadMenu();
 
     await menuLogout();
 
@@ -180,5 +206,126 @@ describe('menuLogout', () => {
     expect(browser.tabs.create).toHaveBeenCalledWith({
       url: `${BASE_URL}/logout`,
     });
+  });
+});
+
+/**
+ * Regression guard for #1120. getLoginState() runs every 60 seconds and on every
+ * Send route change, and it asks menuLoggedIn() to keep the app menu in step.
+ * TBProMenu.create() rejects an id that already exists, so rebuilding the
+ * submenu on every one of those calls threw "Menu item manageDashboard already
+ * exists" once a minute -- and the old code caught that alongside a genuine
+ * storage failure, so a signed-in user was reported as signed out.
+ */
+const SIGNED_IN_MENU_ITEMS = 4;
+
+const createsFor = (action: string) =>
+  mockOf(browser.TBProMenu.create).mock.calls.filter(([id]) => id === action)
+    .length;
+
+describe('menu upkeep during repeated login checks', () => {
+  it('builds the signed-in submenu once, not on every check', async () => {
+    setupBrowserMock(authWith());
+    const { getLoginState } = await loadMenu();
+
+    await getLoginState();
+    expect(browser.TBProMenu.create).toHaveBeenCalledTimes(
+      SIGNED_IN_MENU_ITEMS
+    );
+
+    // Three more probes, standing in for the next three minutes of the timer.
+    for (let i = 0; i < 3; i++) {
+      const state = await getLoginState();
+      expect(state).toEqual({ isLoggedIn: true, username: USERNAME });
+    }
+
+    // Nothing was re-added, so there is nothing to collide with and nothing to log.
+    expect(browser.TBProMenu.create).toHaveBeenCalledTimes(
+      SIGNED_IN_MENU_ITEMS
+    );
+  });
+
+  it('builds the submenu once when two login checks overlap', async () => {
+    setupBrowserMock(authWith());
+    const { getLoginState } = await loadMenu();
+
+    // init() fires a login check without waiting for it while background's
+    // main() awaits its own, so the very first two checks genuinely overlap.
+    const states = await Promise.all([getLoginState(), getLoginState()]);
+
+    expect(states).toEqual([
+      { isLoggedIn: true, username: USERNAME },
+      { isLoggedIn: true, username: USERNAME },
+    ]);
+    expect(browser.TBProMenu.create).toHaveBeenCalledTimes(
+      SIGNED_IN_MENU_ITEMS
+    );
+  });
+
+  it('empties the submenu before adding the signed-in items', async () => {
+    setupBrowserMock(authWith());
+    const { getLoginState } = await loadMenu();
+
+    await getLoginState();
+
+    // Order is load-bearing: clearing after the items were added would wipe them.
+    expect(browser.TBProMenu.clear).toHaveBeenCalledWith(MENU_ACTIONS.ROOT);
+    expect(
+      mockOf(browser.TBProMenu.clear).mock.invocationCallOrder[0]
+    ).toBeLessThan(
+      mockOf(browser.TBProMenu.create).mock.invocationCallOrder[0]
+    );
+  });
+
+  it('reports the session as live even when the menu cannot be updated', async () => {
+    setupBrowserMock(authWith());
+    const { getLoginState } = await loadMenu();
+    mockOf(browser.TBProMenu.create).mockRejectedValueOnce(
+      new Error('Menu item manageDashboard already exists')
+    );
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const state = await getLoginState();
+
+    // The stored session is untouched by a menu problem, so the Send route guard
+    // must not be told the user is signed out.
+    expect(state).toEqual({ isLoggedIn: true, username: USERNAME });
+  });
+
+  it('retries the submenu on the next check after a partial failure', async () => {
+    setupBrowserMock(authWith());
+    const { getLoginState } = await loadMenu();
+    mockOf(browser.TBProMenu.create).mockRejectedValueOnce(
+      new Error('menu is having a bad day')
+    );
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await getLoginState();
+    expect(createsFor(MENU_ACTIONS.MANAGE_DASHBOARD)).toBe(1);
+
+    await getLoginState();
+
+    // A half-built menu is not treated as done, so the next check finishes it.
+    expect(createsFor(MENU_ACTIONS.MANAGE_DASHBOARD)).toBe(2);
+    expect(browser.TBProMenu.create).toHaveBeenCalledWith(
+      MENU_ACTIONS.LOGOUT,
+      expect.anything()
+    );
+  });
+
+  it('rebuilds the submenu when a user signs in again after signing out', async () => {
+    setupBrowserMock(authWith());
+    const { getLoginState, menuLogout } = await loadMenu();
+
+    await getLoginState();
+    await menuLogout();
+    mockOf(browser.TBProMenu.create).mockClear();
+
+    await getLoginState();
+
+    // Signing out empties the submenu, so the next sign-in has to put it back.
+    expect(browser.TBProMenu.create).toHaveBeenCalledTimes(
+      SIGNED_IN_MENU_ITEMS
+    );
   });
 });


### PR DESCRIPTION
## What changed?

The add-on now keeps track of which user its Thunderbird Pro menu is showing, and only rebuilds that menu when the answer actually changes. Before this, the once-a-minute sign-in check tried to rebuild the menu on every single run.

Four parts:

1. **The menu is built once per sign-in, not once a minute.** Repeated sign-in checks now leave an already-correct menu alone.
2. **Menu updates happen one at a time.** Sign-in and sign-out reach the menu from several directions — a timer, the Send web app asking, a couple of message handlers, and the Log out item itself — and they could previously overlap. A sign-out landing in the middle of a sign-in used to leave the menu showing the sign-in prompt above a full signed-in submenu, and it did not recover: signing back in did nothing until Thunderbird restarted. Menu work is now queued, so the last thing that happened is what you see.
3. **A menu problem no longer looks like a sign-out.** Updating the menu is a display concern, so it can no longer change the answer to "is this user signed in?". The error message on the storage path was also blaming the wrong thing and now says what actually failed.
4. **Housekeeping in the menu code itself.** Several places assumed a piece of Thunderbird's app menu would definitely be there and crashed unhelpfully if it wasn't — most exposed on the sign-out and menu-removal paths. Those now skip quietly, and the one case that means "the menu cannot appear at all" logs a warning instead of failing silently. A line that cleared Thunderbird's startup cache on every disable or uninstall has been removed; it was marked `TODO disable` and was making the next start of Thunderbird slower than necessary.

Tests: nine new cases in `packages/addon/src/test/menu.test.ts` cover the once-only build, overlapping checks, two accounts signing in at once, a sign-out landing mid-rebuild, recovering afterwards, staying signed in through a menu failure, and retrying after a partial failure. Six of them fail against the code they replaced. The test file now loads `menu.ts` fresh per test, since it holds state between calls.

The integration harness's stand-in for the menu API always succeeded, which is why no integration test ever caught this. It now refuses to add a menu item twice, the way the real API does, so the existing startup tests guard this bug too — confirmed by checking that one of them fails against the old code.

Two other test files were touched. `c2-reenable-trusts-stale-auth.test.ts` waited for startup by counting a fixed number of promise ticks, which broke as soon as the startup path gained a step; it now uses the same `vi.waitFor` approach as its neighbours in that directory. `fakeThunderbirdHost.ts` is the harness change described above.

**AI disclosure:** written by Claude (agent) from an audit of `TBProMenu/implementation.js` requested in a Claude Code session, then revised after a second agent reviewed the diff — parts 2 and the harness change came out of that review, and the reviewer's suggestions to normalize usernames and to drop the `remove()` hardening were considered and declined (see Notes). A human directed the work, chose the scope, and reviewed the result; the code, comments, and tests are agent-written. Verified locally: the full add-on suite passes (106 tests), ESLint reports no new problems on any changed file, and `tsc --noEmit` reports no new errors. One Prettier warning in the C2 test file pre-dates this branch and was left alone rather than reformatting unrelated lines.

## Why?

While you were signed in, the add-on kept trying to add account menu items it had already added, and every attempt after the first failed. That failure made the sign-in check report "not signed in" for someone who was signed in — and because the Send web app asks the add-on that same question when it loads a page, Send could show a signed-out state to a signed-in user. It also wrote an error to the console once a minute for as long as Thunderbird stayed open.

## Limitations and Notes

- Not yet exercised in a running Thunderbird. The bug and the fix were both worked out by reading the code, and the tests run against a stand-in for the menu API rather than the real one, since that only exists inside a Thunderbird process. Worth a manual pass: sign in, leave Thunderbird open a few minutes with the Error Console open, then sign out and back in and confirm the submenu comes back.
- Three places in `background.ts` call the menu update without waiting for it, so a genuine failure there is still unreported. Much quieter now that the call is usually a no-op. Left as follow-up to keep this change focused.
- The two places that identify the signed-in user do so slightly differently — one prefers the account's display name, the other uses the email. If those ever disagree for the same person, the menu is rebuilt once extra at sign-in. Harmless, and not a repeating cost, so left alone rather than adding name-normalizing code for a case that may not exist.
- The `remove()` entry point in the menu API has no callers anywhere in the codebase, so hardening it was arguably premature. Kept, because it is reachable from the API surface and was one of the weaker spots found in the audit.
- Removing the startup-cache flush is the right call for shipped builds, but anyone who was relying on it while debugging the experiment API locally will notice it is gone.

## Applicable Issues

Closes #1120

## Screenshots

N/A — no visible change when things are working. The menu looks exactly as it does today; the difference is that it stops failing behind the scenes.