### PR TITLE
fix(send): give /fonts/ its own nginx location (immutable + 404 on miss)

### DIFF
--- a/packages/send/frontend/docker/etc/nginx/conf.d/send.conf
+++ b/packages/send/frontend/docker/etc/nginx/conf.d/send.conf
@@ -207,46 +207,21 @@ server {
         }
     }
 
-    # Unhashed but content-stable: public/fonts/ holds 55 files (36 .woff2 referenced
-    # by apps/send/fonts.css, plus 18 legacy .woff and a licence file), and fonts.css
-    # is imported by apps/send/style.css, so the woff2 are on the critical path of
-    # every SPA page load. Without this block they fall into `location /` below, which
-    # is wrong twice.
+    # Fonts need their own block: without it they fall into `location /`, which
+    # caches them for 300s and, worse, serves a MISSING font as the SPA shell
+    # (200 text/html) via `try_files $uri /index.html` -- unparseable, and silent.
+    # Same failure /assets/ already guards. 36 .woff2 here are referenced by
+    # apps/send/fonts.css (imported by apps/send/style.css); the rest are legacy
+    # .woff and a licence file.
     #
-    # 1. TTL. `location /` sets max-age=300, so immutable font files revalidate every
-    #    five minutes. That is a REGRESSION against legacy prod, not just a missed
-    #    optimisation: the legacy CloudFront Function (send-suite-prod-rewrite) lists
-    #    /fonts in its ignorePaths, so those requests bypassed the SPA rewrite, hit S3,
-    #    and were cached by the default behaviour's Managed-CachingOptimized at
-    #    DefaultTTL 86400.
+    # This sets the EDGE TTL too, on its own: the Send distribution's default
+    # behaviour is MinTTL 0 / DefaultTTL 0 / MaxTTL 31536000 and nothing matches
+    # /fonts/*, so the origin header is authoritative up to a year. No CloudFront
+    # behaviour is needed for /fonts/*.
     #
-    # 2. A MISSING FONT IS SERVED AS THE SPA SHELL. `location /` ends
-    #    `try_files $uri /index.html`, so a font absent from the image returns
-    #    200 text/html. The browser cannot parse it, the @font-face silently fails,
-    #    and nothing logs an error. Same failure /assets/ already guards.
-    #
-    # WHAT THIS DOES AT THE EDGE, stated correctly -- an earlier revision of this
-    # comment got it wrong and the wrong version reached a PR description and two
-    # platform-infrastructure comments. The Send distribution's DEFAULT behaviour uses
-    # a custom cache policy at MinTTL 0 / DefaultTTL 0 / MaxTTL 31536000, and no
-    # ordered behaviour matches /fonts/*. So the origin header is ALREADY
-    # edge-authoritative up to a year: shipping this block sets a one-year per-POP TTL
-    # by itself, and a later /fonts/* CachingOptimized behaviour would only move
-    # MinTTL 0->1, which is a no-op. There is nothing to "restore" at the edge.
-    #
-    # The claim that a CachingOptimized behaviour would pin a shell-as-font response
-    # for 24h was FALSE and is the specific thing to not repeat: the fallback
-    # internally redirects into `location = /index.html`, so it carries
-    # `Cache-Control: no-store` (verified live). CloudFront's DefaultTTL applies only
-    # when the origin sends NO Cache-Control, so that response was never cacheable for
-    # more than MinTTL. The real argument for fixing it here is simpler and does not
-    # depend on the edge at all: a 200 text/html font is broken at the browser however
-    # long it is cached.
-    #
-    # UNLIKE /assets/, THESE FILENAMES ARE NOT CONTENT-HASHED, so a rename is the only
-    # cache-bust and nothing invalidates on promotion. If a font is ever replaced in
-    # place, the escape hatch is an explicit
-    # `aws cloudfront create-invalidation --paths '/fonts/*'`.
+    # These filenames are NOT content-hashed, unlike /assets/, so an in-place
+    # replacement needs `aws cloudfront create-invalidation --paths '/fonts/*'`.
+    # A future restyle is cheaper as a directory bump (/fonts/v2/...).
     location ^~ /fonts/ {
         # Deliberately no `always`, matching /assets/ above: the =404 below must not
         # carry a one-year TTL.

--- a/packages/send/frontend/docker/etc/nginx/conf.d/send.conf
+++ b/packages/send/frontend/docker/etc/nginx/conf.d/send.conf
@@ -207,6 +207,36 @@ server {
         }
     }
 
