### PR TITLE
fix(send-backend): gate /can-upload on auth, and fail closed if that slips

### DIFF
--- a/packages/send/backend/src/middleware.ts
+++ b/packages/send/backend/src/middleware.ts
@@ -430,38 +430,72 @@ export function addVersionHeader(
   next();
 }
 
-export async function checkStorageLimit(
-  req: Request,
-  res: Response,
-  next: NextFunction
-) {
-  // Check if the body has the size property
-  const size = req?.body?.size || 0;
-
-  const { tier, id } = getDataFromAuthenticatedRequest(req);
-  const limit = getStorageLimitForTier(tier);
-
-  const { active } = await getUsedStorage(id);
-
-  if (active + size >= limit) {
-    return res.status(403).json({
-      message: `Storage limit exceeded. Please remove files to continue uploading.`,
-    });
+/**
+ * Read the caller's identity, or respond 403 and return null.
+ *
+ * `getDataFromAuthenticatedRequest` throws when there is no `authorization`
+ * cookie. Inside an `async` middleware that throw becomes a rejected promise,
+ * and Express 4 discards it -- `Layer.handle_request` only try/catches
+ * synchronous throws -- so Node terminates the process. One anonymous request
+ * would take out a replica.
+ *
+ * Every caller below is also gated by `requireJWT`, so this should be
+ * unreachable. That is exactly why it is here: the gate is a matter of argument
+ * order at each call site, and the cost of getting that order wrong should be a
+ * 403, not an outage.
+ */
+function getCallerOrReject(req: Request, res: Response) {
+  try {
+    return getDataFromAuthenticatedRequest(req);
+  } catch {
+    reject(res);
+    return null;
   }
-
-  return next();
 }
 
-export async function requireAdminPermisions(
-  req: Request,
-  res: Response,
-  next: NextFunction
-) {
-  const { id } = getDataFromAuthenticatedRequest(req);
+// Wrapped rather than exported bare: `getUsedStorage` and `getAdminStatus` reach
+// the database, and a rejection there is the same unhandled-rejection process
+// kill as above. `wrapAsyncHandler` routes it to `next` instead.
+export const checkStorageLimit: RequestHandler = wrapAsyncHandler(
+  async function checkStorageLimit(
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ) {
+    // Check if the body has the size property
+    const size = req?.body?.size || 0;
 
-  const adminStatus = await getAdminStatus(id);
-  if (!adminStatus) {
-    return reject(res);
+    const caller = getCallerOrReject(req, res);
+    if (!caller) return;
+
+    const { tier, id } = caller;
+    const limit = getStorageLimitForTier(tier);
+
+    const { active } = await getUsedStorage(id);
+
+    if (active + size >= limit) {
+      return res.status(403).json({
+        message: `Storage limit exceeded. Please remove files to continue uploading.`,
+      });
+    }
+
+    return next();
   }
-  next();
-}
+);
+
+export const requireAdminPermisions: RequestHandler = wrapAsyncHandler(
+  async function requireAdminPermisions(
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ) {
+    const caller = getCallerOrReject(req, res);
+    if (!caller) return;
+
+    const adminStatus = await getAdminStatus(caller.id);
+    if (!adminStatus) {
+      return reject(res);
+    }
+    next();
+  }
+);

--- a/packages/send/backend/src/routes/uploads.ts
+++ b/packages/send/backend/src/routes/uploads.ts
@@ -739,7 +739,7 @@ router.get(
 This route checks if the user can upload files
 It's a good way to run a quick check with our middlewares before we start any uploads
  */
-router.get('/can-upload', checkStorageLimit, requireJWT, (req, res) => {
+router.get('/can-upload', requireJWT, checkStorageLimit, (req, res) => {
   res.status(200).json({ message: 'Good to go' });
 });
 

--- a/packages/send/backend/src/test/middleware.test.ts
+++ b/packages/send/backend/src/test/middleware.test.ts
@@ -602,6 +602,25 @@ describe('requireAdminPermisions', () => {
     expect(mockResponse.status).toHaveBeenCalledWith(403);
     expect(nextFunction).not.toHaveBeenCalled();
   });
+
+  // Same guard as `checkStorageLimit` -- see the note there. Both routes using
+  // this middleware gate on `requireJWT` first, so this is the cost of getting
+  // that order wrong, not a path anything reaches today.
+  it('rejects with 403 instead of throwing when there is no token', async () => {
+    vi.mocked(getDataFromAuthenticatedRequest).mockImplementation(() => {
+      throw new Error(
+        'No token found in request: This should not happen if the user is authenticated'
+      );
+    });
+
+    await expect(
+      requireAdminPermisions(mockRequest as Request, mockResponse, nextFunction)
+    ).resolves.not.toThrow();
+
+    expect(mockResponse.status).toHaveBeenCalledWith(403);
+    expect(nextFunction).not.toHaveBeenCalled();
+    expect(getAdminStatus).not.toHaveBeenCalled();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -671,6 +690,43 @@ describe('checkStorageLimit', () => {
     await checkStorageLimit(mockRequest as Request, mockResponse, nextFunction);
 
     expect(nextFunction).toHaveBeenCalled();
+  });
+
+  // An unauthenticated caller must never reach this middleware -- `requireJWT`
+  // runs first on every route that uses it. These pin what happens when that
+  // ordering is wrong anyway, which is how private#43 took down a replica:
+  // `getDataFromAuthenticatedRequest` throws, and inside an `async` middleware
+  // Express 4 drops the rejection on the floor and Node kills the process.
+  it('rejects with 403 instead of throwing when there is no token', async () => {
+    vi.mocked(getDataFromAuthenticatedRequest).mockImplementation(() => {
+      throw new Error(
+        'No token found in request: This should not happen if the user is authenticated'
+      );
+    });
+
+    await expect(
+      checkStorageLimit(mockRequest as Request, mockResponse, nextFunction)
+    ).resolves.not.toThrow();
+
+    expect(mockResponse.status).toHaveBeenCalledWith(403);
+    expect(nextFunction).not.toHaveBeenCalled();
+    // The storage read is the expensive part and it needs a user id. Reaching
+    // it at all would mean the guard above did not hold.
+    expect(getUsedStorage).not.toHaveBeenCalled();
+  });
+
+  it('does not crash the process when the storage read rejects', async () => {
+    mockRequest.body = { size: 100 };
+    vi.mocked(getStorageLimitForTier).mockReturnValue(1000);
+    vi.mocked(getUsedStorage).mockRejectedValue(new Error('database is down'));
+
+    // `wrapAsyncHandler` hands it to `next`; unwrapped, this rejection would be
+    // an unhandled rejection and the process would exit.
+    await expect(
+      checkStorageLimit(mockRequest as Request, mockResponse, nextFunction)
+    ).resolves.not.toThrow();
+
+    expect(nextFunction).toHaveBeenCalledWith(expect.any(Error));
   });
 });
 

--- a/packages/send/backend/src/test/routes/uploads.can-upload.routes.test.ts
+++ b/packages/send/backend/src/test/routes/uploads.can-upload.routes.test.ts
@@ -1,0 +1,86 @@
+import express from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockGetUsedStorage, mockGetDataFromAuthenticatedRequest } = vi.hoisted(
+  () => ({
+    mockGetUsedStorage: vi.fn(),
+    mockGetDataFromAuthenticatedRequest: vi.fn(),
+  })
+);
+
+// The route only needs getUsedStorage; stub the rest of the barrel so the
+// import resolves without a database.
+vi.mock('@send-backend/models', () => ({
+  getUsedStorage: mockGetUsedStorage,
+  deleteUploadsByIds: vi.fn(),
+  reportUpload: vi.fn(),
+}));
+
+// Avoid the real storage client (Backblaze token timer + AWS SDK) at import.
+vi.mock('@send-backend/storage', () => ({
+  default: { del: vi.fn() },
+}));
+
+vi.mock('@send-backend/auth/client', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@send-backend/auth/client')>()),
+  getDataFromAuthenticatedRequest: mockGetDataFromAuthenticatedRequest,
+}));
+
+// Deliberately NOT mocking '../../middleware'. Pass-through mocks return 200
+// for either middleware order, so they cannot see the bug this file exists for.
+import router from '../../routes/uploads';
+
+const app = express();
+app.use(express.json());
+app.use('/api/uploads', router);
+
+/**
+ * `GET /api/uploads/can-upload` ran `checkStorageLimit` before `requireJWT`
+ * (private#43). `checkStorageLimit` reads the caller off the request, which
+ * throws when there is no `authorization` cookie -- and because it is `async`,
+ * Express 4 drops the rejection rather than catching it, so Node terminated the
+ * process. One anonymous GET, no account, one dead replica.
+ */
+describe('GET /api/uploads/can-upload', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetDataFromAuthenticatedRequest.mockImplementation(() => {
+      throw new Error(
+        'No token found in request: This should not happen if the user is authenticated'
+      );
+    });
+  });
+
+  it('refuses an unauthenticated caller without reaching the storage read', async () => {
+    const rejections: unknown[] = [];
+    const record = (reason: unknown) => rejections.push(reason);
+    process.on('unhandledRejection', record);
+
+    try {
+      const response = await request(app).get('/api/uploads/can-upload');
+
+      // 403 is what `requireJWT` returns for a missing token; it reserves 401
+      // for a token that expired but can still be refreshed.
+      expect(response.status).toBe(403);
+
+      // The assertion that pins the ordering. Both orders now answer 403 --
+      // `checkStorageLimit` fails closed too -- so only the message says which
+      // middleware got there first. This one is `requireJWT`'s; running
+      // `checkStorageLimit` first yields the bare 'Not authorized' from
+      // `reject()`.
+      expect(response.body).toEqual({
+        message: 'Not authorized: Token not found',
+      });
+
+      // And the storage read stays out of reach of an anonymous caller.
+      expect(mockGetUsedStorage).not.toHaveBeenCalled();
+
+      // Give a rejection a tick to surface before we stop listening.
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(rejections).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', record);
+    }
+  });
+});


