### PR TITLE
fix(send): close the storage quota bypass on presigned uploads

### DIFF
--- a/packages/send/backend/src/errors/routes.ts
+++ b/packages/send/backend/src/errors/routes.ts
@@ -166,6 +166,10 @@ export const UPLOAD_ERRORS = {
     statusCode: 404,
     message: 'Could not report upload.',
   },
+  INVALID_SIZE: {
+    statusCode: 400,
+    message: 'A valid file size is required.',
+  },
 };
 
 export const USER_ERRORS = {

--- a/packages/send/backend/src/models/uploads.ts
+++ b/packages/send/backend/src/models/uploads.ts
@@ -9,6 +9,10 @@ import {
   UPLOAD_NOT_FOUND,
   UPLOAD_SIZE_ERROR,
 } from '../errors/models';
+import {
+  ECE_RECORD_SIZE,
+  calculateEncryptedSize,
+} from '../utils/encryptedSize';
 
 export async function createUpload(
   id: string,
@@ -18,9 +22,19 @@ export async function createUpload(
   part?: number,
   fileHash?: string
 ) {
-  // Confirm that file `id` exists and what's on disk
-  // is at least as large as the stated size.
-  // (Encrypted files are larger than the decrypted contents)
+  // Verify against provider ground truth, not the client's stated number
+  // (private #36). `size` is the PLAINTEXT size; storage holds ECE ciphertext,
+  // which is deterministically larger. Compare the object actually on disk
+  // against the encrypted size the plaintext claim implies, with a small
+  // tolerance band:
+  //   - lower bound: `calculateEncryptedSize(size)` — an object smaller than the
+  //     ciphertext this plaintext size must produce means the claim was
+  //     understated (the old `sizeOnDisk < size` check let this through, since a
+  //     plaintext number is always below its own ciphertext size).
+  //   - upper bound: one extra record. ECE padding can push the last record to
+  //     a full record boundary, so the true ciphertext is `expected` or up to
+  //     one `ECE_RECORD_SIZE` above it; anything beyond that is a client PUTting
+  //     more than it declared.
 
   let sizeOnDisk = 0;
 
@@ -30,7 +44,11 @@ export async function createUpload(
     console.error('ERROR reading storage length:', error);
   }
 
-  if (sizeOnDisk < size) {
+  const expectedEncrypted = calculateEncryptedSize(size);
+  if (
+    sizeOnDisk < expectedEncrypted ||
+    sizeOnDisk > expectedEncrypted + ECE_RECORD_SIZE
+  ) {
     throw new BaseError(UPLOAD_SIZE_ERROR);
   }
 

--- a/packages/send/backend/src/routes/uploads.ts
+++ b/packages/send/backend/src/routes/uploads.ts
@@ -31,6 +31,7 @@ import {
   requireJWT,
   requireWritePermission,
 } from '../middleware';
+import { calculateEncryptedSize } from '../utils/encryptedSize';
 
 const router: Router = Router();
 
@@ -159,16 +160,50 @@ router.post(
  *       500:
  *         description: Failed to generate pre-signed URL
  */
+// The client must state the (plaintext) size up front so the quota check runs
+// against a real number, not the `|| 0` default that let any request pass
+// (private #36). `checkStorageLimit` reads `req.body.size`, so validation has
+// to run before it.
+const signedSchema = z.object({
+  type: z.string(),
+  size: z
+    .number({ required_error: 'size is required' })
+    .int()
+    .positive('size must be greater than 0'),
+});
+
 router.post(
   '/signed',
   requireJWT,
+  addErrorHandling(UPLOAD_ERRORS.INVALID_SIZE),
+  wrapAsyncHandler(async (req, res, next) => {
+    const result = signedSchema.safeParse(req.body);
+    if (!result.success) {
+      return res.status(400).json({
+        message: result.error.issues[0]?.message ?? 'Invalid request body',
+      });
+    }
+    // Normalize so `checkStorageLimit` (which reads `req.body.size`) gates on
+    // the validated value.
+    req.body.size = result.data.size;
+    return next();
+  }),
   checkStorageLimit,
   addErrorHandling(UPLOAD_ERRORS.NO_BUCKET),
   wrapAsyncHandler(async (req, res) => {
     const uploadId = uuidv4();
-    const { type } = req.body;
+    const { type, size } = req.body;
+    // Sign the exact ciphertext content-length into the URL. `size` is the
+    // plaintext size the client stated (validated above); storage holds ECE
+    // ciphertext, which is deterministically larger, so we sign the encrypted
+    // size, not the plaintext claim (private #36).
+    const contentLength = calculateEncryptedSize(size);
     try {
-      const url = await storage.getUploadBucketUrl(uploadId, type);
+      const url = await storage.getUploadBucketUrl(
+        uploadId,
+        type,
+        contentLength
+      );
       return res.json({ id: uploadId, url });
     } catch (error) {
       console.error('Error generating pre-signed URL:', error);

--- a/packages/send/backend/src/storage/index.ts
+++ b/packages/send/backend/src/storage/index.ts
@@ -161,12 +161,19 @@ export class FileStore {
     return this.s3;
   }
 
-  async getUploadBucketUrl(key: string, contentType: string) {
+  async getUploadBucketUrl(
+    key: string,
+    contentType: string,
+    // Exact ciphertext size the PUT is allowed to carry, signed into the URL so
+    // a client cannot request a small object and upload a large one (#36).
+    contentLength?: number
+  ) {
     const { presigner, bucket } = this.bucketApi();
     return await getSignedUrl(presigner, {
       Bucket: bucket,
       Key: key,
       ContentType: contentType,
+      ContentLength: contentLength,
     });
   }
 

--- a/packages/send/backend/src/storage/s3b2.ts
+++ b/packages/send/backend/src/storage/s3b2.ts
@@ -75,22 +75,26 @@ export async function getSignedUrl(
     ...(ContentLength !== undefined ? { ContentLength } : {}),
   });
 
-  // Pin content-type and content-length into the signature so a client cannot
-  // request a URL for a small object and then PUT gigabytes. `content-length`
-  // is only signable when we actually set `ContentLength` on the command.
+  // Pin content-length into the signature so a client cannot request a URL for
+  // a small object and then PUT gigabytes (private #36). Only signable when we
+  // actually set `ContentLength` on the command.
+  //
+  // Content-type is deliberately NOT signed: the browser decides the stored
+  // type, and signing it would start rejecting uploads that succeed today (see
+  // `presigned-roundtrip.test.ts` "leaves the content type to the browser").
+  // #36 is a size-enforcement fix, not a content-type one.
+  //
   // Caveat (private #36): provider-side enforcement of a signed content-length
   // on a presigned PUT is not officially documented for B2/R2; create-entry's
   // provider-ground-truth check (`createUpload`) is the backstop enforcement
   // point if the provider does not reject an over-size PUT itself.
-  const signableHeaders = new Set(['content-type']);
-  if (ContentLength !== undefined) {
-    signableHeaders.add('content-length');
-  }
+  const signableHeaders =
+    ContentLength !== undefined ? new Set(['content-length']) : undefined;
 
   // Generate the presigned URL (expires in 3600 seconds / 1 hour by default)
   const signedUrl = await getSignedUrlCommand(s3Client, command, {
     expiresIn: 3600,
-    signableHeaders,
+    ...(signableHeaders ? { signableHeaders } : {}),
   });
   return signedUrl;
 }

--- a/packages/send/backend/src/storage/s3b2.ts
+++ b/packages/send/backend/src/storage/s3b2.ts
@@ -58,17 +58,39 @@ export async function getSignedUrl(
     Bucket,
     Key,
     ContentType,
-  }: { Bucket: string; Key: string; ContentType: string }
+    ContentLength,
+  }: {
+    Bucket: string;
+    Key: string;
+    ContentType: string;
+    // The exact ciphertext size the client is allowed to PUT. Signing it binds
+    // the upload to the size the quota check approved (private #36).
+    ContentLength?: number;
+  }
 ) {
   const command = new PutObjectCommand({
     Bucket,
     Key,
     ContentType,
+    ...(ContentLength !== undefined ? { ContentLength } : {}),
   });
+
+  // Pin content-type and content-length into the signature so a client cannot
+  // request a URL for a small object and then PUT gigabytes. `content-length`
+  // is only signable when we actually set `ContentLength` on the command.
+  // Caveat (private #36): provider-side enforcement of a signed content-length
+  // on a presigned PUT is not officially documented for B2/R2; create-entry's
+  // provider-ground-truth check (`createUpload`) is the backstop enforcement
+  // point if the provider does not reject an over-size PUT itself.
+  const signableHeaders = new Set(['content-type']);
+  if (ContentLength !== undefined) {
+    signableHeaders.add('content-length');
+  }
 
   // Generate the presigned URL (expires in 3600 seconds / 1 hour by default)
   const signedUrl = await getSignedUrlCommand(s3Client, command, {
     expiresIn: 3600,
+    signableHeaders,
   });
   return signedUrl;
 }

--- a/packages/send/backend/src/test/routes/uploads.signed.routes.test.ts
+++ b/packages/send/backend/src/test/routes/uploads.signed.routes.test.ts
@@ -1,0 +1,115 @@
+import express from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockGetUploadBucketUrl, mockGetUsedStorage, mockCaller } = vi.hoisted(
+  () => ({
+    mockGetUploadBucketUrl: vi.fn(),
+    mockGetUsedStorage: vi.fn(),
+    mockCaller: vi.fn(),
+  })
+);
+
+// Storage: only the presigned-url call matters here.
+vi.mock('@send-backend/storage', () => ({
+  default: { getUploadBucketUrl: mockGetUploadBucketUrl, del: vi.fn() },
+}));
+
+// checkStorageLimit imports getUsedStorage from ./models (the models barrel).
+vi.mock('@send-backend/models', () => ({
+  reportUpload: vi.fn(),
+  deleteUploadsByIds: vi.fn(),
+  getUsedStorage: mockGetUsedStorage,
+}));
+vi.mock('../../models', () => ({
+  reportUpload: vi.fn(),
+  deleteUploadsByIds: vi.fn(),
+  getUsedStorage: mockGetUsedStorage,
+}));
+
+// checkStorageLimit is the real middleware — it reads req.body.size and the
+// caller's tier/usage. Stub only its data dependencies so the quota math runs
+// against known numbers.
+vi.mock('@send-backend/auth/client', () => ({
+  getDataFromAuthenticatedRequest: mockCaller,
+}));
+
+// requireJWT is a pass-through; checkStorageLimit stays real so the quota gate
+// is exercised end to end.
+vi.mock('../../middleware', async (importOriginal) => {
+  const actual = await importOriginal<object>();
+  const passthrough = (_req, _res, next) => next();
+  return {
+    ...actual,
+    requireJWT: passthrough,
+    getGroupMemberPermissions: passthrough,
+    requireWritePermission: passthrough,
+  };
+});
+
+import router from '../../routes/uploads';
+import { errorHandler } from '../../errors/routes';
+
+const app = express();
+app.use(express.json());
+app.use('/api/uploads', router);
+app.use((err, req, res, next) => errorHandler(err, req, res, next));
+
+describe('POST /api/uploads/signed (quota bypass, private #36)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // A generous tier so the quota gate only trips on the values we choose.
+    mockCaller.mockReturnValue({ id: 'user-1', tier: 'PRO', uniqueHash: 'h' });
+    mockGetUsedStorage.mockResolvedValue({ active: 0 });
+    mockGetUploadBucketUrl.mockResolvedValue('https://bucket/signed-url');
+  });
+
+  it('rejects a request with no size (the old bypass) with 400', async () => {
+    const res = await request(app)
+      .post('/api/uploads/signed')
+      .send({ type: 'application/octet-stream' })
+      .set('Content-Type', 'application/json');
+
+    expect(res.status).toBe(400);
+    // No URL is minted for an unsized request.
+    expect(mockGetUploadBucketUrl).not.toHaveBeenCalled();
+  });
+
+  it('rejects size: 0 with 400', async () => {
+    const res = await request(app)
+      .post('/api/uploads/signed')
+      .send({ type: 'application/octet-stream', size: 0 })
+      .set('Content-Type', 'application/json');
+
+    expect(res.status).toBe(400);
+    expect(mockGetUploadBucketUrl).not.toHaveBeenCalled();
+  });
+
+  it('signs the encrypted content-length, not the plaintext claim', async () => {
+    const plaintext = 1024;
+    const res = await request(app)
+      .post('/api/uploads/signed')
+      .send({ type: 'application/octet-stream', size: plaintext })
+      .set('Content-Type', 'application/json');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ url: 'https://bucket/signed-url' });
+    // Third arg is the signed content-length; it must be the ciphertext size
+    // (strictly larger than the plaintext claim), never the raw plaintext.
+    const [, , contentLength] = mockGetUploadBucketUrl.mock.calls[0];
+    expect(contentLength).toBeGreaterThan(plaintext);
+  });
+
+  it('still enforces the quota against the stated size', async () => {
+    // Usage already at the tier ceiling: any positive size trips the gate.
+    mockGetUsedStorage.mockResolvedValue({ active: Number.MAX_SAFE_INTEGER });
+
+    const res = await request(app)
+      .post('/api/uploads/signed')
+      .send({ type: 'application/octet-stream', size: 1024 })
+      .set('Content-Type', 'application/json');
+
+    expect(res.status).toBe(403);
+    expect(mockGetUploadBucketUrl).not.toHaveBeenCalled();
+  });
+});

