### PR TITLE
fix(send-frontend): set CSP, X-Frame-Options and HSTS at the nginx origin

### DIFF
--- a/packages/send/frontend/docker/etc/nginx/conf.d/send.conf
+++ b/packages/send/frontend/docker/etc/nginx/conf.d/send.conf
@@ -11,22 +11,37 @@
 # LOAD-BEARING rather than a nicety: the JS bundle is over 1 MB, so anything
 # reaching the origin hostname directly transfers it uncompressed.
 #
-# SECURITY HEADERS ARE THE EDGE'S JOB and are deliberately NOT set here.
+# THREE SECURITY HEADERS ARE SET HERE, at the origin, because the edge cannot
+# supply them: Content-Security-Policy, X-Frame-Options and Strict-Transport-
+# Security. The rest stay the edge's job.
 #
-# The S3/CloudFront path gets CSP, HSTS, X-Frame-Options, X-Content-Type-Options,
-# Referrer-Policy and COOP/COEP/CORP from `packages/send/pulumi/cloudfront.py`.
-# The equivalent for this image is a CloudFront ResponseHeadersPolicy on the
-# Pattern-C distribution, which lives in thunderbird/platform-infrastructure and
-# must be in place before this image serves user traffic.
+# The Pattern-C distribution carries AWS's `Managed-SecurityHeadersPolicy`
+# (67f7725c-6f97-4210-82d7-5512b31e9d03). Its ContentSecurityPolicy is unset, so
+# it delivers NO CSP at all; its X-Frame-Options (SAMEORIGIN) and HSTS (max-age
+# only) are `Override: false`, which AWS documents as "when the origin response
+# contains the header, CloudFront includes the header that it received from the
+# origin". So the origin is the only place a CSP can come from, and the only
+# place the other two can be raised to what the S3/CloudFront stack serves --
+# with no distribution change. X-Content-Type-Options and Referrer-Policy are
+# left to the edge: its values already match `packages/send/pulumi/cloudfront.py`.
 #
 # `csp.config.js` in this package CANNOT cover this image: it builds `connect-src`
 # from build-time VITE_SEND_SERVER_URL / VITE_OIDC_ROOT_URL / VITE_POSTHOG_HOST /
 # VITE_SENTRY_DSN, and this image deliberately bakes none of them, so it would
-# emit a `'self'`-only policy that breaks OIDC, PostHog, Sentry and B2. If a
-# policy is ever wanted at the ORIGIN instead, generate it in
-# docker-entrypoint.d/40-send-config.sh from the APP_* values that script already
-# reads -- and repeat every header in EVERY location block below, because a
-# location-level `add_header` drops all inherited ones.
+# emit a `'self'`-only policy that breaks OIDC, PostHog, Sentry and B2. The policy
+# below is a literal rather than something templated from the APP_* env that
+# docker-entrypoint.d/40-send-config.sh already reads, because a templated CSP
+# fails OPEN: an environment that forgets the variable would ship no policy,
+# which is the exact regression this closes. The only genuinely per-environment
+# source is the Keycloak host, and those are enumerated instead.
+#
+# THE TRAP: a location-level `add_header` DROPS ALL headers inherited from an
+# enclosing block. These are therefore repeated in EVERY location that sets an
+# add_header of its own, and deliberately NOT set at server scope -- see the
+# duplicate-header note on `location ^~ /api/` for why that would be wrong. Every
+# one carries `always`: without it nginx emits them only on a 2xx/3xx, so the
+# /assets/ 404 and the /50x.html 500 -- both trivially reachable -- would arrive
+# with no clickjacking or transport protection at all.
 
 # Connection header for the WebSocket upgrade dance: "upgrade" when the client
 # asked for an upgrade, "close" otherwise. MUST be at http scope, which is where
