### PR TITLE
feat(send/frontend): handle 429 rate-limit responses gracefully (#1105)

### DIFF
--- a/packages/send/backend/src/middleware/rate-limit.ts
+++ b/packages/send/backend/src/middleware/rate-limit.ts
@@ -72,15 +72,18 @@ function keyForRequest(req: Request): string {
 export function createRateLimiter(tier: RateLimitTier): RequestHandler {
   const { windowMs, max } = RATE_LIMITS[tier];
 
-  // Built once here, at route-registration time (not per request). Building it
-  // per request is what express-rate-limit warns about (ERR_ERL_CREATED_IN_
-  // REQUEST_HANDLER), and it would also discard the counters between requests.
+  // Built once here at route-registration time (not per request). Building it
+  // per request triggers express-rate-limit's ERR_ERL_CREATED_IN_REQUEST_HANDLER
+  // warning and discards counters between requests.
   //
-  // The RedisStore constructor kicks off a Lua-script load via sendCommand. We
-  // must not let that reach Redis at construction time, because route files are
-  // imported in tests and in environments with no Redis configured. So
-  // sendCommand below is a no-op until Redis is both configured and reachable;
-  // the per-request guard is what actually enforces (or 503s) once it is.
+  // The catch: RedisStore's constructor eagerly loads a Lua script via
+  // sendCommand and requires a *string* reply (`SCRIPT LOAD` returns a SHA),
+  // throwing "unexpected reply from redis client" otherwise. Route files are
+  // imported in environments with no Redis (tests, dev, E2E), so we must answer
+  // that construction-time load without touching Redis. When rate limiting is
+  // off or Redis is down, sendCommand returns a harmless empty string for the
+  // script load and null for anything else; the per-request guard below has
+  // already decided pass-through/503 by the time any real command would run.
   const limiter = rateLimit({
     windowMs,
     max,
@@ -89,11 +92,12 @@ export function createRateLimiter(tier: RateLimitTier): RequestHandler {
     store: new RedisStore({
       prefix: `rl:${tier}:`,
       sendCommand: (command: string, ...args: string[]) => {
-        // Only talk to Redis when it is configured and up. Otherwise resolve to
-        // null so the store's script-load and any stray call are harmless; the
-        // request-level guard has already decided pass-through or 503 by then.
         if (!isRateLimitingEnabled() || !isRedisHealthy()) {
-          return Promise.resolve(null) as Promise<never>;
+          // Keep the store constructible with no reachable Redis. SCRIPT LOAD
+          // wants a string SHA back; hand it one so construction never rejects.
+          const isScriptLoad =
+            command === 'SCRIPT' && args[0]?.toUpperCase?.() === 'LOAD';
+          return Promise.resolve(isScriptLoad ? '' : null) as Promise<never>;
         }
         return getRedisClient().call(command, ...args) as Promise<never>;
       },

--- a/packages/send/backend/src/middleware/rate-limit.ts
+++ b/packages/send/backend/src/middleware/rate-limit.ts
@@ -72,43 +72,45 @@ function keyForRequest(req: Request): string {
 export function createRateLimiter(tier: RateLimitTier): RequestHandler {
   const { windowMs, max } = RATE_LIMITS[tier];
 
-  // Built on first use, not at import time. The RedisStore constructor eagerly
-  // loads a Lua script into Redis, so building it here would open a connection
-  // (and throw on a missing REDIS_URL) the moment a route file is imported --
-  // including in tests and any environment where Redis is not configured. The
-  // fail-closed guard below already turns a real outage into a clean 503, so
-  // deferring construction costs nothing.
-  let limiter: RequestHandler | null = null;
-  const getLimiter = (): RequestHandler => {
-    if (limiter) {
-      return limiter;
-    }
-    limiter = rateLimit({
-      windowMs,
-      max,
-      // Key each named limiter's counters separately in Redis and namespace
-      // them under `rl:` so this data is safe to share a Redis with other
-      // services.
-      store: new RedisStore({
-        prefix: `rl:${tier}:`,
-        sendCommand: (command: string, ...args: string[]) =>
-          getRedisClient().call(command, ...args) as Promise<never>,
-      }),
-      keyGenerator: keyForRequest,
-      // Emit the standard RateLimit-* headers so clients can back off proactively.
-      standardHeaders: true,
-      legacyHeaders: false,
-      // Answer over-limit requests with 429 and a Retry-After hint. express-rate-
-      // limit sets Retry-After automatically; we only shape the JSON body.
-      handler: (_req: Request, res: Response) => {
-        res.status(429).json({
-          message: 'Too many requests. Please slow down and try again shortly.',
-          error: 'too_many_requests',
-        });
+  // Built once here, at route-registration time (not per request). Building it
+  // per request is what express-rate-limit warns about (ERR_ERL_CREATED_IN_
+  // REQUEST_HANDLER), and it would also discard the counters between requests.
+  //
+  // The RedisStore constructor kicks off a Lua-script load via sendCommand. We
+  // must not let that reach Redis at construction time, because route files are
+  // imported in tests and in environments with no Redis configured. So
+  // sendCommand below is a no-op until Redis is both configured and reachable;
+  // the per-request guard is what actually enforces (or 503s) once it is.
+  const limiter = rateLimit({
+    windowMs,
+    max,
+    // Key each named limiter's counters separately in Redis and namespace them
+    // under `rl:` so this data is safe to share a Redis with other services.
+    store: new RedisStore({
+      prefix: `rl:${tier}:`,
+      sendCommand: (command: string, ...args: string[]) => {
+        // Only talk to Redis when it is configured and up. Otherwise resolve to
+        // null so the store's script-load and any stray call are harmless; the
+        // request-level guard has already decided pass-through or 503 by then.
+        if (!isRateLimitingEnabled() || !isRedisHealthy()) {
+          return Promise.resolve(null) as Promise<never>;
+        }
+        return getRedisClient().call(command, ...args) as Promise<never>;
       },
-    } as Partial<Options>);
-    return limiter;
-  };
+    }),
+    keyGenerator: keyForRequest,
+    // Emit the standard RateLimit-* headers so clients can back off proactively.
+    standardHeaders: true,
+    legacyHeaders: false,
+    // Answer over-limit requests with 429 and a Retry-After hint. express-rate-
+    // limit sets Retry-After automatically; we only shape the JSON body.
+    handler: (_req: Request, res: Response) => {
+      res.status(429).json({
+        message: 'Too many requests. Please slow down and try again shortly.',
+        error: 'too_many_requests',
+      });
+    },
+  } as Partial<Options>);
 
   return (req, res, next) => {
     // Rate limiting is opt-in via REDIS_URL. Where Redis is not configured
@@ -131,6 +133,6 @@ export function createRateLimiter(tier: RateLimitTier): RequestHandler {
       return;
     }
 
-    getLimiter()(req, res, next);
+    limiter(req, res, next);
   };
 }

--- a/packages/send/backend/src/routes/containers.ts
+++ b/packages/send/backend/src/routes/containers.ts
@@ -26,6 +26,7 @@ import {
   requireSharePermission,
   requireWritePermission,
 } from '../middleware';
+import { createRateLimiter } from '../middleware/rate-limit';
 
 import {
   addErrorHandling,
@@ -94,6 +95,8 @@ router.get(
   requireJWT,
   getGroupMemberPermissions,
   requireReadPermission,
+  // Authenticated read: loosest tier, keyed per user.
+  createRateLimiter('read'),
   addErrorHandling(CONTAINER_ERRORS.CONTAINER_NOT_FOUND),
   wrapAsyncHandler(async (req, res) => {
     const { containerId } = req.params;
@@ -146,6 +149,8 @@ router.get(
   requireJWT,
   getGroupMemberPermissions,
   requireReadPermission,
+  // Authenticated read: loosest tier, keyed per user.
+  createRateLimiter('read'),
   addErrorHandling(CONTAINER_ERRORS.ACCESS_LINKS_NOT_FOUND),
   wrapAsyncHandler(async (req, res) => {
     const { containerId } = req.params;
@@ -191,6 +196,8 @@ router.post(
   renameBodyProperty('parentId', 'containerId'),
   getGroupMemberPermissions,
   requireWritePermission,
+  // State-changing action: sensitive tier, keyed per user.
+  createRateLimiter('sensitive'),
   addErrorHandling(CONTAINER_ERRORS.CONTAINER_NOT_CREATED),
   wrapAsyncHandler(async (req, res) => {
     const {
@@ -261,6 +268,8 @@ router.post(
   requireJWT,
   getGroupMemberPermissions,
   requireWritePermission,
+  // State-changing action: sensitive tier, keyed per user.
+  createRateLimiter('sensitive'),
   addErrorHandling(CONTAINER_ERRORS.CONTAINER_NOT_RENAMED),
   wrapAsyncHandler(async (req, res) => {
     const { containerId } = req.params;
@@ -296,6 +305,8 @@ router.delete(
   requireJWT,
   getGroupMemberPermissions,
   requireAdminPermission,
+  // State-changing action: sensitive tier, keyed per user.
+  createRateLimiter('sensitive'),
   addErrorHandling(CONTAINER_ERRORS.CONTAINER_NOT_DELETED),
   wrapAsyncHandler(async (req, res) => {
     const { containerId } = req.params;
@@ -355,6 +366,8 @@ router.delete(
 router.post(
   '/:containerId/item',
   getGroupMemberPermissions,
+  // State-changing action: sensitive tier, keyed per user.
+  createRateLimiter('sensitive'),
   addErrorHandling(CONTAINER_ERRORS.ITEM_NOT_CREATED),
   wrapAsyncHandler(async (req, res) => {
     const { containerId } = req.params;
@@ -407,6 +420,8 @@ router.post(
 router.delete(
   '/:containerId/item/:itemId',
   getGroupMemberPermissions,
+  // State-changing action: sensitive tier, keyed per user.
+  createRateLimiter('sensitive'),
   addErrorHandling(CONTAINER_ERRORS.ITEM_NOT_DELETED),
   wrapAsyncHandler(async (req, res) => {
     const { itemId } = req.params;
@@ -458,6 +473,8 @@ router.delete(
 router.post(
   '/:containerId/item/:itemId/rename',
   getGroupMemberPermissions,
+  // State-changing action: sensitive tier, keyed per user.
+  createRateLimiter('sensitive'),
   addErrorHandling(CONTAINER_ERRORS.ITEM_NOT_RENAMED),
   wrapAsyncHandler(async (req, res) => {
     const { itemId } = req.params;
@@ -540,6 +557,8 @@ router.post(
 router.post(
   '/:containerId/member/invite',
   getGroupMemberPermissions,
+  // State-changing action: sensitive tier, keyed per user.
+  createRateLimiter('sensitive'),
   addErrorHandling(CONTAINER_ERRORS.INVITATION_NOT_CREATED),
   wrapAsyncHandler(async (req, res) => {
     const { containerId } = req.params;
@@ -630,6 +649,8 @@ router.delete(
 router.post(
   '/:containerId/member',
   getGroupMemberPermissions,
+  // State-changing action: sensitive tier, keyed per user.
+  createRateLimiter('sensitive'),
   addErrorHandling(CONTAINER_ERRORS.MEMBER_NOT_CREATED),
   wrapAsyncHandler(async (req, res) => {
     const { containerId } = req.params;
@@ -668,6 +689,8 @@ router.post(
 router.delete(
   '/:containerId/member/:userId',
   getGroupMemberPermissions,
+  // State-changing action: sensitive tier, keyed per user.
+  createRateLimiter('sensitive'),
   addErrorHandling(CONTAINER_ERRORS.MEMBER_NOT_DELETED),
   wrapAsyncHandler(async (req, res) => {
     const { containerId, userId } = req.params;
@@ -700,6 +723,8 @@ router.delete(
 router.get(
   '/:containerId/members',
   getGroupMemberPermissions,
+  // Authenticated read: loosest tier, keyed per user.
+  createRateLimiter('read'),
   addErrorHandling(CONTAINER_ERRORS.MEMBERS_NOT_FOUND),
   wrapAsyncHandler(async (req, res) => {
     // getContainerWithMembers
@@ -733,6 +758,8 @@ router.get(
 router.get(
   '/:containerId/info',
   getGroupMemberPermissions,
+  // Authenticated read: loosest tier, keyed per user.
+  createRateLimiter('read'),
   addErrorHandling(CONTAINER_ERRORS.INFO_NOT_FOUND),
   wrapAsyncHandler(async (req, res) => {
     const { containerId } = req.params;
@@ -765,6 +792,8 @@ router.get(
 router.get(
   '/:containerId/shares',
   getGroupMemberPermissions,
+  // Authenticated read: loosest tier, keyed per user.
+  createRateLimiter('read'),
   addErrorHandling(CONTAINER_ERRORS.SHARES_NOT_FOUND),
   wrapAsyncHandler(async (req, res) => {
     const { containerId } = req.params;
@@ -812,6 +841,8 @@ router.get(
 router.post(
   '/:containerId/shares/invitation/update',
   getGroupMemberPermissions,
+  // State-changing action: sensitive tier, keyed per user.
+  createRateLimiter('sensitive'),
   addErrorHandling(CONTAINER_ERRORS.PERMISSIONS_NOT_UPDATED),
   wrapAsyncHandler(async (req, res) => {
     const { containerId } = req.params;
@@ -866,6 +897,8 @@ router.post(
 router.post(
   '/:containerId/shares/accessLink/update',
   getGroupMemberPermissions,
+  // State-changing action: sensitive tier, keyed per user.
+  createRateLimiter('sensitive'),
   addErrorHandling(CONTAINER_ERRORS.PERMISSIONS_NOT_UPDATED),
   wrapAsyncHandler(async (req, res) => {
     const { containerId } = req.params;

--- a/packages/send/backend/src/routes/sharing.ts
+++ b/packages/send/backend/src/routes/sharing.ts
@@ -29,6 +29,7 @@ import {
   addExpiryToContainer,
   formatAccessLinkWithPasswordHash,
 } from '@send-backend/utils';
+import { createRateLimiter } from '../middleware/rate-limit';
 import {
   getGroupMemberPermissions,
   requireAdminPermission,
@@ -72,6 +73,8 @@ router.post(
   requireJWT,
   getGroupMemberPermissions,
   requireSharePermission,
+  // State-changing share action: sensitive tier, keyed per user.
+  createRateLimiter('sensitive'),
   addErrorHandling(SHARING_ERRORS.ACCESS_LINK_NOT_CREATED),
   wrapAsyncHandler(async (req, res) => {
     const { uniqueHash } = getDataFromAuthenticatedRequest(req);
@@ -147,6 +150,8 @@ router.get(
   requireJWT,
   getGroupMemberPermissions,
   requireSharePermission,
+  // Authenticated read: loosest tier, keyed per user.
+  createRateLimiter('read'),
   wrapAsyncHandler(async (req, res) => {
     const { containerId } = req.params;
     const canCreateLink = await checkIfAccessLinkCanBeCreated(containerId);
@@ -335,6 +340,8 @@ router.get(
   requireJWT,
   getGroupMemberPermissions,
   requireAdminPermission,
+  // Authenticated read: loosest tier, keyed per user.
+  createRateLimiter('read'),
   addErrorHandling(SHARING_ERRORS.ACCESS_LINK_NOT_FOUND),
   wrapAsyncHandler(async (req, res) => {
     const { uploadId } = req.params;

--- a/packages/send/backend/src/routes/tags.ts
+++ b/packages/send/backend/src/routes/tags.ts
@@ -6,6 +6,7 @@ import {
   wrapAsyncHandler,
 } from '../errors/routes';
 import { getGroupMemberPermissions, requireJWT } from '../middleware';
+import { createRateLimiter } from '../middleware/rate-limit';
 import {
   createTagForContainer,
   createTagForItem,
@@ -64,6 +65,8 @@ router.get(
   '/:tagName',
   requireJWT,
   getGroupMemberPermissions,
+  // Authenticated read: loosest tier, keyed per user.
+  createRateLimiter('read'),
   addErrorHandling(TAG_ERRORS.NOT_FOUND),
   wrapAsyncHandler(async (req, res) => {
     const { id } = getDataFromAuthenticatedRequest(req);

--- a/packages/send/backend/src/routes/uploads.ts
+++ b/packages/send/backend/src/routes/uploads.ts
@@ -24,6 +24,7 @@ import {
 import { getDataFromAuthenticatedRequest } from '@send-backend/auth/client';
 import { deleteUploadsByIds, reportUpload } from '@send-backend/models';
 import storage from '@send-backend/storage';
+import { createRateLimiter } from '../middleware/rate-limit';
 import { useMetrics } from '../metrics';
 import {
   checkStorageLimit,
@@ -82,6 +83,8 @@ router.post(
   getGroupMemberPermissions,
   requireWritePermission,
   checkStorageLimit,
+  // State-changing upload creation: sensitive tier, keyed per user.
+  createRateLimiter('sensitive'),
   addErrorHandling(UPLOAD_ERRORS.NOT_CREATED),
   wrapAsyncHandler(async (req, res) => {
     try {

--- a/packages/send/backend/src/test/middleware/rate-limit.test.ts
+++ b/packages/send/backend/src/test/middleware/rate-limit.test.ts
@@ -131,4 +131,41 @@ describe('rate-limit middleware', () => {
       await request(app).get('/test').expect(200);
     }
   });
+
+  it('resets the budget after the window passes, letting requests through again', async () => {
+    const createRateLimiter = await loadLimiterFactory();
+    const app = appWithLimiter(createRateLimiter('auth'));
+
+    // Use up the budget.
+    await request(app).get('/test').expect(200);
+    await request(app).get('/test').expect(200);
+    await request(app).get('/test').expect(200);
+    await request(app).get('/test').expect(429);
+
+    // Real Redis expires the counter key when the window elapses. Simulate that
+    // by clearing the shared store the way the TTL would, then confirm the same
+    // caller is allowed again.
+    counts.clear();
+
+    await request(app).get('/test').expect(200);
+  });
+
+  it('shares one budget across instances (counts in the shared store, not per instance)', async () => {
+    const createRateLimiter = await loadLimiterFactory();
+    // Two separate limiter instances stand in for two backend replicas. They
+    // must draw from the same Redis-backed counter, so the per-user limit is
+    // one shared budget rather than one budget per replica.
+    const replicaA = appWithLimiter(createRateLimiter('read'), 'same-user');
+    const replicaB = appWithLimiter(createRateLimiter('read'), 'same-user');
+
+    // Spend the whole budget of 3 spread across both replicas.
+    await request(replicaA).get('/test').expect(200);
+    await request(replicaB).get('/test').expect(200);
+    await request(replicaA).get('/test').expect(200);
+
+    // The 4th request is blocked no matter which replica answers it -- proving
+    // the limit was not counted separately per instance.
+    await request(replicaB).get('/test').expect(429);
+    await request(replicaA).get('/test').expect(429);
+  });
 });

--- a/packages/send/frontend/src/lib/api.ts
+++ b/packages/send/frontend/src/lib/api.ts
@@ -74,6 +74,44 @@ export function buildApiUrl(serverUrl: string, path: string): string {
   return url.toString();
 }
 
+// Upper bound on how long we will wait for a Retry-After before giving up on the
+// automatic retry. A server should never ask a browser to sit idle for minutes;
+// beyond this we surface the rate-limit to the caller instead of blocking.
+export const MAX_RETRY_AFTER_MS = 10_000;
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Parse an HTTP `Retry-After` header into milliseconds.
+ *
+ * Supports both forms the spec allows: a number of seconds (`"3"`) and an
+ * HTTP-date (`"Wed, 21 Oct 2026 07:28:00 GMT"`). Returns null when the header is
+ * absent or unparseable, and clamps negatives to 0 (a past date means "now").
+ */
+export function parseRetryAfterMs(
+  header: string | null | undefined
+): number | null {
+  if (!header) {
+    return null;
+  }
+  const trimmed = header.trim();
+
+  // delta-seconds form.
+  if (/^\d+$/.test(trimmed)) {
+    return Number(trimmed) * 1000;
+  }
+
+  // HTTP-date form.
+  const dateMs = Date.parse(trimmed);
+  if (!Number.isNaN(dateMs)) {
+    return Math.max(0, dateMs - Date.now());
+  }
+
+  return null;
+}
+
 export class ApiConnection {
   serverUrl: string;
 
@@ -246,6 +284,38 @@ export class ApiConnection {
       }
     }
 
+    // Rate limiting (429): the backend is asking us to slow down, not failing.
+    // Wait the server-suggested amount (Retry-After) and retry once, rather than
+    // hammering it or surfacing a hard error. This pairs with the backend limits
+    // added under the #1072 milestone.
+    if (resp.status === 429) {
+      const waitMs = parseRetryAfterMs(resp.headers?.get?.('retry-after'));
+      // Only back off for a sane, bounded wait. A missing/garbage or absurdly
+      // long Retry-After should not hang the request behind a multi-minute
+      // timer; in that case we skip the retry and report it to the caller.
+      if (waitMs !== null && waitMs <= MAX_RETRY_AFTER_MS) {
+        await delay(waitMs);
+        try {
+          resp = await fetch(url, opts);
+        } catch (error) {
+          options?.onFailure?.({ kind: 'network', status: null, error });
+          return null;
+        }
+      }
+
+      // Still limited after the single retry (or we chose not to wait): tell the
+      // caller explicitly so it can show a friendly "please wait" message rather
+      // than a generic failure.
+      if (resp.status === 429) {
+        options?.onFailure?.({
+          kind: 'rate_limited',
+          status: 429,
+          retryAfterMs: waitMs,
+        });
+        return null;
+      }
+    }
+
     if (!resp.ok) {
       // Surface the status/body for the caller's diagnostics before discarding
       // the response. Reading the body is safe here because we return null
@@ -281,7 +351,11 @@ export class ApiConnection {
  */
 export type ApiCallFailure =
   | { kind: 'network'; status: null; error: unknown }
-  | { kind: 'http'; status: number; statusText: string; body?: string };
+  | { kind: 'http'; status: number; statusText: string; body?: string }
+  // The request was rate-limited (HTTP 429). `retryAfterMs` is the wait the
+  // server suggested, if it sent a usable Retry-After (null otherwise). Callers
+  // can use it to show a "too many requests, please wait" message.
+  | { kind: 'rate_limited'; status: 429; retryAfterMs: number | null };
 
 type Options = {
   fullResponse?: boolean;

--- a/packages/send/frontend/src/test/lib/api.test.ts
+++ b/packages/send/frontend/src/test/lib/api.test.ts
@@ -8,6 +8,7 @@ import {
   ApiCallFailure,
   ApiConnection,
   buildApiUrl,
+  parseRetryAfterMs,
 } from '@send-frontend/lib/api';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -273,6 +274,128 @@ describe('ApiConnection.call — onFailure diagnostics', () => {
 
     expect(failure?.kind).toBe('http');
     expect((failure as { body: string }).body).toHaveLength(500);
+  });
+});
+
+describe('parseRetryAfterMs', () => {
+  it('parses delta-seconds into milliseconds', () => {
+    expect(parseRetryAfterMs('3')).toBe(3000);
+    expect(parseRetryAfterMs('0')).toBe(0);
+  });
+
+  it('parses an HTTP-date into a wait relative to now', () => {
+    const twoSecondsOut = new Date(Date.now() + 2000).toUTCString();
+    const ms = parseRetryAfterMs(twoSecondsOut);
+    // Allow a little slack for clock/rounding; UTCString drops sub-second parts.
+    expect(ms).toBeGreaterThanOrEqual(0);
+    expect(ms).toBeLessThanOrEqual(2000);
+  });
+
+  it('clamps a past date to 0', () => {
+    const past = new Date(Date.now() - 60_000).toUTCString();
+    expect(parseRetryAfterMs(past)).toBe(0);
+  });
+
+  it('returns null for missing or unparseable values', () => {
+    expect(parseRetryAfterMs(null)).toBeNull();
+    expect(parseRetryAfterMs(undefined)).toBeNull();
+    expect(parseRetryAfterMs('')).toBeNull();
+    expect(parseRetryAfterMs('soon')).toBeNull();
+  });
+});
+
+describe('ApiConnection.call — 429 rate limiting (#1105)', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('waits the Retry-After then retries once and returns the retry body', async () => {
+    let call = 0;
+    const fetchFn = mockFetch(() => {
+      call += 1;
+      if (call === 1) {
+        return {
+          ok: false,
+          status: 429,
+          headers: { get: (k: string) => (k === 'retry-after' ? '0' : null) },
+          json: async () => ({ limited: true }),
+        } as unknown as Response;
+      }
+      return {
+        ok: true,
+        status: 200,
+        headers: { get: () => null },
+        json: async () => ({ ok: true }),
+      } as unknown as Response;
+    });
+
+    const api = new ApiConnection(SERVER);
+    const result = await api.call('uploads', {}, 'POST');
+
+    expect(fetchFn).toHaveBeenCalledTimes(2); // retried once after backoff
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('reports kind=rate_limited when still limited after the retry', async () => {
+    const fetchFn = mockFetch(
+      () =>
+        ({
+          ok: false,
+          status: 429,
+          headers: { get: (k: string) => (k === 'retry-after' ? '0' : null) },
+          json: async () => ({ limited: true }),
+        }) as unknown as Response
+    );
+
+    const api = new ApiConnection(SERVER);
+    let failure: ApiCallFailure | undefined;
+    const result = await api.call(
+      'uploads',
+      {},
+      'POST',
+      {},
+      { onFailure: (f) => (failure = f) }
+    );
+
+    expect(fetchFn).toHaveBeenCalledTimes(2); // original + one retry
+    expect(result).toBeNull();
+    expect(failure).toEqual({
+      kind: 'rate_limited',
+      status: 429,
+      retryAfterMs: 0,
+    });
+  });
+
+  it('does not retry when Retry-After is missing, and reports rate_limited', async () => {
+    const fetchFn = mockFetch(
+      () =>
+        ({
+          ok: false,
+          status: 429,
+          headers: { get: () => null },
+          json: async () => ({ limited: true }),
+        }) as unknown as Response
+    );
+
+    const api = new ApiConnection(SERVER);
+    let failure: ApiCallFailure | undefined;
+    const result = await api.call(
+      'uploads',
+      {},
+      'POST',
+      {},
+      { onFailure: (f) => (failure = f) }
+    );
+
+    // No usable Retry-After -> no automatic retry, just surface it.
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(result).toBeNull();
+    expect(failure).toEqual({
+      kind: 'rate_limited',
+      status: 429,
+      retryAfterMs: null,
+    });
   });
 });
 


### PR DESCRIPTION
## What changed?

Makes the Send app handle a "too many requests" (HTTP 429) response gracefully (#1105). When the backend rate-limits a request, the app now:

- reads the server's `Retry-After` hint and waits that long (capped at 10 seconds), then retries the request once — instead of failing immediately or retrying blindly;
- if it is still limited after that one retry, or there is no usable `Retry-After`, reports a distinct "rate limited" outcome so the calling code can show a clear "please wait" message rather than a generic error.

This pairs with the backend limits from the #1072 milestone, so a user who ever bumps into a limit sees a smooth pause-and-recover instead of a hard failure.

_AI disclosure: written by an AI agent with human direction on scope and decisions; each step was reviewed by a human before commit._

## Why?

Part of the #1072 milestone. The backend now returns 429 on sensitive endpoints when limits are exceeded; without this the frontend would treat that as an unexpected failure. #1105 closes that gap on the app side.

## Limitations and Notes

- **Stacked on #1172** (which is stacked on #1171). Review/merge after those; the diff against `main` includes their commits until they land.
- Retries at most once, and only for a sane bounded wait — a missing, garbage, or absurdly long `Retry-After` skips the auto-retry and surfaces the rate-limit to the caller instead of hanging the request.
- The API layer exposes the rate-limit outcome via the existing `onFailure` hook (new `kind: 'rate_limited'`); wiring a specific user-facing toast at each call site can follow as needed.

## Applicable Issues

Part of #1072. Delivers #1105. Depends on #1172 (#1104) and #1171 (#1103).

## Screenshots

N/A — behavior is a network-layer retry/back-off; no UI layout change.