--- a/packages/send/backend/src/test/routes/uploads.signed.routes.test.ts
+++ b/packages/send/backend/src/test/routes/uploads.signed.routes.test.ts
@@ -53,7 +53,7 @@ import { errorHandler } from '../../errors/routes';
 const app = express();
 app.use(express.json());
 app.use('/api/uploads', router);
-app.use((err, req, res, next) => errorHandler(err, req, res, next));
+app.use((err, req, res, _next) => errorHandler(err, req, res));
 
 describe('POST /api/uploads/signed (quota bypass, private #36)', () => {
   beforeEach(() => {

--- a/packages/send/backend/src/utils/encryptedSize.ts
+++ b/packages/send/backend/src/utils/encryptedSize.ts
@@ -1,16 +1,18 @@
-// Deterministic ECE (Encrypted Content-Encoding) size math, mirrored from the
-// frontend (`frontend/src/lib/ece.ts` + `helpers.ts:calculateEncryptedSize`).
+// Deterministic ECE (Encrypted Content-Encoding) size math for the ciphertext
+// the browser produces in `frontend/src/lib/ece.ts` (`encryptStream`). The
+// frontend has no size function of its own -- the one in `helpers.ts` went with
+// the WebSocket upload path in #1161 -- so this is the only place the math
+// lives, and it is derived from ece.ts's constants below.
 //
 // Storage holds ECE-encrypted ciphertext, which is ALWAYS strictly larger than
 // the plaintext blob (per-record tag + padding, plus a one-time header). The
-// backend needs the same function the client uses so it can:
+// backend has to predict that size exactly, so it can:
 //   1. sign the exact ciphertext content-length into the presigned PUT, and
 //   2. verify the uploaded object against provider ground truth
 // without trusting a client-stated number (private #36).
 //
-// These constants MUST match the frontend. If the client's record size or
-// overhead ever changes, both sides change together or every upload is
-// rejected.
+// These constants MUST match ece.ts. If the client's record size or overhead
+// ever changes, both sides change together or every upload is rejected.
 
 export const ECE_RECORD_SIZE = 1024 * 64;
 const TAG_LENGTH = 16;

--- a/packages/send/backend/src/utils/encryptedSize.ts
+++ b/packages/send/backend/src/utils/encryptedSize.ts
@@ -1,0 +1,34 @@
+// Deterministic ECE (Encrypted Content-Encoding) size math, mirrored from the
+// frontend (`frontend/src/lib/ece.ts` + `helpers.ts:calculateEncryptedSize`).
+//
+// Storage holds ECE-encrypted ciphertext, which is ALWAYS strictly larger than
+// the plaintext blob (per-record tag + padding, plus a one-time header). The
+// backend needs the same function the client uses so it can:
+//   1. sign the exact ciphertext content-length into the presigned PUT, and
+//   2. verify the uploaded object against provider ground truth
+// without trusting a client-stated number (private #36).
+//
+// These constants MUST match the frontend. If the client's record size or
+// overhead ever changes, both sides change together or every upload is
+// rejected.
+
+export const ECE_RECORD_SIZE = 1024 * 64;
+const TAG_LENGTH = 16;
+export const OVERHEAD_SIZE = TAG_LENGTH + 1; // 17
+export const HEADER_SIZE = 21;
+
+/**
+ * The size a plaintext blob becomes after ECE encryption.
+ *
+ * @param originalSize plaintext size in bytes
+ * @param recordSize   per-record chunk size (defaults to ECE_RECORD_SIZE)
+ * @returns ciphertext size in bytes
+ */
+export function calculateEncryptedSize(
+  originalSize: number,
+  recordSize = ECE_RECORD_SIZE
+): number {
+  const chunkSize = recordSize - OVERHEAD_SIZE;
+  const numChunks = Math.ceil(originalSize / chunkSize);
+  return originalSize + numChunks * OVERHEAD_SIZE + HEADER_SIZE;
+}

--- a/packages/send/frontend/src/lib/filesync.ts
+++ b/packages/send/frontend/src/lib/filesync.ts
@@ -126,11 +126,15 @@ export async function sendBlob(
   const stream = blobStream(blob);
 
   try {
-    // Get the bucket url
+    // Get the bucket url. Send the plaintext size so the backend can gate the
+    // request against the real quota and sign the exact ciphertext
+    // content-length into the presigned PUT (private #36). The backend rejects
+    // a missing/invalid size with 400.
     const { id, url } = await api.call<{ url: string; id: string }>(
       'uploads/signed',
       {
         type: 'application/octet-stream',
+        size: blob.size,
       },
       'POST'
     );


### PR DESCRIPTION
## What changed?

Closes the storage quota bypass on presigned uploads.

Two cooperating gaps let an **authenticated** client store past its quota:

1. `checkStorageLimit` trusted `req.body.size`, which defaulted to `0` when omitted — so a request that sent no size passed the quota check as `active + 0`.
2. The presigned PUT bound no content-length, so the signed URL accepted a PUT of any size.

Together: request a signed URL claiming `size: 0` (passes the check), then PUT gigabytes. Post-upload validation (`createUpload`) only checked `sizeOnDisk < size` against the understated plaintext number, so it never caught it, and `Upload.size` stored the claimed value — leaving quota accounting undercounted.

## The fix (all three parts of [#36](https://github.com/thunderbird/private-issue-tracking/issues/36))

- **`POST /api/uploads/signed`** now requires a positive integer `size` (400 on missing/zero) and gates `checkStorageLimit` on the validated value.
- **The presigned PUT signs the exact ciphertext content-length** via `signableHeaders`, binding the URL to the approved size. The signed length is the **encrypted** size, computed from the plaintext claim by a new backend `calculateEncryptedSize` that mirrors the frontend's ECE math (`utils/encryptedSize.ts`). Caveat noted in code: provider-side enforcement of a signed content-length on presigned PUT isn't officially documented for B2/R2 — the create-entry check below is the backstop.
- **`createUpload` verifies against provider ground truth** (`storage.length(id)`) using the encrypted size, within a one-record tolerance for ECE padding — replacing the `sizeOnDisk < size` check that a plaintext number always passed. `Upload.size` stays in plaintext semantics, so quota accounting and size display are unaffected.

## Verification

- New regression test (`uploads.signed.routes.test.ts`): no-size/`size:0` → 400; signed content-length is the ciphertext size, not the plaintext claim; the quota gate still trips against the stated size.
- Full backend route + models + storage suites green (57 tests). Prettier clean.

## Notes

- The signed content-length is only enforceable if the provider honors it; the `createUpload` ground-truth check is the enforcement point that does not depend on provider behavior. Worth confirming on staging (per the [#36 ](https://github.com/thunderbird/private-issue-tracking/issues/36)caveat) which layer actually rejects an over-size PUT.
- ECE constants in `utils/encryptedSize.ts` must stay in sync with the frontend (`frontend/src/lib/ece.ts`); a mismatch would reject legitimate uploads. Comment says so.

**AI disclosure.** Written with Claude Code. I set the approach and scope; the agent traced the size flow across the route, presigner and create-entry, implemented the three-part fix, and added the regression test. I reviewed it.

## Applicable Issues

`thunderbird/private-issue-tracking#36`
