### PR TITLE
fix(send-backend): refuse /api/ws wherever storage is a bucket (#44)

### DIFF
--- a/packages/send/backend/src/test/ws/setup.test.ts
+++ b/packages/send/backend/src/test/ws/setup.test.ts
@@ -1,8 +1,13 @@
 import { TRPC_WS_PATH } from '@send-backend/config';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { mockValidateJWT, mockUploadHandler, mockUploadServer, mockWss } =
-  vi.hoisted(() => ({
+const {
+  mockValidateJWT,
+  mockUploadHandler,
+  mockUploadServer,
+  mockWss,
+  storage,
+} = vi.hoisted(() => ({
     mockValidateJWT: vi.fn(),
     mockUploadHandler: vi.fn(),
     mockUploadServer: { handleUpgrade: vi.fn(), emit: vi.fn() },
@@ -12,7 +17,18 @@ const { mockValidateJWT, mockUploadHandler, mockUploadServer, mockWss } =
       on: vi.fn(),
       clients: new Set(),
     },
+    // `IS_USING_BUCKET_STORAGE` is a module-level const, so it cannot be
+    // stubbed through the environment after `config` has been imported. A
+    // getter over this holder gives the suite a value it can move per test.
+    storage: { isBucket: true },
   }));
+
+vi.mock('@send-backend/config', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@send-backend/config')>()),
+  get IS_USING_BUCKET_STORAGE() {
+    return storage.isBucket;
+  },
+}));
 
 vi.mock('../../auth/jwt', () => ({ validateJWT: mockValidateJWT }));
 vi.mock('../../wsUploadHandler', () => ({ default: mockUploadHandler }));
@@ -30,7 +46,10 @@ const UPLOAD_PATH = '/api/ws';
  * `/api/ws` hands the socket to an upload handler that streams into storage on
  * the server's own credentials. The upgrade used to be performed with no token
  * check at all, so anyone who could reach the host could write to the bucket
- * (private-issue-tracking#44).
+ * (private-issue-tracking#44). A session is required now, and where storage is
+ * a bucket -- which is every deployment -- the path is refused outright: the
+ * handler runs no `checkStorageLimit` and writes no database row, so a session
+ * alone still buys unaccounted writes.
  */
 describe('wsHandler', () => {
   let upgrade: (req, socket, head) => void;
@@ -46,31 +65,60 @@ describe('wsHandler', () => {
     // which quietly turned the no-token cases below into no-ops. Unauthenticated
     // is the safe default to leak.
     mockValidateJWT.mockReturnValue(null);
+    // What every deployment runs. The filesystem cases below opt out.
+    storage.isBucket = true;
     const server = { on: vi.fn() };
     wsHandler(server);
     upgrade = server.on.mock.calls.find(([event]) => event === 'upgrade')[1];
   });
 
-  it('refuses an unauthenticated upgrade to the upload path with 401', () => {
-    mockValidateJWT.mockReturnValue(null);
-    const s = socket();
+  // Where a bucket exists the client never takes this path, so these hold only
+  // for a filesystem dev stack -- the one configuration that still uploads over
+  // the socket. They are the gate from the first half of the fix; the bucket
+  // cases below are what covers every deployment.
+  describe('on a filesystem stack, where the path is still live', () => {
+    beforeEach(() => {
+      storage.isBucket = false;
+    });
 
-    upgrade({ url: UPLOAD_PATH, headers: {} }, s, Buffer.alloc(0));
+    it('refuses an unauthenticated upgrade to the upload path with 401', () => {
+      mockValidateJWT.mockReturnValue(null);
+      const s = socket();
 
-    expect(mockUploadServer.handleUpgrade).not.toHaveBeenCalled();
-    expect(mockUploadHandler).not.toHaveBeenCalled();
-    expect(s.end).toHaveBeenCalledWith(
-      expect.stringContaining('401 Unauthorized'),
-      expect.any(Function)
+      upgrade({ url: UPLOAD_PATH, headers: {} }, s, Buffer.alloc(0));
+
+      expect(mockUploadServer.handleUpgrade).not.toHaveBeenCalled();
+      expect(mockUploadHandler).not.toHaveBeenCalled();
+      expect(s.end).toHaveBeenCalledWith(
+        expect.stringContaining('401 Unauthorized'),
+        expect.any(Function)
+      );
+    });
+
+    // An expired access token cannot be refreshed over a handshake that is being
+    // answered right now, so only 'valid' gets through.
+    it.each(['shouldRefresh', 'shouldLogin'])(
+      'refuses the upload path when the token is %s',
+      (result) => {
+        mockValidateJWT.mockReturnValue(result);
+        const s = socket();
+
+        upgrade(
+          { url: UPLOAD_PATH, headers: { cookie: authedCookie } },
+          s,
+          Buffer.alloc(0)
+        );
+
+        expect(mockUploadServer.handleUpgrade).not.toHaveBeenCalled();
+        expect(s.end).toHaveBeenCalledWith(
+          expect.stringContaining('401'),
+          expect.any(Function)
+        );
+      }
     );
-  });
 
-  // An expired access token cannot be refreshed over a handshake that is being
-  // answered right now, so only 'valid' gets through.
-  it.each(['shouldRefresh', 'shouldLogin'])(
-    'refuses the upload path when the token is %s',
-    (result) => {
-      mockValidateJWT.mockReturnValue(result);
+    it('upgrades the upload path for a valid session', () => {
+      mockValidateJWT.mockReturnValue('valid');
       const s = socket();
 
       upgrade(
@@ -79,15 +127,14 @@ describe('wsHandler', () => {
         Buffer.alloc(0)
       );
 
-      expect(mockUploadServer.handleUpgrade).not.toHaveBeenCalled();
-      expect(s.end).toHaveBeenCalledWith(
-        expect.stringContaining('401'),
-        expect.any(Function)
-      );
-    }
-  );
+      expect(mockUploadServer.handleUpgrade).toHaveBeenCalled();
+      expect(s.end).not.toHaveBeenCalled();
+    });
+  });
 
-  it('upgrades the upload path for a valid session', () => {
+  // The pin that matters in production, and the one that survives the path's
+  // removal unchanged: a valid session is not enough.
+  it('refuses the upload path with 404 when storage is a bucket', () => {
     mockValidateJWT.mockReturnValue('valid');
     const s = socket();
 
@@ -97,8 +144,15 @@ describe('wsHandler', () => {
       Buffer.alloc(0)
     );
 
-    expect(mockUploadServer.handleUpgrade).toHaveBeenCalled();
-    expect(s.end).not.toHaveBeenCalled();
+    // Asserting on the handler as well as the status, because the status alone
+    // does not pin this: a future refactor could 404 after having already
+    // streamed the body. Nothing may reach `FileStore.set`.
+    expect(mockUploadServer.handleUpgrade).not.toHaveBeenCalled();
+    expect(mockUploadHandler).not.toHaveBeenCalled();
+    expect(s.end).toHaveBeenCalledWith(
+      expect.stringContaining('404 Not Found'),
+      expect.any(Function)
+    );
   });
 
   // Do not "harden" this one to match the upload path. Logging in happens over

--- a/packages/send/backend/src/ws/setup.ts
+++ b/packages/send/backend/src/ws/setup.ts
@@ -1,5 +1,5 @@
 // Configure sentry
-import { TRPC_WS_PATH } from '@send-backend/config';
+import { IS_USING_BUCKET_STORAGE, TRPC_WS_PATH } from '@send-backend/config';
 import '../sentry';
 
 import { logger } from '@send-backend/utils/logger';
@@ -65,6 +65,27 @@ export const wsHandler = (server) => {
 
   server.on('upgrade', (req, socket, head) => {
     if (req.url === WS_UPLOAD_PATH) {
+      // Unreachable by the product wherever there is a bucket: the client only
+      // takes this path when the backend has none, and every deployment sets
+      // STORAGE_BACKEND=b2 (`pulumi/config.{prod,stage,ci}.yaml`). Requiring a
+      // session was the first half of the fix; this is the rest of it. The
+      // handler behind it streams into storage on the server's credentials
+      // under a key it invents, and unlike `POST /api/uploads` it runs no
+      // `checkStorageLimit` and writes no database row -- so an authenticated
+      // caller could park unbounded, unaccounted objects in the bucket
+      // (private-issue-tracking#44).
+      //
+      // Only a filesystem dev stack still uploads here, and the removal of both
+      // is tracked separately. 404 rather than 403, because that is the answer
+      // the path gives once it is gone, and the pin below should not have to
+      // change when it is.
+      if (IS_USING_BUCKET_STORAGE) {
+        logger.log(
+          `⛔ Refused an upgrade to ${WS_UPLOAD_PATH}: storage is a bucket`
+        );
+        return refuse(socket, 404, 'Not Found');
+      }
+
       // This handler streams straight into storage on the server's own
       // credentials (`wsUploadHandler` -> `FileStore.set`). It used to accept
       // any peer that could reach the host (private-issue-tracking#44).


### PR DESCRIPTION
> **Stack** — replaces #1152, split for review. Merge in order:
> 1. #1158 — refuse `/api/ws` wherever storage is a bucket *(closes #44 operationally; no dependencies)*
> 2. #1159 — delete the unreachable chat app
> 3. #1160 — run dev and the default e2e lane against MinIO *(all the CI risk lives here)*
> 4. #1161 — remove the `/api/ws` upload path and `FileStore.set`
> 5. #1162 — remove `GET /api/download/:id` and `FileStore.get`
> 6. #1163 — remove the filesystem storage backend
>
> Each PR is based on the one above it, so its diff shows only its own change.

## What changed?

`/api/ws` is now refused wherever storage is a bucket — which is every deployment.

Requiring a session (#1153) closed the anonymous half of `thunderbird/private-issue-tracking#44`. This closes the rest. The handler behind that path streams into storage on the server's own credentials, under a key it invents. Unlike every route in `routes/uploads.ts` it runs no `checkStorageLimit`, and it writes no database row — that is the separate `POST /api/uploads` step, which a caller is under no obligation to make. A session alone therefore still bought unbounded, unaccounted objects in the bucket: invisible to quota accounting, invisible to the UI, and never collected.

No client reaches the path where a bucket exists. The browser only uploads over the socket when the backend has none, and `pulumi/config.{prod,stage,ci}.yaml` all set `STORAGE_BACKEND=b2`. `IS_USING_BUCKET_STORAGE` is also `true` when the variable is unset, so this fails closed.

The refusal is a 404 rather than a 403 on purpose: that is the answer the path gives once it is removed outright, so the new assertion survives the removal unchanged.

**AI disclosure.** Written with Claude Code. I set the approach and the scope; the agent traced the callers, wrote the change and the tests, and verified them. The test suite is mutation-checked — disabling the gate fails the new assertion, and a second test I had asked for turned out to pass with the gate disabled, so it was dropped rather than kept as decoration.

## Why?

`thunderbird/private-issue-tracking#44`.

The full fix is to delete the path and the filesystem backend behind it, which is #1161. That work depends on moving CI off filesystem storage first, so it cannot move quickly. This does not depend on anything, and it closes the hole in every environment that is actually exposed.

## Limitations and Notes

- A filesystem dev stack still uploads over this socket and is unaffected. That is deliberate — it is the one configuration that has no other write path until the backend is removed.
- This adds a line of code to a path that is being deleted three PRs later. That is the trade for not making the security fix wait on a CI migration.

## Applicable Issues

`thunderbird/private-issue-tracking#44`