### PR TITLE
fix(send-frontend): serve CSP, X-Frame-Options and HSTS from the nginx origin

### DIFF
--- a/packages/send/frontend/docker/docker-entrypoint.d/40-send-config.sh
+++ b/packages/send/frontend/docker/docker-entrypoint.d/40-send-config.sh
@@ -14,11 +14,16 @@
 # unset is written as an empty string, and src/config.ts treats empty as unset.
 #
 # NAMESPACE NOTE: every APP_* var this script reads is emitted into the
-# publicly-served config.js, with exactly two exceptions -- APP_CONFIG_PATH and
-# APP_API_UPSTREAM below configure the entrypoint/nginx themselves and never
-# reach the browser. Keep it that way: a new APP_* var must be either clearly
-# public SPA config (add it to the jq object AND src/config.ts AND
-# public/config.js) or renamed out of the pattern.
+# publicly-served config.js, with three exceptions -- APP_CONFIG_PATH,
+# APP_API_UPSTREAM and APP_CSP_REPORT_ONLY below configure the entrypoint/nginx
+# themselves and never reach the browser. Keep it that way: a new APP_* var must
+# be either clearly public SPA config (add it to the jq object AND src/config.ts
+# AND public/config.js) or renamed out of the pattern.
+#
+# Two of the public vars are read a SECOND time below, to build the nginx CSP:
+# APP_SEND_SERVER_URL and APP_OIDC_ROOT_URL must each be an https:// URL with a
+# plain host[:port] or they are dropped from the policy with a warning. Every
+# other APP_* var is unvalidated -- widening either of those two is not free.
 set -eu
 
 CONFIG_PATH="${APP_CONFIG_PATH:-/usr/share/nginx/html/config.js}"
@@ -86,6 +91,93 @@ if [ -z "${APP_ENV:-}" ]; then
   echo "send: WARNING APP_ENV is unset; the SPA will report a fallback environment (staging) and use the -stage sibling-service URLs" >&2
 fi
 