@@ -34,6 +49,40 @@
 map $http_upgrade $connection_upgrade {
     default upgrade;
     ''      close;
+}
+
+# The two policies, named once. nginx has no http-scope constant, so `map` with
+# only a `default` is the idiom; $host is just a key it has to be given.
+#
+# This is the S3/CloudFront stack's live policy with the two Pattern-C
+# adaptations. Removed: `https://send-backend[-stage].tb.pro` and its `wss://`
+# twin -- under Pattern C the API and the /api/ws + /trpc/ws upgrades are on the
+# SAME origin as the page, and CSP3 'self' matches a wss: URL with the page's
+# host and port (spec 6.7.2.6), so 'self' already covers them. Substituted: the
+# single legacy Keycloak host, for the three that exist -- oidc-client-ts fetches
+# discovery and token endpoints from the browser, so the authority must be in
+# connect-src, and a fourth environment will fail loudly at first login rather
+# than quietly. `https://*.backblazeb2.com` is load-bearing: uploads go
+# browser-direct to B2, and dropping it breaks every upload.
+map $host $send_csp {
+    default "default-src 'self'; script-src 'self' blob: https://us-assets.i.posthog.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' https: data:; font-src 'self' data: https://fonts.gstatic.com; object-src 'none'; frame-ancestors 'none'; connect-src 'self' https://us-assets.i.posthog.com https://*.backblazeb2.com https://*.sentry.io https://*.posthog.com/* https://us.i.posthog.com https://auth.tb-dev.thunderbird.dev https://auth-stage.tb.pro https://auth.tb.pro";
+}
+
+# The OIDC landing pages need their own, looser, policy. They are backend-served
+# (packages/send/backend/public/login-{success,failed}.html) and each carries an
+# inline <script> countdown plus an inline `onclick="window.close()"`, so the
+# strict `script-src` above would leave the popup open forever with a dead
+# fallback link. This is NEW exposure created by Pattern C, not a legacy
+# regression: on the S3/CloudFront stack those pages are served from a separate
+# backend origin that sends no CSP at all, so no policy has ever applied to them.
+# Everything else is tightened instead -- they load nothing cross-origin.
+#
+# Hash-pinning the two inline blocks would avoid 'unsafe-inline', but the hashes
+# would live here while the HTML lives in the backend package: an edit there
+# would break login with nothing to catch it. Removing the inline script from
+# those two files is the real fix and is a backend change.
+map $host $send_csp_login {
+    default "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; object-src 'none'; frame-ancestors 'none'; connect-src 'self'";
 }
 
 # $remote_addr is the private address of whatever proxied the request (an in-VPC
