### PR TITLE
test(e2e): @deployment-analysis login-only sign-in smoke for the Send Kargo gate

### DIFF
--- a/packages/send/e2e/const/const.js
+++ b/packages/send/e2e/const/const.js
@@ -2,6 +2,8 @@
 export const PLAYWRIGHT_TAG_DEV_DESKTOP = '@dev-desktop';
 export const PLAYWRIGHT_TAG_DESKTOP_NIGHTLY = '@desktop-nightly';
 export const PLAYWRIGHT_TAG_MOBILE_NIGHTLY = '@mobile-nightly';
+// Login-only smoke run as the Kargo freight-verification gate against a deployed env.
+export const PLAYWRIGHT_TAG_DEPLOYMENT_ANALYSIS = '@deployment-analysis';
 
 // test environment details
 export const TB_SEND_TARGET_ENV = String(process.env.TB_SEND_TARGET_ENV);

--- a/packages/send/e2e/package.json
+++ b/packages/send/e2e/package.json
@@ -11,6 +11,8 @@
     "test:e2e:headless": "pnpm exec playwright test --config playwright.config.dev.ts --grep dev-desktop --project=firefox",
     "test:e2e:ui": "pnpm exec playwright test --config playwright.config.dev.ts --grep dev-desktop --project=firefox --ui",
     "test:e2e:ci": "../../../scripts/e2e.sh",
+    "deployment-analysis-e2e": "pnpm exec playwright test --grep deployment-analysis --project=deployment-analysis",
+    "deployment-analysis-e2e:headed": "pnpm exec playwright test --grep deployment-analysis --project=deployment-analysis --headed",
     "test:e2e:nightly": "pnpm exec playwright test --grep desktop-nightly --project=firefox --headed",
     "test:e2e:nightly:ui": "pnpm exec playwright test --grep desktop-nightly --project=firefox --ui",
     "test:e2e:nightly:mobile:viewport": "pnpm exec playwright test --grep mobile-nightly --project=Google-Pixel-7-View --headed",

