### PR TITLE
fix(send-backend): Don't recommend setting Sentry DSN in example .env

### DIFF
--- a/packages/send/backend/.env.sample
+++ b/packages/send/backend/.env.sample
@@ -26,7 +26,7 @@ COMBINED_LOG=logs/combined.log
 # Sentry
 SENTRY_ORG=thunderbird
 SENTRY_PROJECT=send-suite-backend
-SENTRY_DSN=https://85b7b08be94b8991ed121578d807f755@o4505428107853824.ingest.us.sentry.io/4507567071232000
+SENTRY_DSN=
 # Build-time only, for the sourcemap upload; nothing at runtime reads it. The
 # image build takes it as a BuildKit secret (see Dockerfile), and no deployed
 # task definition or pod carries it. Leave empty locally.

--- a/packages/send/frontend/.env.sample
+++ b/packages/send/frontend/.env.sample
@@ -38,7 +38,7 @@ VITE_APPOINTMENT_URL=https://appointment-stage.tb.pro/
 
 # Sentry
 VITE_SENTRY_AUTH_TOKEN=
-VITE_SENTRY_DSN=https://af0e7594fd7dedb0d5c59ec7ecf169b5@o4505428107853824.ingest.us.sentry.io/4507567067758592
+VITE_SENTRY_DSN=
 
 # Posthog
 VITE_POSTHOG_PROJECT_KEY=
@@ -60,5 +60,4 @@ VITE_OIDC_ROOT_URL=
 
 # Logging
 VITE_LOGGER_LEVEL=warn
-
 

--- a/packages/send/frontend/src/plugins/posthog.js
+++ b/packages/send/frontend/src/plugins/posthog.js
@@ -9,6 +9,16 @@ function initPosthog() {
   if (initialized) {
     return;
   }
+  // Skip init when no project key is configured (e.g. local dev, where
+  // `.env.sample` ships VITE_POSTHOG_PROJECT_KEY blank). Calling
+  // `posthog.init('')` makes posthog-js log `console.warn('[PostHog.js]
+  // PostHog was initialized without a token …')`, and Sentry's
+  // captureConsoleIntegration (lib/sentry.ts) forwards that warn as an event --
+  // the source of tens of thousands of noise events from localhost. No key
+  // means nothing to capture to anyway, so there is nothing to initialize.
+  if (!config.posthogProjectKey) {
+    return;
+  }
   posthog.init(config.posthogProjectKey, {
     api_host: config.posthogHost,
     persistence: 'memory',


### PR DESCRIPTION
Our most comment Sentry events from this projects are:

"[PostHog.js] PostHog was initialized without a token. This likely indicates a misconfiguration. Please check the first argument passed to posthog.init()"

These all from localhost URLs that weren't intended to be sent to Sentry. We've sent close to 50,000 of such events.

To stop sending these noisy events from local development, developers need to unset the Sentry
DSN in their .env, and we need to remove this from the example to discourage new devs from
causing a regression.