+# Substitute the two environment-specific origins into the Content-Security-Policy
+# in the nginx config. They are baked as `*.invalid` HOST placeholders inside the
+# $send_csp map -- see the note above that map in send.conf for why they are
+# templated, and why the OIDC entry must be an origin rather than
+# APP_OIDC_ROOT_URL verbatim.
+#
+# Only the HOST is substituted; the `https://` and `wss://` schemes stay baked in
+# the config, so no value can introduce a scheme of its own.
+#
+# NO SUPPLIED VALUE IS FATAL. Missing or unusable, it leaves the .invalid
+# placeholder, which keeps the policy complete and enforced; `'self'` still
+# covers the same-origin API and both WebSockets, so the visible symptom is a
+# CSP violation on OIDC login rather than a header that quietly went missing.
+# That matters because this image is also published to GHCR for plain
+# Docker/Compose consumers, whose `http://localhost` origins would otherwise
+# turn a security-header change into a boot crash-loop. The only fatal case is
+# a placeholder that is ALREADY gone, which means conf.d is not the image layer.
+
+# Reduce an https:// URL to its bare host[:port] in CSP_HOST. Returns non-zero
+# and sets nothing if the value cannot be used. The character class is the same
+# one APP_API_UPSTREAM uses below and for the same reasons: this value is
+# interpolated into an nginx config by sed.
+csp_host() {
+  csp_host_var="$1"
+  csp_host_url="$2"
+  case "$csp_host_url" in
+    https://*) ;;
+    *)
+      echo "send: WARNING $csp_host_var is not an https:// URL, so it is left out of the CSP: '$csp_host_url'" >&2
+      return 1
+      ;;
+  esac
+  CSP_HOST="${csp_host_url#https://}"
+  CSP_HOST="${CSP_HOST%%/*}"
+  CSP_HOST="${CSP_HOST%%\?*}"
+  CSP_HOST="${CSP_HOST%%#*}"
+  case "$CSP_HOST" in
+    '' | *[!A-Za-z0-9.:_-]*)
+      echo "send: WARNING $csp_host_var has no plain host[:port], so it is left out of the CSP: '$csp_host_url'" >&2
+      return 1
+      ;;
+  esac
+}
+
+# One-shot against a placeholder, with the same assertion the upstream rewrite
+# below uses and for the same reason: if it is already gone, /etc/nginx/conf.d is
+# not coming from the immutable image layer and this would otherwise silently
+# keep the previous start's value.
+csp_replace() {
+  if ! grep -q "$1" /etc/nginx/conf.d/default.conf; then
+    echo "send: FATAL CSP placeholder $1 already replaced; is /etc/nginx/conf.d on a persistent volume?" >&2
+    exit 1
+  fi
+  sed -i "s|$1|$2|g" /etc/nginx/conf.d/default.conf
+}
+
+# csp_host runs as an `if` condition, so its non-zero return is not a `set -e`
+# abort -- it falls through to the warning below.
+if [ -n "${APP_SEND_SERVER_URL:-}" ] && csp_host APP_SEND_SERVER_URL "${APP_SEND_SERVER_URL}"; then
+  csp_replace 'send-origin.invalid' "${CSP_HOST}"
+  echo "send: CSP connect-src send origin set to ${CSP_HOST}"
+else
+  echo "send: WARNING CSP keeps send-origin.invalid; same-origin API calls and B2 uploads still work, the WebSockets fall back to 'self'" >&2
+fi
+
+if [ -n "${APP_OIDC_ROOT_URL:-}" ] && csp_host APP_OIDC_ROOT_URL "${APP_OIDC_ROOT_URL}"; then
+  csp_replace 'oidc-origin.invalid' "${CSP_HOST}"
+  echo "send: CSP connect-src OIDC origin set to ${CSP_HOST}"
+else
+  echo "send: WARNING CSP keeps oidc-origin.invalid; OIDC login will be blocked" >&2
+fi
+
+# ESCAPE HATCH. The policy is ENFORCED by default, but a CSP violation is
+# invisible server-side -- no report-uri collector exists, and a blocked fetch
+# never reaches this origin -- so the posture is flippable without an image
+# rebuild while a suspected breakage is diagnosed. Set APP_CSP_REPORT_ONLY=1 and
+# restart the pod; unset means enforced.
+if [ "${APP_CSP_REPORT_ONLY:-}" = "1" ]; then
+  if ! grep -q 'add_header Content-Security-Policy ' /etc/nginx/conf.d/default.conf; then
+    echo "send: FATAL CSP header already renamed; is /etc/nginx/conf.d on a persistent volume?" >&2
+    exit 1
+  fi
+  sed -i 's|add_header Content-Security-Policy |add_header Content-Security-Policy-Report-Only |g' \
+    /etc/nginx/conf.d/default.conf
+  echo "send: WARNING APP_CSP_REPORT_ONLY=1 -- the CSP is report-only and nothing is enforced" >&2
+fi
+
 # Point the nginx API/tRPC proxy at the backend. On EKS the backend is a SEPARATE
 # Service, so the baked default (send-backend:8080, for a compose/sidecar
 # topology) must be overridden. Set APP_API_UPSTREAM to host:port with NO scheme,
@@ -99,7 +191,7 @@ fi
 if [ -n "${APP_API_UPSTREAM:-}" ]; then
   # Validate before substituting. This value is interpolated into an nginx config
   # by sed, so an unvalidated one is both a config-injection point and a
-  # silent-corruption point:
+  # silent-corruption point (same class as csp_host above):
   #   * `&` in the replacement expands to the whole matched text
   #     ("a&b:8080" -> "asend-backend:8080b:8080");
   #   * a `}` closes the location block and everything after it is parsed as

--- a/packages/send/frontend/docker/etc/nginx/conf.d/send.conf
+++ b/packages/send/frontend/docker/etc/nginx/conf.d/send.conf
@@ -11,22 +11,40 @@
 # LOAD-BEARING rather than a nicety: the JS bundle is over 1 MB, so anything
 # reaching the origin hostname directly transfers it uncompressed.
 #