+    # Unhashed but content-stable: the font files under public/fonts/ are requested
+    # root-relative from apps/send/fonts.css (imported by apps/send/style.css), so
+    # they are on the critical path of every page load. Without this block they fall
+    # into `location /` below, which is wrong twice.
+    #
+    # 1. TTL. `location /` sets max-age=300, so 55 immutable woff2 files revalidate
+    #    every five minutes. That is a REGRESSION against legacy prod, not just a
+    #    missed optimisation: the legacy CloudFront Function (send-suite-prod-rewrite)
+    #    lists /fonts in its ignorePaths, so those requests bypassed the SPA rewrite,
+    #    hit S3, and were cached by the default behaviour's Managed-CachingOptimized
+    #    at DefaultTTL 86400.
+    #
+    # 2. A MISSING FONT IS SERVED AS THE SPA SHELL. `location /` ends
+    #    `try_files $uri /index.html`, so a font that is not in the image returns
+    #    200 text/html. The browser cannot parse it, the @font-face silently fails,
+    #    and nothing logs an error. Same failure mode /assets/ already guards.
+    #
+    # This block is what makes a /fonts/* CloudFront behaviour SAFE to add later. It
+    # is deliberately absent from the Send distribution today, because a
+    # CachingOptimized behaviour (MinTTL 1 / DefaultTTL 86400) layered over a
+    # shell-as-font response would pin that wrong body for 24h per POP -- convention
+    # 4's trap in platform-infrastructure docs/appointment-edge.md. Origin first,
+    # edge second.
+    location ^~ /fonts/ {
+        # Deliberately no `always`, matching /assets/ above: the =404 below must not
+        # carry a one-year TTL.
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        try_files $uri =404;
+    }
+
     # The SPA shell is the deploy pointer -- never cache it, or a browser keeps
     # loading a shell that references a deleted bundle. `no-store` rather than
     # `no-cache` because it is the only directive that also keeps the shell out

--- a/packages/send/frontend/docker/etc/nginx/conf.d/send.conf
+++ b/packages/send/frontend/docker/etc/nginx/conf.d/send.conf
@@ -207,29 +207,46 @@ server {
         }
     }
 
-    # Unhashed but content-stable: the font files under public/fonts/ are requested
-    # root-relative from apps/send/fonts.css (imported by apps/send/style.css), so
-    # they are on the critical path of every page load. Without this block they fall
-    # into `location /` below, which is wrong twice.
+    # Unhashed but content-stable: public/fonts/ holds 55 files (36 .woff2 referenced
+    # by apps/send/fonts.css, plus 18 legacy .woff and a licence file), and fonts.css
+    # is imported by apps/send/style.css, so the woff2 are on the critical path of
+    # every SPA page load. Without this block they fall into `location /` below, which
+    # is wrong twice.
     #
-    # 1. TTL. `location /` sets max-age=300, so 55 immutable woff2 files revalidate
-    #    every five minutes. That is a REGRESSION against legacy prod, not just a
-    #    missed optimisation: the legacy CloudFront Function (send-suite-prod-rewrite)
-    #    lists /fonts in its ignorePaths, so those requests bypassed the SPA rewrite,
-    #    hit S3, and were cached by the default behaviour's Managed-CachingOptimized
-    #    at DefaultTTL 86400.
+    # 1. TTL. `location /` sets max-age=300, so immutable font files revalidate every
+    #    five minutes. That is a REGRESSION against legacy prod, not just a missed
+    #    optimisation: the legacy CloudFront Function (send-suite-prod-rewrite) lists
+    #    /fonts in its ignorePaths, so those requests bypassed the SPA rewrite, hit S3,
+    #    and were cached by the default behaviour's Managed-CachingOptimized at
+    #    DefaultTTL 86400.
     #
     # 2. A MISSING FONT IS SERVED AS THE SPA SHELL. `location /` ends
-    #    `try_files $uri /index.html`, so a font that is not in the image returns
+    #    `try_files $uri /index.html`, so a font absent from the image returns
     #    200 text/html. The browser cannot parse it, the @font-face silently fails,
-    #    and nothing logs an error. Same failure mode /assets/ already guards.
+    #    and nothing logs an error. Same failure /assets/ already guards.
     #
