### PR TITLE
test(send): skip storage suites when credentials are missing

### DIFF
--- a/packages/send/backend/src/test/testutils.test.ts
+++ b/packages/send/backend/src/test/testutils.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { shouldRunSuite } from './testutils';
 
-describe('runOrSkip', () => {
+describe('shouldRunSuite', () => {
   const originalEnv = { ...process.env };
   const originalConsoleWarn = console.warn;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -18,13 +18,6 @@ describe('runOrSkip', () => {
     console.warn = originalConsoleWarn;
   });
 
-  it('should return true when IS_CI_AUTOMATION is set', () => {
-    process.env.IS_CI_AUTOMATION = 'true';
-    const result = shouldRunSuite({ someKey: '' }, 'test suite');
-    expect(result).toBe(true);
-    expect(mockConsoleWarn).not.toHaveBeenCalled();
-  });
-
   it('should return true when all config values are truthy', () => {
     const result = shouldRunSuite(
       { key1: 'value1', key2: 'value2' },
@@ -32,6 +25,25 @@ describe('runOrSkip', () => {
     );
     expect(result).toBe(true);
     expect(mockConsoleWarn).not.toHaveBeenCalled();
+  });
+
+  it('should return true when all config values are truthy even in CI', () => {
+    process.env.IS_CI_AUTOMATION = 'true';
+    const result = shouldRunSuite(
+      { key1: 'value1', key2: 'value2' },
+      'test suite'
+    );
+    expect(result).toBe(true);
+    expect(mockConsoleWarn).not.toHaveBeenCalled();
+  });
+
+  it('should return false and warn when a config value is missing, even in CI', () => {
+    process.env.IS_CI_AUTOMATION = 'true';
+    const result = shouldRunSuite({ key1: 'value1', key2: '' }, 'test suite');
+    expect(result).toBe(false);
+    expect(mockConsoleWarn).toHaveBeenCalledWith(
+      'env variables are not correctly set to run test suite'
+    );
   });
 
   it('should return false and log warning when some config values are falsy', () => {

--- a/packages/send/backend/src/test/testutils.ts
+++ b/packages/send/backend/src/test/testutils.ts
@@ -2,7 +2,11 @@ export function shouldRunSuite(
   config: Record<string, string>,
   suiteName: string
 ) {
-  if (process.env.IS_CI_AUTOMATION) return true;
+  // A suite can only run when every value it needs is actually present.
+  // This is true even in CI: IS_CI_AUTOMATION being set does not mean the
+  // suite's credentials are available (for example the Backblaze/S3 secrets
+  // may be missing), so running anyway would fail against a bucket that does
+  // not exist. When credentials are missing we skip the suite with a warning.
   const canRun = Object.values(config).every((value) => !!value);
   if (!canRun) {
     console.warn(`env variables are not correctly set to run ${suiteName}`);


### PR DESCRIPTION
## What changed?

`shouldRunSuite` (in `packages/send/backend/src/test/testutils.ts`) no longer returns `true` just because `IS_CI_AUTOMATION` is set. It now only lets a suite run when every credential/value it needs is actually present; otherwise the suite skips and the existing warning is logged.

I also updated `testutils.test.ts` to cover the fixed behavior, including the case where `IS_CI_AUTOMATION` is set but a config value is missing (now returns `false`, so the suite skips).

Disclosure: this change was written by an AI agent. A human directed the task and specified the intended fix; the agent implemented the code, tests, and description.

## Why?

The `backend-tests` CI job was running the storage test suites (Backblaze B2 and S3) without any credentials. Because `shouldRunSuite` returned `true` whenever `IS_CI_AUTOMATION` was set, those suites ran against a bucket that does not exist and failed with errors like `expected null to be truthy`, turning CI red. Now they skip cleanly when credentials are not set, while still running wherever credentials are provided.

## Limitations and Notes

There is a separate, pre-existing failure in `src/test/storage/filesystem.test.ts` (local filesystem storage) that is unrelated to this change and is not addressed here.

## Applicable Issues

Closes #1135

## Screenshots

N/A