--- a/packages/send/e2e/playwright.config.ts
+++ b/packages/send/e2e/playwright.config.ts
@@ -85,6 +85,26 @@ export default defineConfig({
       dependencies: ['desktop-auth'],
     },
 
+    // Standalone login-only OIDC smoke for the Kargo freight-verification gate. NO
+    // `dependencies` (skips desktop-auth key-restore setup) and NO storageState -- it signs in
+    // fresh each run, so it needs no pre-provisioned encryption key. testMatch pins it to the
+    // one spec so `--project=deployment-analysis` never pulls in the nightly suite.
+    {
+      name: 'deployment-analysis',
+      testMatch: /.*deployment-analysis-signin\.spec\.ts/,
+      use: {
+        ...devices['Desktop Firefox'],
+        screenshot: 'only-on-failure',
+        launchOptions: {
+          firefoxUserPrefs: {
+            "dom.push.enabled": false,
+            "dom.webnotifications.enabled": false,
+            "privacy.trackingprotection.enabled": false,
+          },
+        },
+      },
+    },
+
     /* Test against mobile viewports. */
     {
       name: 'Google-Pixel-7-View',

--- a/packages/send/e2e/tests/desktop/deployment-analysis-signin.spec.ts
+++ b/packages/send/e2e/tests/desktop/deployment-analysis-signin.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from '@playwright/test';
+
+import { PLAYWRIGHT_TAG_DEPLOYMENT_ANALYSIS } from '../../const/const';
+import { signInOnly } from '../../utils/utils';
+
+/**
+ * Kargo freight-verification gate for TB Send.
+ *
+ * A stock Playwright container (run by the send-e2e AnalysisTemplate on mzla-eks-shared01)
+ * clones this repo and runs this single spec against the freshly-promoted deploy. It is a
+ * NON-DESTRUCTIVE, login-only OIDC smoke: it does not upload, share, download, or restore a
+ * key, so it needs no encryption-key code and no key-provisioned test user -- any TB Pro OIDC
+ * user works. A red run leaves the freight unverified and blocks promotion.
+ *
+ * Requires TB_SEND_BASE_URL (deployed host, trailing slash), TB_SEND_TARGET_ENV (non-`dev` so
+ * the OIDC path is taken), and TBPRO_USERNAME / TBPRO_PASSWORD (read via const/const.js).
+ */
+test.describe('deployment analysis on desktop', () => {
+  test('signs in via OIDC and reaches the authenticated Send app', {
+    tag: [PLAYWRIGHT_TAG_DEPLOYMENT_ANALYSIS],
+  }, async ({ page }) => {
+    for (const key of ['TB_SEND_BASE_URL', 'TBPRO_USERNAME', 'TBPRO_PASSWORD']) {
+      expect(process.env[key], `${key} must be set for the deployment-analysis gate`).toBeTruthy();
+    }
+
+    await signInOnly(page);
+  });
+});

--- a/packages/send/e2e/utils/utils.ts
+++ b/packages/send/e2e/utils/utils.ts
@@ -47,3 +47,36 @@ export const signInAndRestoreSendKey = async (page: Page) => {
   // restore the access key
   await securityPrivacyPage.restoreAccessKey();
 }
+
+/**
+ * Login-only variant of signInAndRestoreSendKey: navigate to TB Send, sign in via TB Pro
+ * OIDC (deployed) or local password (dev), and assert we land on the authenticated Send app
+ * shell -- WITHOUT restoring the encryption key. This is the Kargo freight-verification gate
+ * (@deployment-analysis): it proves OIDC sign-in works against the freshly-promoted deploy
+ * without needing TB_SEND_ENCRYPTION_KEY_CODE or a key-provisioned user. A signed-in user may
+ * land on the dashboard or, if they have never created a key, the first-time key-setup screen;
+ * either way the Send header logo renders, so that is the landing signal (same checkpoint
+ * signInAndRestoreSendKey asserts before it restores the key).
+ */
+export const signInOnly = async (page: Page) => {
+  console.log(`navigating to send ${TB_SEND_TARGET_ENV} (${TB_SEND_BASE_URL})`);
+  const tbAcctsSignInPage = new TBAcctsPage(page);
+
+  // ios has intermittent errors on this page.goto call so we must catch
+  await page.goto(`${TB_SEND_BASE_URL}`, { waitUntil: 'commit', timeout: 30_000 }).catch(() => {});
+  await page.waitForTimeout(TIMEOUT_5_SECONDS);
+
+  // local dev can use local 'password' auth only or tb accts
+  if (TB_SEND_TARGET_ENV == 'dev') {
+    if (await tbAcctsSignInPage.localDevEmailInput.isVisible()) {
+      await tbAcctsSignInPage.localSendSignIn();
+    }
+  } else {
+    await tbAcctsSignInPage.signIn();
+  }
+
+  const dashboardPage = new DashboardPage(page);
+
+  // authenticated app shell rendered -> OIDC sign-in succeeded (no key restore)
+  await expect(dashboardPage.sendHdrLogoLink).toBeVisible({ timeout: TIMEOUT_30_SECONDS });
+}


### PR DESCRIPTION
Adds a login-only OIDC sign-in smoke that runs against a **deployed** Send env (not the docker-compose dev stack), for use as the Send Kargo freight-verification gate on platform-infrastructure — mirroring the accounts and appointment gates.

## Changes (`packages/send/e2e`)
- **`utils/utils.ts`** — `signInOnly(page)`: `signInAndRestoreSendKey` minus the key-restore step. Needs no `TB_SEND_ENCRYPTION_KEY_CODE` and no key-provisioned user; asserts the authenticated Send header renders (the same checkpoint the existing helper asserts before restoring the key).
- **`tests/desktop/deployment-analysis-signin.spec.ts`** — the gate spec, tagged `@deployment-analysis`.
- **`playwright.config.ts`** — standalone `deployment-analysis` project (Desktop Firefox), **no `desktop-auth` dependency and no storageState**, so it signs in fresh and never triggers the key-restore setup.
- **`const/const.js`** / **`package.json`** — the tag const and `deployment-analysis-e2e` scripts.

## Notes
- Non-destructive: no upload/share/download/delete, no key restore, no settings mutation.
- Uses the nightly OIDC path (`pages/tb-accts-page.ts` `signIn`), which has no hardcoded Keycloak host — so it targets tb-dev without touching the dev-only `pages/dev/oidc.ts` (which hardcodes `auth-stage.tb.pro`).
- **Validated in-cluster**: run against `https://send.tb-dev.thunderbird.dev/` via the platform-infra AnalysisTemplate — **1 passed (20.6s)**.