-# SECURITY HEADERS ARE THE EDGE'S JOB and are deliberately NOT set here.
-#
-# The S3/CloudFront path gets CSP, HSTS, X-Frame-Options, X-Content-Type-Options,
-# Referrer-Policy and COOP/COEP/CORP from `packages/send/pulumi/cloudfront.py`.
-# The equivalent for this image is a CloudFront ResponseHeadersPolicy on the
-# Pattern-C distribution, which lives in thunderbird/platform-infrastructure and
-# must be in place before this image serves user traffic.
+# SECURITY HEADERS ARE THIS ORIGIN'S JOB. The Pattern-C distribution attaches
+# AWS's Managed-SecurityHeadersPolicy (67f7725c), whose ContentSecurityPolicy
+# entry is empty and whose every other entry is `Override: false` -- CloudFront
+# supplies a value ONLY when the origin sends none. With nothing set here the
+# viewer got no CSP at all, `SAMEORIGIN` instead of `DENY`, and an HSTS max-age
+# with no `includeSubDomains`: a downgrade against the legacy S3/CloudFront
+# stack this image replaces (packages/send/pulumi/cloudfront.py). Setting them
+# here is what fixes the edge; no distribution change is involved.
 #
 # `csp.config.js` in this package CANNOT cover this image: it builds `connect-src`
 # from build-time VITE_SEND_SERVER_URL / VITE_OIDC_ROOT_URL / VITE_POSTHOG_HOST /
 # VITE_SENTRY_DSN, and this image deliberately bakes none of them, so it would
-# emit a `'self'`-only policy that breaks OIDC, PostHog, Sentry and B2. If a
-# policy is ever wanted at the ORIGIN instead, generate it in
-# docker-entrypoint.d/40-send-config.sh from the APP_* values that script already
-# reads -- and repeat every header in EVERY location block below, because a
-# location-level `add_header` drops all inherited ones.
+# emit a `'self'`-only policy that breaks OIDC, PostHog, Sentry and B2. The
+# policies below are http-scope `map`s instead, and the two environment-specific
+# origins in `connect-src` are substituted at container start by
+# docker-entrypoint.d/40-send-config.sh.
+#
+# THE INHERITANCE TRAP, which is why these three headers are declared at ten
+# sites below -- eight full sets plus the X-Frame-Options/HSTS pair in /api/ and
+# /trpc: a location-level `add_header` drops EVERY header inherited from an
+# outer scope, so the server-scope declaration reaches only the locations that
+# declare no `add_header` of their own (/style.css, /50x.html). A NESTED location
+# inherits from its ENCLOSING location, not from server scope -- `~ \.map$` takes
+# its set from /assets/. Every location that sets its own Cache-Control has to
+# re-declare all three. Adding a location with an `add_header` and forgetting
+# this is silent -- `nginx -t` passes and the headers are simply absent on that
+# one path.
+#
+# THE MIRROR TRAP, on every location that proxies to the backend: `add_header`
+# APPENDS to what the upstream sent. Two CSPs are enforced as their intersection
+# and RFC 6797 makes a browser honour only the FIRST HSTS, so an upstream bare
+# `max-age` would silently reinstate the gap this file closes. Hence the
+# `proxy_hide_header`s. /api/ and /trpc also omit the CSP, leaving it to helmet
+# (backend/src/index.ts), which is stricter there than the SPA's.
 
 # Connection header for the WebSocket upgrade dance: "upgrade" when the client
 # asked for an upgrade, "close" otherwise. MUST be at http scope, which is where
