### PR TITLE
fix(send): stop POST /api/uploads/report crashing on an unknown id

### DIFF
--- a/packages/send/backend/src/errors/routes.ts
+++ b/packages/send/backend/src/errors/routes.ts
@@ -169,6 +169,10 @@ export const UPLOAD_ERRORS = {
     statusCode: 500,
     message: 'Could not get url for bucket.',
   },
+  REPORT_FAILED: {
+    statusCode: 404,
+    message: 'Could not report upload.',
+  },
 };
 
 export const USER_ERRORS = {

--- a/packages/send/backend/src/routes/uploads.ts
+++ b/packages/send/backend/src/routes/uploads.ts
@@ -639,12 +639,20 @@ router.post('/items', async (req, res) => {
  *               example:
  *                 message: "Failed to process report"
  */
-router.post('/report', async (req, res) => {
-  const { uploadId } = req.body;
-  const id = await reportSuspiciousFile(uploadId);
-  await reportUpload(uploadId);
-  res.status(200).json({ message: 'Report received', id });
-});
+router.post(
+  '/report',
+  addErrorHandling(UPLOAD_ERRORS.REPORT_FAILED),
+  wrapAsyncHandler(async (req, res) => {
+    const { uploadId } = req.body;
+    // `reportSuspiciousFile` -> `getUploadParts` throws `UPLOAD_NOT_FOUND` for an
+    // unknown id. Without an async boundary that rejection was unhandled and
+    // terminated the process (private #49); `wrapAsyncHandler` routes it to the
+    // error handler, which answers 404 from `REPORT_FAILED` instead.
+    const id = await reportSuspiciousFile(uploadId);
+    await reportUpload(uploadId);
+    res.status(200).json({ message: 'Report received', id });
+  })
+);
 
 /**
  * @openapi

--- a/packages/send/backend/src/test/routes/uploads.report.routes.test.ts
+++ b/packages/send/backend/src/test/routes/uploads.report.routes.test.ts
@@ -1,0 +1,90 @@
+import express from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { UPLOAD_NOT_FOUND } from '@send-backend/errors/models';
+
+const { mockReportSuspiciousFile, mockReportUpload } = vi.hoisted(() => ({
+  mockReportSuspiciousFile: vi.fn(),
+  mockReportUpload: vi.fn(),
+}));
+
+// The route imports `reportSuspiciousFile` from `../models/uploads` and
+// `reportUpload` from the `@send-backend/models` barrel — mock both.
+vi.mock('../../models/uploads', () => ({
+  reportSuspiciousFile: mockReportSuspiciousFile,
+}));
+vi.mock('@send-backend/models', () => ({
+  reportUpload: mockReportUpload,
+  deleteUploadsByIds: vi.fn(),
+}));
+
+// Avoid the real storage client (Backblaze token timer + AWS SDK) at import.
+vi.mock('@send-backend/storage', () => ({
+  default: { del: vi.fn() },
+}));
+
+vi.mock('@send-backend/auth/client', () => ({
+  getDataFromAuthenticatedRequest: vi.fn(() => ({ id: 'user-1' })),
+}));
+
+// All middleware becomes a pass-through so we exercise the handler directly.
+vi.mock('../../middleware', () => {
+  const passthrough = (_req, _res, next) => next();
+  return {
+    requireJWT: passthrough,
+    checkStorageLimit: passthrough,
+    getGroupMemberPermissions: passthrough,
+    requireWritePermission: passthrough,
+  };
+});
+
+// vi.mock() calls above are hoisted above imports, so this router picks up the
+// stubs.
+import router from '../../routes/uploads';
+import { errorHandler } from '../../errors/routes';
+
+const app = express();
+app.use(express.json());
+app.use('/api/uploads', router);
+// `errorHandler` has a 3-arg signature, so Express would register it as normal
+// middleware and skip it for errors (in prod, Sentry's 4-arg handler runs
+// first). Wrap it in the 4-arg error-middleware shape so the route's async
+// boundary is exercised end to end here.
+app.use((err, req, res, next) => errorHandler(err, req, res, next));
+
+describe('POST /api/uploads/report', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('reports a known upload and returns 200', async () => {
+    mockReportSuspiciousFile.mockResolvedValue([{ id: 'report-1' }]);
+    mockReportUpload.mockResolvedValue(undefined);
+
+    const response = await request(app)
+      .post('/api/uploads/report')
+      .send({ uploadId: 'known-id' })
+      .set('Content-Type', 'application/json');
+
+    expect(response.status).toBe(200);
+    expect(mockReportSuspiciousFile).toHaveBeenCalledWith('known-id');
+    expect(mockReportUpload).toHaveBeenCalledWith('known-id');
+    expect(response.body).toMatchObject({ message: 'Report received' });
+  });
+
+  // Regression for private #49: an unknown id must not crash the process. Before
+  // the fix the route had no async boundary, so this rejection was unhandled and
+  // terminated Node; now it is answered with a 404.
+  it('answers 404 (does not crash) when the upload id is unknown', async () => {
+    mockReportSuspiciousFile.mockRejectedValue(new Error(UPLOAD_NOT_FOUND));
+
+    const response = await request(app)
+      .post('/api/uploads/report')
+      .send({ uploadId: 'does-not-exist' })
+      .set('Content-Type', 'application/json');
+
+    expect(response.status).toBe(404);
+    expect(mockReportUpload).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What changed?

`POST /api/uploads/report` no longer crashes the backend process on an unknown upload id.

`reportSuspiciousFile` → `getUploadParts` (`models/uploads.ts:112`) throws `UPLOAD_NOT_FOUND` for an id with no upload row. The route had no async error boundary (`wrapAsyncHandler`, try/catch), so the rejection was unhandled and terminated Node — a single `POST /api/uploads/report` with a random uuid could take down a replica. Sustained requests give sustained outage.

The fix follows the pattern the sibling upload routes already use: tag the route with `addErrorHandling(UPLOAD_ERRORS.REPORT_FAILED)` (a new 404) and wrap the handler in `wrapAsyncHandler`, so the throw routes to the global error handler and answers **404** instead of crashing.

## Changes

- **`errors/routes.ts`** — add `UPLOAD_ERRORS.REPORT_FAILED` (`statusCode: 404`, "Could not report upload.").
- **`routes/uploads.ts`** — wrap `POST /report` in `addErrorHandling(...)` + `wrapAsyncHandler(...)`, with a comment naming the crash it closes.
- **`test/routes/uploads.report.routes.test.ts`** — regression test: known id → 200; unknown id → 404 (and `reportUpload` is not called). The suite mounts the global `errorHandler` in its 4-arg error-middleware form so the async boundary is exercised end to end.

## Verification

- New test passes; full `src/test/routes/` suite green (34 tests).
- `prettier --check` clean on all three files.

## Why?

`thunderbird/private-issue-tracking#49`. Same crash class as #43/#45: an unhandled synchronous/async throw in an unguarded handler terminates the process. The fix is to make an unknown id non-fatal — it holds whether or not the caller is authenticated. (The route being reachable without auth is noted separately in #49 as its own concern; this PR is scoped to the crash.)

**AI disclosure.** Written with Claude Code. I set the approach and scope; the agent traced the throw path, made the change, and added the regression test. I reviewed it.

## Applicable Issues

`thunderbird/private-issue-tracking#49`
