### PR TITLE
fix(send-backend): stop group-permission denials from answering twice

### DIFF
--- a/packages/send/backend/src/middleware.ts
+++ b/packages/send/backend/src/middleware.ts
@@ -9,6 +9,7 @@ import {
   validateOIDCToken,
 } from './auth/oidc';
 import { VERSION, X_LOGOUT_HEADER } from './config';
+import { wrapAsyncHandler } from './errors/routes';
 import { getUsedStorage } from './models';
 import { fromPrismaV2 } from './models/prisma-helper';
 import { getAdminStatus, getUserByOIDCSubject } from './models/users';
@@ -67,6 +68,23 @@ export function reject(
   status = 403,
   message = `Not authorized`
 ) {
+  // Deny helpers get called on paths where something upstream may already have
+  // answered -- `getGroupMemberPermissions` runs `requireAuth` with a sentinel
+  // `next`, and `requireAuth` signals denial by responding rather than by
+  // throwing. Writing a second time makes `res.send` call `setHeader` on a sent
+  // response, which throws ERR_HTTP_HEADERS_SENT; inside an `async` middleware
+  // Express 4 drops that rejection and Node terminates the process.
+  //
+  // The first response is also the better one: it distinguishes an expired
+  // token (401, which the client auto-retries) from a missing one (403), where
+  // this helper only ever says 403.
+  if (res.headersSent) {
+    console.warn(
+      'reject() called after a response was already sent; keeping the first'
+    );
+    return;
+  }
+
   res.status(status).json({
     message,
   });
@@ -279,81 +297,84 @@ function getAuthenticatedUserData(
 }
 
 // Gets a user's permissions for a container and adds it to the request.
-export const getGroupMemberPermissions: RequestHandler = async (
-  req,
-  res,
-  next
-) => {
-  // Since we're calling a function intended to be used as middleware, we need to call next() if auth is valid
-  // We set a boolean to make sure next() is called. This means that the auth has been verified
-  let goodToGo = false;
-  const nextTrigger = () => {
-    goodToGo = true;
-  };
-  await requireAuth(req as AuthenticatedRequest, res, nextTrigger);
+export const getGroupMemberPermissions: RequestHandler = wrapAsyncHandler(
+  async (req, res, next) => {
+    // Since we're calling a function intended to be used as middleware, we need to call next() if auth is valid
+    // We set a boolean to make sure next() is called. This means that the auth has been verified
+    let goodToGo = false;
+    // Express calls `next(err)` to report failure, so a sentinel that ignores
+    // its argument would read an auth error as success. `requireAuth` does not
+    // do that today; this makes sure it cannot start to.
+    const nextTrigger = (err?: unknown) => {
+      goodToGo = !err;
+    };
+    await requireAuth(req as AuthenticatedRequest, res, nextTrigger);
 
-  if (!goodToGo) {
-    return reject(res);
-  }
+    if (!goodToGo) {
+      // `requireAuth` has already answered on every denial path. `reject` is a
+      // no-op once that has happened, and is here for the case where it has not.
+      return reject(res);
+    }
 
-  const userData = getAuthenticatedUserData(req as AuthenticatedRequest);
-  if (!userData) {
-    console.error('No authenticated user data found');
-    return reject(res);
-  }
+    const userData = getAuthenticatedUserData(req as AuthenticatedRequest);
+    if (!userData) {
+      console.error('No authenticated user data found');
+      return reject(res);
+    }
 
-  const userId = userData.id;
-  const containerId = extractContainerId(req);
+    const userId = userData.id;
+    const containerId = extractContainerId(req);
 
-  /* 
-  Users have full permissions to their own top-level (aka root folder)
-  Whenever a request doesn't contain a containerId, we assume it's a top-level folder
-  This happens client side when creating a new folder that doesn't have a parent
-  It also happens when a new account is created and we create a default folder
- */
-  if (userId && !containerId) {
-    req[PERMISSION_REQUEST_KEY] = allPermissions();
-    next();
-    return;
-  }
+    /* 
+    Users have full permissions to their own top-level (aka root folder)
+    Whenever a request doesn't contain a containerId, we assume it's a top-level folder
+    This happens client side when creating a new folder that doesn't have a parent
+    It also happens when a new account is created and we create a default folder
+   */
+    if (userId && !containerId) {
+      req[PERMISSION_REQUEST_KEY] = allPermissions();
+      next();
+      return;
+    }
 
-  if (!userId || !containerId) {
-    reject(res);
-    return;
-  }
+    if (!userId || !containerId) {
+      reject(res);
+      return;
+    }
 
-  try {
-    const findGroupQuery = {
-      where: {
-        container: {
-          id: containerId,
+    try {
+      const findGroupQuery = {
+        where: {
+          container: {
+            id: containerId,
+          },
         },
-      },
-    };
-    const group = await fromPrismaV2(
-      prisma.group.findFirstOrThrow,
-      findGroupQuery
-    );
+      };
+      const group = await fromPrismaV2(
+        prisma.group.findFirstOrThrow,
+        findGroupQuery
+      );
 
-    const findMembershipQuery = {
-      where: {
-        groupId_userId: { groupId: group.id, userId },
-      },
-    };
-    const membership = await fromPrismaV2(
-      prisma.membership.findUniqueOrThrow,
-      findMembershipQuery
-    );
+      const findMembershipQuery = {
+        where: {
+          groupId_userId: { groupId: group.id, userId },
+        },
+      };
+      const membership = await fromPrismaV2(
+        prisma.membership.findUniqueOrThrow,
+        findMembershipQuery
+      );
 
-    // Attach it to the request
-    req[PERMISSION_REQUEST_KEY] = membership.permission;
-    next();
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  } catch (err) {
-    reject(res);
-    return;
+      // Attach it to the request
+      req[PERMISSION_REQUEST_KEY] = membership.permission;
+      next();
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    } catch (err) {
+      reject(res);
+      return;
+    }
   }
-};
+);
 
 export function requireReadPermission(req, res, next) {
   if (!hasRead(req[PERMISSION_REQUEST_KEY])) {

--- a/packages/send/backend/src/test/middleware.test.ts
+++ b/packages/send/backend/src/test/middleware.test.ts
@@ -10,6 +10,7 @@ import { validateJWT } from '../auth/jwt';
 import {
   addVersionHeader,
   checkStorageLimit,
+  reject,
   getGroupMemberPermissions,
   renameBodyProperty,
   requireAdminPermission,
@@ -909,5 +910,43 @@ describe('addVersionHeader', () => {
       expect.any(String)
     );
     expect(nextFunction).toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// reject
+// ---------------------------------------------------------------------------
+
+describe('reject', () => {
+  it('sends a 403 by default', () => {
+    const mockResponse = {
+      headersSent: false,
+      json: vi.fn(),
+      status: vi.fn(() => mockResponse),
+    };
+
+    reject(mockResponse as unknown as Response);
+
+    expect(mockResponse.status).toHaveBeenCalledWith(403);
+    expect(mockResponse.json).toHaveBeenCalledWith({
+      message: 'Not authorized',
+    });
+  });
+
+  // Writing to an already-sent response makes `res.send` call `setHeader`,
+  // which throws ERR_HTTP_HEADERS_SENT. From an async middleware that is an
+  // unhandled rejection, and Node ends the process -- so this guard is the
+  // difference between a stale deny and a dead replica.
+  it('does not write again once a response has been sent', () => {
+    const mockResponse = {
+      headersSent: true,
+      json: vi.fn(),
+      status: vi.fn(() => mockResponse),
+    };
+
+    reject(mockResponse as unknown as Response, 401, 'Token expired');
+
+    expect(mockResponse.status).not.toHaveBeenCalled();
+    expect(mockResponse.json).not.toHaveBeenCalled();
   });
 });

--- a/packages/send/backend/src/test/routes/containers.anonymous-crash.routes.test.ts
+++ b/packages/send/backend/src/test/routes/containers.anonymous-crash.routes.test.ts
@@ -1,0 +1,107 @@
+import express from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockPrisma } = vi.hoisted(() => ({
+  mockPrisma: {
+    group: { findFirstOrThrow: vi.fn() },
+    membership: { findUniqueOrThrow: vi.fn() },
+  },
+}));
+
+vi.mock('@prisma/client', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@prisma/client')>()),
+  PrismaClient: class {
+    constructor() {
+      return mockPrisma;
+    }
+  },
+}));
+
+// Keep the import graph off the database and the AWS SDK. The middleware under
+// test is real -- that is the point of this file.
+vi.mock('@send-backend/models', () => ({
+  getUsedStorage: vi.fn(),
+  createItem: vi.fn(),
+  deleteItem: vi.fn(),
+  updateItemName: vi.fn(),
+}));
+vi.mock('@send-backend/storage', () => ({ default: { del: vi.fn() } }));
+
+import { getGroupMemberPermissions } from '../../middleware';
+
+/**
+ * `getGroupMemberPermissions` is the first middleware, with no gate before it,
+ * on twelve `containers.ts` routes. It runs `requireAuth` with a sentinel
+ * `next`, and `requireAuth` signals denial by *responding* rather than by
+ * throwing. The old code then called `reject(res)` on that already-sent
+ * response: `res.send` calls `setHeader`, Node throws ERR_HTTP_HEADERS_SENT,
+ * and because this middleware is `async` Express 4 drops the rejection and the
+ * process exits.
+ *
+ * Anonymous requests hit it, and so does any signed-in user whose access token
+ * has expired -- `requireAuth` answers 401 there, which is equally a response.
+ */
+describe('getGroupMemberPermissions on an unauthenticated request', () => {
+  const app = express();
+  app.use(express.json());
+  app.get('/:containerId/item', getGroupMemberPermissions, (_req, res) => {
+    res.status(200).json({ message: 'reached the handler' });
+  });
+
+  let rejections: unknown[];
+  const record = (reason: unknown) => rejections.push(reason);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    rejections = [];
+    process.on('unhandledRejection', record);
+  });
+
+  const settle = async () => {
+    await new Promise((resolve) => setImmediate(resolve));
+    process.off('unhandledRejection', record);
+  };
+
+  it('answers once and does not crash when no credentials are sent', async () => {
+    const response = await request(app).get('/abc/item');
+    await settle();
+
+    // requireAuth's own message, not the bare 'Not authorized' that a second
+    // reject() would have written over it.
+    expect(response.status).toBe(403);
+    expect(response.body).toEqual({
+      message: 'Not authorized: No valid authentication found',
+    });
+    expect(rejections).toEqual([]);
+  });
+
+  it('preserves the 401 the client auto-retries on, for an expired token', async () => {
+    // A valid refresh token with a dead access token is the ordinary state of a
+    // signed-in user mid-session, so this path is reached organically -- it is
+    // not only an anonymous-attacker case.
+    const jwt = await import('jsonwebtoken');
+    process.env.ACCESS_TOKEN_SECRET = 'access-secret';
+    process.env.REFRESH_TOKEN_SECRET = 'refresh-secret';
+    const expired = jwt.default.sign({ id: 'u1' }, 'access-secret', {
+      expiresIn: '-1s',
+    });
+    const refresh = jwt.default.sign({ id: 'u1' }, 'refresh-secret', {
+      expiresIn: '7d',
+    });
+
+    const response = await request(app)
+      .get('/abc/item')
+      .set(
+        'Cookie',
+        `authorization=Bearer%20${expired};refresh_token=Bearer%20${refresh}`
+      );
+    await settle();
+
+    // The old code overwrote this 401 with a generic 403 -- when it did not
+    // crash first. The distinction matters: the client refreshes on 401.
+    expect(response.status).toBe(401);
+    expect(response.body).toEqual({ message: 'Not authorized: Token expired' });
+    expect(rejections).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What changed?

`getGroupMemberPermissions` calls `requireAuth` with a sentinel `next` and reads the sentinel to decide whether authentication passed:

```ts
let goodToGo = false;
const nextTrigger = () => { goodToGo = true; };
await requireAuth(req as AuthenticatedRequest, res, nextTrigger);

if (!goodToGo) {
  return reject(res);      // <- requireAuth has already responded
}
```

`requireAuth` signals denial by **responding**, not by throwing or by calling `next`. So on every denial path the sentinel stays unset and the caller answered a second time. A second write makes `res.send` call `setHeader` on a sent response, which throws `ERR_HTTP_HEADERS_SENT` — and Express 4 catches a synchronous throw from a handler but not a rejected promise from an `async` one, so it went unhandled.

Four changes, smallest first:

- **`reject` returns early when `res.headersSent`**, and warns. One guard covers every current and future caller, which is worth more than four call-site checks inside this one function.
- **The first response now survives.** It was always the better one: `requireAuth` distinguishes a missing token (403) from an expired one (401), and `reject` only ever says 403. A client that needs the 401 to trigger its token refresh was getting a 403 instead — when it got a response at all.
- **`getGroupMemberPermissions` goes through the existing `wrapAsyncHandler`** (`errors/routes.ts:251`), so a rejection out of `requireAuth` — whose OIDC introspection reaches the network — lands on `next` rather than on the process.
- **The sentinel no longer reads `next(err)` as success.** This one is unreachable today and has no test: `requireAuth` never calls `next` with an argument. It is one line so that wrapping `requireAuth` later — the obvious next hardening — cannot quietly turn an auth error into an authenticated request.

**No route changes, deliberately.** The filed issue suggested putting `requireJWT` in front of the twelve routes. That would be a regression: `requireJWT` is JWT-cookie only (`middleware.ts:203`) and would reject OIDC bearer callers, which these routes accept via `requireAuth`'s OIDC-first path. `requireAuth` already runs inside the middleware, so an outer gate would also double the introspection calls. I've corrected the issue.

**AI disclosure.** Written with Claude Code. I directed the work and reviewed every change; the agent did the investigation, wrote the code and tests, and drafted this description.

## Why?

Reachable with no credentials on the twelve `containers.ts` routes that mount this middleware with nothing in front of it (`:355, 407, 458, 540, 588, 630, 668, 700, 733, 765, 812, 866`).

It is **also reachable by an ordinary signed-in user whose access token has expired** — `requireAuth` answers 401 on that path, which is equally a response, so the same double-write follows. A valid refresh token with a dead access token is the normal mid-session state, and `POST /:containerId/item` is a routine operation, so this does not need an attacker to fire.

## Limitations and Notes

- **`errorHandler` is still not an error handler.** `errors/routes.ts:262` declares `(err, req, res)` — three parameters, where Express dispatches on `fn.length === 4`. So the `next(err)` this PR now routes rejections to still ends at Express's `finalhandler` rather than at the JSON shape the codebase defines. Not fixed here: giving it its fourth parameter switches on a handler that has never run and changes error responses repo-wide from HTML to JSON. It needs its own PR and a pass over the error-shape assertions in the tests.
- No `process.on('unhandledRejection')` / `uncaughtException` handler exists anywhere in the backend. Out of scope here.
- The sentinel pattern itself survives. Calling one middleware from inside another with a fake `next` is what made a double-send possible; composing them at the route level would be the structural fix, but that changes the middleware's contract across 12+ routes and is not something to do in a security patch.
- The twelve routes still have no explicit gate in their own definition — authorization depends on `getGroupMemberPermissions` remembering to check. That reads as an accident waiting to happen even though it is correct today.
- Description kept narrow while this is unreleased; happy to expand after it deploys.

## Applicable Issues

Refs `private-issue-tracking#45`. Related: `private-issue-tracking#43` / #1149, same class, different trigger.

## Screenshots

n/a — backend only.

---

Verified locally: `tsc --noEmit` clean; `eslint src` 0 errors (8 pre-existing `no-explicit-any` warnings in an untouched file); `prettier --check` clean on all three touched files; `vitest run` → 165 passed. The two `src/test/storage/backblaze.test.ts` failures are pre-existing on `04ae249b` and unrelated — see the note on #1149.

Mutation-verified, and the first attempt was not good enough: with both fixes in place the route tests passed even with the `headersSent` guard removed, because `wrapAsyncHandler` was catching what the guard would have prevented. Each fix is now pinned separately.

| mutation | fails |
|---|---|
| guard **and** wrapper removed (the original code) | both route tests, on `ERR_HTTP_HEADERS_SENT` surfacing as an unhandled rejection |
| `headersSent` guard alone removed | the `reject` unit test, on the second write happening |
| sentinel hardening reverted | nothing — unreachable, as described above |

The route test registers an `unhandledRejection` listener for the duration of the request, so it reproduces the actual production failure rather than a proxy for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