-    # This block is what makes a /fonts/* CloudFront behaviour SAFE to add later. It
-    # is deliberately absent from the Send distribution today, because a
-    # CachingOptimized behaviour (MinTTL 1 / DefaultTTL 86400) layered over a
-    # shell-as-font response would pin that wrong body for 24h per POP -- convention
-    # 4's trap in platform-infrastructure docs/appointment-edge.md. Origin first,
-    # edge second.
+    # WHAT THIS DOES AT THE EDGE, stated correctly -- an earlier revision of this
+    # comment got it wrong and the wrong version reached a PR description and two
+    # platform-infrastructure comments. The Send distribution's DEFAULT behaviour uses
+    # a custom cache policy at MinTTL 0 / DefaultTTL 0 / MaxTTL 31536000, and no
+    # ordered behaviour matches /fonts/*. So the origin header is ALREADY
+    # edge-authoritative up to a year: shipping this block sets a one-year per-POP TTL
+    # by itself, and a later /fonts/* CachingOptimized behaviour would only move
+    # MinTTL 0->1, which is a no-op. There is nothing to "restore" at the edge.
+    #
+    # The claim that a CachingOptimized behaviour would pin a shell-as-font response
+    # for 24h was FALSE and is the specific thing to not repeat: the fallback
+    # internally redirects into `location = /index.html`, so it carries
+    # `Cache-Control: no-store` (verified live). CloudFront's DefaultTTL applies only
+    # when the origin sends NO Cache-Control, so that response was never cacheable for
+    # more than MinTTL. The real argument for fixing it here is simpler and does not
+    # depend on the edge at all: a 200 text/html font is broken at the browser however
+    # long it is cached.
+    #
+    # UNLIKE /assets/, THESE FILENAMES ARE NOT CONTENT-HASHED, so a rename is the only
+    # cache-bust and nothing invalidates on promotion. If a font is ever replaced in
+    # place, the escape hatch is an explicit
+    # `aws cloudfront create-invalidation --paths '/fonts/*'`.
     location ^~ /fonts/ {
         # Deliberately no `always`, matching /assets/ above: the =404 below must not
         # carry a one-year TTL.
@@ -258,7 +275,8 @@ server {
     # (packages/send/pulumi/cloudfront.py) has MinTTL 1. Put the SPA shell and
     # /config.js on a CachingDisabled-equivalent behaviour.
 
-    # SPA + unhashed public/ files (icons, fonts, manifest.json, bird.svg).
+    # SPA + unhashed public/ files (icons, manifest.json, bird.svg). NOT fonts --
+    # those have their own ^~ /fonts/ block above.
     # try_files falls back to the shell so client-side routes like /share/<id>
     # and /send/profile resolve. The internal redirect re-runs location matching
     # into `= /index.html` above, so those responses get `no-store`, not this


### PR DESCRIPTION
Font files fall into `location /` today, which is wrong twice.

- **TTL** — `location /` sets `max-age=300`, so immutable fonts revalidate every five minutes.
  Legacy prod cached them at 86400 (its CloudFront Function lists `/fonts` in `ignorePaths`), so
  this is a regression, not a missed optimisation.
- **A missing font returns the SPA shell as `200 text/html`** — `try_files $uri /index.html`. The
  browser can't parse it, the `@font-face` silently fails, nothing logs. `/assets/` already guards
  this; `/fonts/` didn't.

`public/fonts/` holds 36 `.woff2` referenced by `apps/send/fonts.css` (imported by
`apps/send/style.css`), plus 18 legacy `.woff` and a licence file.

## Fix

```nginx
location ^~ /fonts/ {
    add_header Cache-Control "public, max-age=31536000, immutable";
    try_files $uri =404;
}
```

No `always`, matching `/assets/` — the `=404` must not carry a one-year TTL.

## Notes for the reviewer

- The Send distribution's default behaviour is MinTTL 0 / DefaultTTL 0 / MaxTTL 31536000 and
  nothing matches `/fonts/*`, so this change alone sets the edge TTL. No follow-up CloudFront
  behaviour is needed.
- These filenames are **not** content-hashed, unlike `/assets/`. An in-place replacement needs
  `aws cloudfront create-invalidation --paths '/fonts/*'`.
- Scoped to fonts. `/icons/`, `manifest.json` and `bird.svg` share the shell-fallback exposure but
  weren't in legacy's `ignorePaths`, so widening this would be new behaviour — a deliberate call to
  make separately.
- Pre-existing, out of scope: `/fonts.css` isn't matched by `^~ /fonts/` and still returns the
  shell, so the backend-rendered login pages get no `@font-face` rules.

## Verification

`nginx -t` passes. After deploy: `/fonts/…/Metropolis-Regular.woff2` → 200 `immutable`;
`/fonts/nope.woff2` → 404, not 200.

Refs thunderbird/platform-infrastructure#1038