@@ -34,6 +52,50 @@
 map $http_upgrade $connection_upgrade {
     default upgrade;
     ''      close;
+}
+
+# The policy, declared once because of the ten declaration sites described above
+# -- a ~450-character string copied out that many times is a drift hazard. `map`
+# rather than `set` so it sits at http scope beside the map above, and because an
+# empty value makes nginx omit the header.
+#
+# Derived from the policy this same SPA bundle already enforces in production on
+# send-stage.tb.pro, with four deliberate differences:
+#   * `https://fonts.googleapis.com` (style-src) and `https://fonts.gstatic.com`
+#     (font-src) are DROPPED -- the 36 .woff2 under public/fonts are self-hosted
+#     and neither host is referenced anywhere in the frontend. They are dead
+#     entries in the legacy policy, inherited from csp.config.js.
+#   * the legacy PostHog trio collapses to `https://*.i.posthog.com`, because
+#     APP_POSTHOG_HOST is per-environment and posthog-js derives its assets host
+#     from the region, so the US pair would break an EU deployment. The legacy
+#     `https://*.posthog.com/*` was dead: a CSP host-source whose path does not
+#     end in `/` is matched EXACTLY, so it only matched the literal path `/*`.
+#   * the legacy `https://send-backend-stage.tb.pro/` + `wss://` pair becomes the
+#     SEND origin placeholders below: Pattern C puts the API on the SPA's own
+#     origin, so this is now the site's own host.
+#   * `https://auth-stage.tb.pro/` becomes the OIDC origin placeholder. It has to
+#     be a bare ORIGIN, not APP_OIDC_ROOT_URL verbatim: that value carries the
+#     `/realms/tbpro` path, and by the exact-match rule above it would then allow
+#     only that one path and block the .well-known discovery fetch -- login dead
+#     under a policy that reads as correct.
+#
+# Those two are TEMPLATED, not a baked list of every environment's hostnames,
+# and naming the send origin outright keeps coverage of `wss://<send origin>`
+# (/api/ws for uploads, /trpc/ws) off the `'self'`-matches-`wss:` rule. The
+# `.invalid` defaults (RFC 2606: they never resolve) keep the policy COMPLETE
+# AND ENFORCED if the entrypoint substitutes nothing -- `'self'` still covers
+# the same-origin API and both sockets, so the visible failure is OIDC login.
+map $host $send_csp {
+    default "default-src 'self'; script-src 'self' blob: https://*.i.posthog.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; font-src 'self' data:; object-src 'none'; frame-ancestors 'none'; connect-src 'self' https://send-origin.invalid wss://send-origin.invalid https://oidc-origin.invalid https://*.i.posthog.com https://*.backblazeb2.com https://*.sentry.io";
+}
+
+# `includeSubDomains` is the whole point of this one -- the CloudFront managed
+# policy supplies a bare max-age. No `preload`: legacy does not send it, and it
+# is a practically irreversible commitment for this host and everything under
+# it. `includeSubDomains` binds only names under THIS host -- sibling services in
+# the same zone (accounts., auth., appointment.) are unaffected.
+map $host $send_hsts {
+    default "max-age=31536000; includeSubDomains";
 }
 
 # $remote_addr is the private address of whatever proxied the request (an in-VPC