### PR DESCRIPTION
## What changed?

`GET /api/uploads/can-upload` was mounted as `checkStorageLimit, requireJWT` — the storage check ran before the request had been authenticated. `checkStorageLimit` reads the caller's `tier` and `id` off the request, and neither is available at that point. Every other guarded route in `uploads.ts` puts `requireJWT` first (`:79`, `:162`, `:682`, `:726`); this one is now the same.

Ordering is a per-call-site argument, though, and getting it wrong should cost a 403, not anything larger. `checkStorageLimit` and `requireAdminPermisions` are the only two exported middlewares that read the caller without a guard, so both now go through a small `getCallerOrReject` helper and answer 403 when there is no token — whatever order they happen to be mounted in. 403 rather than 401 to match `requireJWT`, which reserves 401 for a token that expired but can still be refreshed.

Both are also now exported through the existing `wrapAsyncHandler` (`errors/routes.ts:251`). They are `async` and they reach the database — `getUsedStorage` and `getAdminStatus` — and Express 4 does not catch a rejected promise from an async middleware the way it catches a synchronous throw (`Layer.prototype.handle_request` try/catches the call, but an async function has already returned by then). A database error there previously had nowhere to go.

**Tests.** A new route-level regression test plus two unit tests:

- `src/test/routes/uploads.can-upload.routes.test.ts` mounts the real router with the **real** middleware. A pass-through middleware mock — the pattern most route tests here use — returns the same result for either ordering and cannot see this bug, so the test asserts on *which* middleware answers: `requireJWT`'s `'Not authorized: Token not found'` rather than the bare `'Not authorized'` that `reject()` produces.
- `middleware.test.ts` covers the tokenless path for both middlewares, and a rejecting `getUsedStorage`.