@@ -110,6 +159,14 @@ server {
     # the backend Service object exists, and keeps a stale ClusterIP if that
     # Service is later deleted and recreated. Sync-wave the Service ahead of this
     # Deployment, and put the readiness probe on an /api/ path rather than `/`.
+    #
+    # NO SECURITY HEADERS HERE OR ON /trpc. The backend runs helmet and already
+    # sends its own Content-Security-Policy, X-Frame-Options and HSTS (with
+    # includeSubDomains) on every response under both prefixes. `add_header`
+    # APPENDS rather than replaces, so setting them here would emit two of each:
+    # a browser enforces the INTERSECTION of two CSPs, treats conflicting
+    # X-Frame-Options as invalid, and per RFC 6797 honours only the FIRST HSTS --
+    # the upstream one, silently discarding whatever this file set.
     location ^~ /api/ {
         proxy_pass http://send-backend:8080;
         proxy_http_version 1.1;
@@ -164,7 +221,14 @@ server {
     # Backend-rendered OIDC/login landing pages. They are not part of dist-web,
     # so without these they would fall through to the SPA shell. The Vite dev
     # server proxies exactly these two paths to the backend for the same reason.
+    #
+    # Unlike /api/ and /trpc these are Express STATIC responses, which never pass
+    # through helmet (verified live: no CSP, and `x-powered-by` still present), so
+    # adding the headers here does not duplicate anything.
     location = /login-success.html {
+        add_header Content-Security-Policy $send_csp_login always;
+        add_header X-Frame-Options "DENY" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
         proxy_pass http://send-backend:8080;
         proxy_http_version 1.1;
         proxy_set_header Host $http_host;
@@ -172,6 +236,9 @@ server {
         proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
     }
     location = /login-failed.html {
+        add_header Content-Security-Policy $send_csp_login always;
+        add_header X-Frame-Options "DENY" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
         proxy_pass http://send-backend:8080;
         proxy_http_version 1.1;
         proxy_set_header Host $http_host;
@@ -184,6 +251,9 @@ server {
     # `location /` and gets the SPA shell as text/html, leaving the OIDC
     # landing pages unstyled (and caching that bogus 200 for 5 minutes).
     location = /style.css {
+        add_header Content-Security-Policy $send_csp always;
+        add_header X-Frame-Options "DENY" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
         proxy_pass http://send-backend:8080;
         proxy_http_version 1.1;
         proxy_set_header Host $http_host;
@@ -193,8 +263,12 @@ server {
     # so these are safe to cache forever.
     location ^~ /assets/ {
         # Deliberately no `always`: the =404 below must not carry this header,
-        # or a missing asset gets cached for a year.
+        # or a missing asset gets cached for a year. The security headers below
+        # take the opposite decision for the opposite reason.
         add_header Cache-Control "public, max-age=31536000, immutable";
+        add_header Content-Security-Policy $send_csp always;
+        add_header X-Frame-Options "DENY" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
         # 404 a missing asset instead of falling through to the SPA shell, which
         # would otherwise be served as JS and fail with a MIME/syntax error.
         try_files $uri =404;
@@ -235,12 +309,18 @@ server {
     # of shared/CDN storage.
     location = /index.html {
         add_header Cache-Control "no-store";
+        add_header Content-Security-Policy $send_csp always;
+        add_header X-Frame-Options "DENY" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     }
 
     # Runtime config, rewritten by docker-entrypoint.d on every container boot.
     # Caching this would pin an environment's config into a shared cache.
     location = /config.js {
         add_header Cache-Control "no-store";
+        add_header Content-Security-Policy $send_csp always;
+        add_header X-Frame-Options "DENY" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     }
 
     # NOTE on the two `no-store` locations above: the intent only holds end to end
@@ -258,6 +338,9 @@ server {
     # location's TTL.
     location / {
         add_header Cache-Control "public, max-age=300";
+        add_header Content-Security-Policy $send_csp always;
+        add_header X-Frame-Options "DENY" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
         # No `$uri/` clause: a bare directory URL (/icons/) would match the
         # real directory, find no index file, and 403 -- SPA fallback is the
         # right answer for those too.
@@ -266,6 +349,9 @@ server {
 
     error_page   500 502 503 504  /50x.html;
     location = /50x.html {
+        add_header Content-Security-Policy $send_csp always;
+        add_header X-Frame-Options "DENY" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
         default_type text/html;
         return 500 'There is a problem loading the API. Please try again later.';
     }


### PR DESCRIPTION
## What changed?

`packages/send/frontend/docker/etc/nginx/conf.d/send.conf` now sets three security
headers at the origin: `Content-Security-Policy`, `X-Frame-Options: DENY` and
`Strict-Transport-Security: max-age=31536000; includeSubDomains`.

The two policy strings live in `map` blocks at http scope so there is one copy to
edit; each location names them. They are repeated in every location that already
sets an `add_header` (a location-level `add_header` drops all inherited ones) and in
the three backend-static locations that set none, and every one carries `always` so
the `/assets/` 404 and the `/50x.html` 500 are covered too. No other file changes:
the entrypoint, the caching directives and the proxy config are untouched.

AI disclosure: written by Claude (Opus 4.8) under human direction; every live fact
below was probed with `curl` and the rendered config was exercised in a container
before commit.

## Why?

The tb-dev Pattern C edge is a posture drop against the S3/CloudFront stack it
replaces:

| header | legacy `send-stage.tb.pro` | edge `send.tb-dev.thunderbird.dev` |
|---|---|---|
| `content-security-policy` | full policy | absent |
| `x-frame-options` | `DENY` | `SAMEORIGIN` |
| `strict-transport-security` | `max-age=31536000; includeSubDomains` | `max-age=31536000` |

Those three edge values are AWS's `Managed-SecurityHeadersPolicy`
(`67f7725c-6f97-4210-82d7-5512b31e9d03`) defaults. Its `ContentSecurityPolicy` is
unset, so it delivers no CSP at all, and its `X-Frame-Options` / HSTS entries are
`Override: false`, which AWS documents as "when this setting is set to `false` and
the origin response contains the header, CloudFront includes the header that it
received from the origin". The origin sends nothing today, which is the whole
reason the managed defaults are what a viewer sees. Setting the headers in nginx
therefore fixes the edge with no CloudFront or Pulumi change.

**Enforce, not `-Report-Only`.** Report-Only closes none of the three gaps as
measured, has no report collector to send violations to, and defers the risk to the
production cutover where a break is expensive. The policy is not speculative: it is
the directive set the same SPA has enforced in production for months, and the only
adapted parts are derived from live `/config.js`. tb-dev is where this should be
found out.

**A literal policy, not one templated through `40-send-config.sh`.** A templated CSP
fails open — an environment that forgets the variable ships no policy, which is the
regression being closed — so it would need a baked safe default anyway, at which
point the machinery buys nothing. It would also need a third exclusion from that
script's rule that every `APP_*` var is emitted into the public `config.js`, and a
character filter that admits `;` `:` `/` `*` `'` while rejecting `"` `\` `$` and
newline, since `add_header` values interpolate nginx variables. The only genuinely
per-environment source is the Keycloak host; those are enumerated instead
(tb-dev, `auth-stage.tb.pro`, `auth.tb.pro`), so a fourth environment fails loudly
at first login rather than silently.

**`X-Frame-Options: DENY` is kept** even though `frame-ancestors 'none'` supersedes
it in every current browser: omitting it leaves the edge serving CloudFront's
`SAMEORIGIN`, which is a real downgrade against legacy, not a harmless redundancy.

The policy is legacy's, with two Pattern C adaptations. `https://send-backend*.tb.pro`
and its `wss://` twin are dropped: the API and the `/api/ws` + `/trpc/ws` upgrades are
same-origin now, and CSP3 `'self'` matches a `wss:` URL on the page's host and port
(spec 6.7.2.6). `https://*.backblazeb2.com` stays — uploads go browser-direct to B2.

## Limitations and Notes

- **The OIDC landing pages get their own looser policy.**
  `backend/public/login-{success,failed}.html` each carry an inline `<script>`
  countdown and an inline `onclick="window.close()"`, and Pattern C puts them on the
  same origin as the CSP-bearing app for the first time (on the S3 stack they are
  served from a separate backend origin that sends no CSP). Under the strict
  `script-src` the popup would never close and the fallback link would be dead, so
  those two locations get `script-src 'self' 'unsafe-inline'` with everything else
  tightened. Removing the inline script from those two files is the real fix and is
  a backend change — worth a follow-up. Hash-pinning was rejected: the hashes would
  live in this file while the HTML lives in another package.
- **`/api/` and `/trpc` are deliberately excluded, and nothing is set at server
  scope.** The backend runs helmet and already sends its own CSP, `X-Frame-Options`
  and HSTS (with `includeSubDomains`) there. `add_header` appends rather than
  replaces, so a server-scope declaration would emit two of each: a browser enforces
  the intersection of two CSPs, treats conflicting `X-Frame-Options` as invalid, and
  per RFC 6797 honours only the first HSTS — the upstream one, silently discarding
  this file's. Express *static* responses (the two login pages and `/style.css`) do
  not pass through helmet, verified live, so adding headers there duplicates nothing.
- **`x-content-type-options` and `referrer-policy` are left to the edge**: the
  managed policy's values already match legacy, so there is no gap to close.
  The COOP/COEP/CORP trio legacy also serves is still absent at the edge and is out
  of scope here.
- **This will turn the Send edge parity suite red until its expectations are
  updated** (https://github.com/thunderbird/platform-infrastructure/pull/1058, which
  says as much: "FAIL here is a deliberate change (for example the CSP gap is
  closed)"). Seven expectations flip: `ORIGIN:csp` absent→present, `ORIGIN:xfo`
  ""→`DENY`, `ORIGIN:hsts` ""→`max-age=31536000; includeSubDomains`,
  `ORIGIN:sec_headers` absent→`partial(missing: x-content-type-options
  referrer-policy x-xss-protection)`, `EDGE:csp` absent→present, `EDGE:xfo`
  `SAMEORIGIN`→`DENY`, `EDGE:hsts` →`max-age=31536000; includeSubDomains`. The
  suite's security-header probe runs on `/` only; the per-path assertions there are
  `cache-control`, which this PR does not touch.

### Verification

Done: `nginx -t` on the rendered config in `nginx:1.28.3`; the config run in a
container against a stub backend and probed per path — `/`, `/index.html`,
`/config.js`, `/assets/<hashed>.js`, a missing asset (404), a `.map` (404),
`/share/xyz`, `/icons/`, `/login-success.html`, `/login-failed.html`, `/style.css`,
`/50x.html` (500) — each returns exactly one of each header with the right policy,
and `/api/`+`/trpc` return none from nginx; `40-send-config.sh` re-rendered with
tb-dev values, still writing `config.js` and still rewriting all five `proxy_pass`
upstreams.

Not done, and cannot be from here: the fixed headers at the live edge. That needs an
image build and a Kargo promotion to tb-dev. After it lands:

```
for p in / /index.html /config.js /login-success.html /style.css /50x.html; do
  echo "== $p"
  curl -sI "https://send.tb-dev.thunderbird.dev$p" \
    | grep -iE '^HTTP|^content-security-policy|^x-frame-options|^strict-transport-security'
done
curl -sI https://send.tb-dev.thunderbird.dev/api/health \
  | grep -ci '^content-security-policy'   # must stay 1, not 2
```

Then log in once and watch the console: the popup must close on its own, and there
must be no CSP violation from the Keycloak discovery/token fetch or from a B2 upload.

## Applicable Issues

Refs https://github.com/thunderbird/platform-infrastructure/issues/914
Refs https://github.com/thunderbird/platform-infrastructure/pull/1058
Related, different stack (S3/CloudFront CSP generation):
https://github.com/thunderbird/tbpro-add-on/issues/224