@@ -91,6 +153,18 @@ server {
 
     access_log  /var/log/nginx/access.log  send_json;
 
+    # The baseline. Reaches /style.css and /50x.html -- and any location added
+    # later that declares no `add_header` of its own -- and nothing else, per THE
+    # INHERITANCE TRAP above. `always` on all three, or they are absent from the
+    # `try_files =404`s below, from nginx-generated 400/403/413, and from the
+    # whole of a backend outage (a 5xx redirects internally to /50x.html, which
+    # declares no `add_header` and so inherits this set). /api/ and /trpc drop
+    # the CSP deliberately, so an nginx-generated 413 there carries only the
+    # XFO/HSTS pair -- nginx's own inert error page, accepted rather than missed.
+    add_header Content-Security-Policy $send_csp always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Strict-Transport-Security $send_hsts always;
+
     # File bytes never traverse this proxy: uploads go over the /api/ws
     # WebSocket or straight to B2 with a signed URL. This bound only has to
     # clear the JSON request bodies of the REST API.
@@ -144,6 +218,16 @@ server {
         # pressure too. Streaming to the backend is also the right behaviour
         # for the WebSocket endpoints under this prefix.
         proxy_request_buffering off;
+        # Replace, do not append -- see THE MIRROR TRAP at the top of this file.
+        # helmet sends `X-Frame-Options: sameorigin` here beside its own
+        # `frame-ancestors 'none'`, which browsers honour instead, so this
+        # override is header-set hygiene, not the reported gap (`frameguard` in
+        # backend/src/index.ts is the real fix). Declaring these also drops the
+        # inherited CSP, which is the intent: helmet's is stricter here.
+        proxy_hide_header X-Frame-Options;
+        proxy_hide_header Strict-Transport-Security;
+        add_header X-Frame-Options "DENY" always;
+        add_header Strict-Transport-Security $send_hsts always;
     }
 
     # tRPC over HTTP (/trpc) and over WebSocket (/trpc/ws).
@@ -159,17 +243,35 @@ server {
         proxy_read_timeout 3600s;
         proxy_send_timeout 3600s;
         proxy_request_buffering off;
+        # Same reasoning as /api/ above.
+        proxy_hide_header X-Frame-Options;
+        proxy_hide_header Strict-Transport-Security;
+        add_header X-Frame-Options "DENY" always;
+        add_header Strict-Transport-Security $send_hsts always;
     }
 
-    # Backend-rendered OIDC/login landing pages. They are not part of dist-web,
-    # so without these they would fall through to the SPA shell. The Vite dev
-    # server proxies exactly these two paths to the backend for the same reason.
+    # Backend-rendered landing pages, orphaned but still routed: nothing in this
+    # repo navigates to them (the OIDC redirect_uri is `<origin>/post-login`, an
+    # SPA route served by `location /`). They are not in dist-web, so without
+    # these they would fall through to the SPA shell -- the Vite dev server
+    # proxies exactly these two paths for the same reason. They take $send_csp
+    # like everything else: their inline <script> countdown and inline
+    # onclick="window.close()" do not survive `script-src 'self'`, and losing
+    # those beats granting 'unsafe-inline' for a flow nothing reaches.
     location = /login-success.html {
         proxy_pass http://send-backend:8080;
         proxy_http_version 1.1;
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $http_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+        # Replace, do not append: express.static is mounted before helmet today
+        # (backend/src/index.ts), and this must not depend on that order holding.
+        proxy_hide_header Content-Security-Policy;
+        proxy_hide_header X-Frame-Options;
+        proxy_hide_header Strict-Transport-Security;
+        add_header Content-Security-Policy $send_csp always;
+        add_header X-Frame-Options "DENY" always;
+        add_header Strict-Transport-Security $send_hsts always;
     }
     location = /login-failed.html {
         proxy_pass http://send-backend:8080;
@@ -177,6 +279,13 @@ server {
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $http_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+        # Same as /login-success.html above.
+        proxy_hide_header Content-Security-Policy;
+        proxy_hide_header X-Frame-Options;
+        proxy_hide_header Strict-Transport-Security;
+        add_header Content-Security-Policy $send_csp always;
+        add_header X-Frame-Options "DENY" always;
+        add_header Strict-Transport-Security $send_hsts always;
     }
     # The login pages' stylesheet. It lives in backend/public (the frontend
     # build copies src/apps/send/style.css there), NOT in dist-web -- without
@@ -187,14 +296,24 @@ server {
         proxy_pass http://send-backend:8080;
         proxy_http_version 1.1;
         proxy_set_header Host $http_host;
+        # Inherits the server-scope set, which would APPEND to whatever the
+        # upstream sent. Same hide as the login pages above.
+        proxy_hide_header Content-Security-Policy;
+        proxy_hide_header X-Frame-Options;
+        proxy_hide_header Strict-Transport-Security;
     }
 
     # Content-hashed Vite bundles: the filename changes whenever the bytes do,
     # so these are safe to cache forever.
     location ^~ /assets/ {
         # Deliberately no `always`: the =404 below must not carry this header,
-        # or a missing asset gets cached for a year.
+        # or a missing asset gets cached for a year. `always` is a per-directive
+        # flag, not a per-block one, so the security headers still reach that 404.
         add_header Cache-Control "public, max-age=31536000, immutable";
+        # Re-declared: inheritance trap, see the top of this file.
+        add_header Content-Security-Policy $send_csp always;
+        add_header X-Frame-Options "DENY" always;
+        add_header Strict-Transport-Security $send_hsts always;
         # 404 a missing asset instead of falling through to the SPA shell, which
         # would otherwise be served as JS and fail with a MIME/syntax error.
         try_files $uri =404;
@@ -224,8 +343,12 @@ server {
     # A future restyle is cheaper as a directory bump (/fonts/v2/...).
     location ^~ /fonts/ {
         # Deliberately no `always`, matching /assets/ above: the =404 below must not
-        # carry a one-year TTL.
+        # carry a one-year TTL. The security headers keep theirs.
         add_header Cache-Control "public, max-age=31536000, immutable";
+        # Re-declared: inheritance trap, see the top of this file.
+        add_header Content-Security-Policy $send_csp always;
+        add_header X-Frame-Options "DENY" always;
+        add_header Strict-Transport-Security $send_hsts always;
         try_files $uri =404;
     }
 
@@ -235,12 +358,20 @@ server {
     # of shared/CDN storage.
     location = /index.html {
         add_header Cache-Control "no-store";
+        # Re-declared: inheritance trap, see the top of this file.
+        add_header Content-Security-Policy $send_csp always;
+        add_header X-Frame-Options "DENY" always;
+        add_header Strict-Transport-Security $send_hsts always;
     }
 
     # Runtime config, rewritten by docker-entrypoint.d on every container boot.
     # Caching this would pin an environment's config into a shared cache.
     location = /config.js {
         add_header Cache-Control "no-store";
+        # Re-declared: inheritance trap, see the top of this file.
+        add_header Content-Security-Policy $send_csp always;
+        add_header X-Frame-Options "DENY" always;
+        add_header Strict-Transport-Security $send_hsts always;
     }
 
     # NOTE on the two `no-store` locations above: the intent only holds end to end
@@ -258,6 +389,10 @@ server {
     # location's TTL.
     location / {
         add_header Cache-Control "public, max-age=300";
+        # Re-declared: inheritance trap, see the top of this file.
+        add_header Content-Security-Policy $send_csp always;
+        add_header X-Frame-Options "DENY" always;
+        add_header Strict-Transport-Security $send_hsts always;
         # No `$uri/` clause: a bare directory URL (/icons/) would match the
         # real directory, find no index file, and 403 -- SPA fallback is the
         # right answer for those too.


### PR DESCRIPTION
Closes the three-header security-posture downgrade the Send edge parity suite found on tb-dev
(https://github.com/thunderbird/platform-infrastructure/pull/1058). Send frontend nginx only — no CloudFront,
Pulumi or app change.

| header | legacy `send-stage.tb.pro` | tb-dev edge today | after this |
|---|---|---|---|
| `content-security-policy` | full policy | **absent** | full policy |
| `x-frame-options` | `DENY` | `SAMEORIGIN` | `DENY` |
| `strict-transport-security` | `max-age=31536000; includeSubDomains` | `max-age=31536000` | `max-age=31536000; includeSubDomains` |

**Those values are CloudFront's, not nginx's, and the origin outranks them.** Read directly, not inferred:

```
aws cloudfront get-response-headers-policy --id 67f7725c-6f97-4210-82d7-5512b31e9d03  # Managed-SecurityHeadersPolicy
  FrameOptions {Override:false, SAMEORIGIN}   StrictTransportSecurity {Override:false, 31536000}
  ReferrerPolicy/XSSProtection {Override:false}   ContentSecurityPolicy {}   ContentTypeOptions {Override:true}
aws cloudfront get-distribution-config --id E1O1C4QY9LB2MO
  that policy on all 5 behaviours; LambdaFunctionAssociations = FunctionAssociations = 0 on every one
```

`Override:false` = the origin's header wins; the empty `ContentSecurityPolicy` neither sets nor strips one. Confirmed
live on that distribution today: `/api/health` delivers the backend's helmet `referrer-policy: no-referrer`,
`x-xss-protection: 0` and HSTS `…; includeSubDomains` to the viewer, while `/` delivers CloudFront's
`strict-origin-when-cross-origin`, `1; mode=block` and bare `max-age`. Sending the headers from nginx is therefore
sufficient.

## The policy

```
default-src 'self'; script-src 'self' blob: https://*.i.posthog.com;
worker-src 'self' blob:; style-src 'self' 'unsafe-inline';
img-src 'self' https: data:; font-src 'self' data:;
object-src 'none'; frame-ancestors 'none';
connect-src 'self' https://<send origin> wss://<send origin> https://<oidc origin>
  https://*.i.posthog.com https://*.backblazeb2.com https://*.sentry.io
```

**Enforced, not Report-Only.** Report-Only is a different header name, so the measured CSP would stay absent and the
gap would not actually close; there is no `report-uri` collector either way; and this is the directive set the same SPA
bundle already enforces on `send-stage.tb.pro`. The genuine risk is `connect-src`, which Pattern C rebuilds — so the
entrypoint takes `APP_CSP_REPORT_ONLY=1` to demote the policy at container start. Recovery on tb-dev is a Deployment
env edit and a pod restart, not a rebuild and re-promotion.

**Templated, not static wildcards.** The send and OIDC origins vary per environment; they are substituted into
`*.invalid` placeholders (RFC 2606) at container start, reusing the validation discipline `APP_API_UPSTREAM` already
has — https-only, bare `host[:port]`, only the host substituted so no value can inject a scheme, and the same
placeholder-still-present assertion so a one-shot rewrite cannot silently no-op. A bad or missing value warns and
leaves `.invalid`: the policy stays complete and enforced, and the image keeps booting for the GHCR
Docker/Compose consumers whose origin is `http://localhost`. No new public `APP_*` var — both are already published in
`config.js`.

Four deliberate differences from legacy, each checked against the deployed artefacts:

- **Backend origin → the send origin.** Pattern C puts the API on the SPA's own host, so `'self'` covers it. The origin
  is still named so that `wss://<origin>/api/ws` (uploads, `lib/helpers.ts:75`) and `/trpc/ws` (`lib/trpc.ts:80`) never
  rest on the `'self'`-matches-`wss:` rule.
- **OIDC as a bare origin, not `APP_OIDC_ROOT_URL` verbatim.** That value carries `/realms/tbpro`; a CSP host-source
  whose path does not end in `/` matches exactly, so verbatim would allow one path and block `.well-known` discovery —
  login dead under a policy that reads correct.
- **PostHog trio → `https://*.i.posthog.com`.** `APP_POSTHOG_HOST` is per-environment and posthog-js derives its assets
  host from the region, so the US pair would break an EU deployment. Legacy's `https://*.posthog.com/*` was already
  dead by the same exact-path rule.
- **Google Fonts dropped.** `fonts.googleapis.com`/`fonts.gstatic.com` appear nowhere in `frontend/src`, `index.html`,
  `public/` or `backend/public/`; all 36 faces are self-hosted `.woff2`. A deliberate reduction below legacy.

`https://*.backblazeb2.com` is required: uploads are a browser-direct `XMLHttpRequest` `PUT` to a signed URL
(`lib/helpers.ts:334`), governed by `connect-src`.

`X-Frame-Options: DENY` ships alongside `frame-ancestors 'none'` — redundant for modern browsers, but it is the header
the gap was measured on, legacy sends both, and nothing self-frames (no `<iframe>` in `frontend/src`;
`automaticSilentRenew: false` in `stores/auth-store.ts` rules out the oidc-client-ts hidden iframe).

`/login-success.html` and `/login-failed.html` take the same policy rather than a relaxed one. Nothing navigates to
them — the OIDC `redirect_uri` is `<origin>/post-login`, an SPA route (`stores/auth-store.ts:23`) — so their inline
countdown and `onclick="window.close()"` are not worth `'unsafe-inline'`. De-inlining them in `backend/public` is the
real fix.

## Two inheritance traps

A location-level `add_header` drops **every** inherited header, which is why the three are declared at ten sites. Two
additions to what the file already documented:

- a **nested** location inherits from its enclosing location, not from server scope (`~ \.map$` takes its set from
  `/assets/`);
- `add_header` **appends** to what an upstream sent. `/style.css`, `/login-success.html` and `/login-failed.html` proxy
  to the backend and lacked the `proxy_hide_header` trio `/api/` and `/trpc` had. Reproduced against a stub upstream:
  two CSPs, and `SAMEORIGIN` before `DENY`. RFC 6797 §8.1 makes a browser honour only the first HSTS, so an upstream
  bare `max-age` would silently reinstate the gap this PR closes. Latent today only because `express.static` mounts
  above helmet in `backend/src/index.ts`. Now guarded.

## Verified here

`nginx:1.28.3` (the `deploy.dockerfile` base) in podman, stub upstream emitting helmet-shaped
CSP / `X-Frame-Options: SAMEORIGIN` / HSTS:

- `nginx -t` passes un-substituted (the build-time gate) and entrypoint-rendered.
- 16 paths probed with occurrence counts — `/`, `/index.html`, `/config.js`, `/style.css`, both login pages,
  `/assets/<hashed>.js`, a missing `/assets/` 404, an `/assets/*.map` 404 (nested), `/fonts/<f>.woff2`, a missing
  `/fonts/` 404, `/api/health`, `/trpc`, `/50x.html` (500), `/share/abc`, `/icons/x.svg`: **exactly one** of each
  header on every path, never zero, never two. The same probe on the pre-fix config reproduces the append defect.
- `/api/ws` and `/trpc/ws`: `101 Switching Protocols`, correct `Sec-WebSocket-Accept`, first frame delivered, upstream
  headers replaced not appended.
- Entrypoint: unset origins → warn, boot, complete enforced policy; `http://localhost` → warn, boot;
  `APP_OIDC_ROOT_URL='https://a.example.com"; add_header X-Evil 1; #'` → rejected, no `X-Evil`, container boots;
  `APP_CSP_REPORT_ONLY=1` → every site flips, including inherited paths. `shellcheck -s sh` clean.

## Not verified — needs image build + Kargo promotion to tb-dev

The fixed headers cannot be observed at the live edge from here. After promotion:

```sh
for p in / /index.html /config.js /style.css /login-success.html /login-failed.html \
         /assets/ /fonts/ /api/health /trpc; do
  printf '== %s\n' "$p"
  curl -sSI "https://send.tb-dev.thunderbird.dev$p" \
    | grep -iE '^HTTP|^content-security-policy|^x-frame-options|^strict-transport-security'
done
curl -sSI https://send.tb-dev.thunderbird.dev/api/health | grep -ci '^content-security-policy'   # must be 1, not 2
```

`/fonts/*` has no dedicated behaviour, falls under `*`, and is served `immutable` under stable non-hashed filenames —
an `x-cache: Hit` there with old headers is a stale object, not a failed fix; clear with
`aws cloudfront create-invalidation --paths '/fonts/*'`.

## Follow-up

**This turns the parity suite red on 7 assertions.** `scripts/send/edge-parity.sh` in
https://github.com/thunderbird/platform-infrastructure/pull/1058 encodes today's downgraded values as expected:

| line | expectation | becomes |
|---|---|---|
| `:531` | `EDGE:csp` / `ORIGIN:csp` → absent | the policy above |
| `:538` | `EDGE:xfo` → `SAMEORIGIN` | `DENY` |
| `:540` | `ORIGIN:xfo` → `""` | `DENY` |
| `:541` | `EDGE:hsts` → `max-age=31536000` | `; includeSubDomains` |
| `:543` | `ORIGIN:hsts` → `""` | `max-age=31536000; includeSubDomains` |
| `:525` | `ORIGIN:sec_headers` → absent | `partial(missing: x-content-type-options referrer-policy x-xss-protection)` |

It reads the live tb-dev edge, so that update must merge **after** this image is promoted, not alongside this PR. The
posture-DROP `note` at `:1031-1035` self-clears and should be deleted, and `docs/send-edge-parity.md:321` prescribes
"reinstate a CSP on the Pattern C ResponseHeadersPolicy" — a remedy this PR makes unnecessary.

**Correction to that suite's stated coverage:** it probes security headers from `/` only (`fetch "https://$host/" -I`,
`:1007`); only `cache-control` is per-path. The per-location coverage above rests on the audit and the container probe.

**Out of scope:** the edge sends `x-xss-protection: 1; mode=block` on SPA paths where legacy sends none and helmet
sends `0` — closing it means a fourth header at all ten sites. Separately, `backend/src/index.ts` sets
`frameguard: { action: 'sameorigin' }` alongside its own `frame-ancestors 'none'`, so the backend ships a
self-contradictory pair for every deployment not behind this nginx.

**Overlap:** https://github.com/thunderbird/tbpro-add-on/pull/1155 is an alternative fix for the same three headers.
Only one should land. This one additionally templates the per-environment origins, guards the three proxied locations
against upstream append, drops the dead Google Fonts and PostHog sources, and adds the Report-Only hatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