**AI disclosure.** Written with Claude Code. I directed the work and reviewed every change; the agent did the investigation, wrote the code and tests, and drafted this description. The audit it ran also turned up a second, wider instance of the same class, which is filed separately rather than folded in here.

## Why?

`getDataFromAuthenticatedRequest` (`auth/client.ts:48`) throws when there is no `authorization` cookie. Running it before the auth gate means that throw is reachable, and reachable throws in an `async` middleware do not degrade gracefully on Express 4 — see above. Making the middlewares fail closed removes the sharp edge rather than just this one instance of it.

## Limitations and Notes

- **The error boundary is still missing, and is worse than it looks.** `errorHandler` (`errors/routes.ts:262`) is declared `(err, req, res)` — three parameters. Express registers error handlers on `fn.length === 4`, so it has never been installed as one, and the 404 catch-all above it at `index.ts:152` makes it unreachable as ordinary middleware too. The `{ status, statusCode, message }` shape it defines has never reached a client. Not fixed here: giving it its fourth parameter switches on an error handler that has never run, which changes error responses repo-wide from Express's HTML 500 to JSON and wants its own PR and a pass over the error-shape assertions in the tests.
- There is no `process.on('unhandledRejection')` or `uncaughtException` handler anywhere in the backend. Out of scope here, tracked with the above.
- `getGroupMemberPermissions` is untouched — it is the subject of the separate issue.
- The audit behind this change also noted, and did not address: unauthenticated tag CRUD (`tags.ts:19, 30, 41, 51`), `POST /api/sharing/:linkId/add-password` with no auth gate (`sharing.ts:368`), and `getUserFromJWT` using `jwt.decode` rather than `verify` (`auth/client.ts:31`), which makes the `tier` that `checkStorageLimit` reads caller-supplied.
- Description kept deliberately narrow while this is unreleased; happy to expand it once it has deployed.

## Applicable Issues

Refs `private-issue-tracking#43`. Related: `private-issue-tracking#45`.

## Screenshots

n/a — backend only.

---

Verified locally: `tsc --noEmit` clean; `eslint src` 0 errors (8 pre-existing `no-explicit-any` warnings in an untouched file); `prettier --check` clean on all four touched files; `vitest run` → 165 passed. Two failures in `src/test/storage/backblaze.test.ts` are pre-existing on `04ae249b` with no changes applied — the credential-gated suite that #1146 removes — and are unrelated.

Three mutations, each caught by exactly the intended test:

| mutation | fails |
|---|---|
| restore `checkStorageLimit, requireJWT` | route test, on the response message |
| drop the `getCallerOrReject` try/catch | both tokenless unit tests, on the 403 |
| drop `wrapAsyncHandler` | the database-error test, on the promise rejecting |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
