### PR TITLE
fix(addon): tell "storage unavailable" apart from "signed out"

### DIFF
--- a/packages/addon/public/token-bridge.js
+++ b/packages/addon/public/token-bridge.js
@@ -167,6 +167,9 @@ browser.runtime.onMessage.addListener((message) => {
         type: LOGIN_STATE_RESPONSE,
         isLoggedIn: message.isLoggedIn,
         username: message.username,
+        // "storage unavailable" is not the same as "signed out" — the Send app
+        // must not act on a signed-out answer we are not sure about.
+        storageUnavailable: message.storageUnavailable ?? false,
       },
       window.location.origin
     );

--- a/packages/addon/src/background.ts
+++ b/packages/addon/src/background.ts
@@ -807,6 +807,18 @@ function initStorageWatcher() {
 // fires onAccountAdded with the OIDC token so we can log the add-on in
 // automatically without requiring a second login through the web UI.
 function initAccountHubListener() {
+  // The experiment API may be unavailable in some builds/contexts. Degrade
+  // gracefully (Accounts Hub auto-login is simply disabled) instead of
+  // throwing -- this now runs before the cloud file gate in main(), so a
+  // throw here would abort startup and skip that gate entirely.
+  if (!browser.AccountHub?.onAccountAdded?.addListener) {
+    console.warn(
+      '[AccountHub] browser.AccountHub.onAccountAdded unavailable; ' +
+        'Accounts Hub auto-login disabled.'
+    );
+    return;
+  }
+
   browser.AccountHub.onAccountAdded.addListener(async ({ token, email }) => {
     console.log(
       `[AccountHub] onAccountAdded fired for ${email}. Logging in add-on.`
@@ -874,21 +886,24 @@ function initTelemetryListener() {
 (async function main() {
   await checkAndUninstallIfDeprecated();
   initMenu();
-  // Only create the Send cloudfile account when the user is already signed in.
-  // A fresh, never-signed-in profile (e.g. the built-in system add-on under
-  // automation) must leave the cloudfile account list untouched so it doesn't
-  // pollute the default profile or break Thunderbird's cloudfile tests
-  // (Bug 2036665). The account is otherwise created on explicit sign-in.
+  // These three only register listeners and don't depend on the login state.
+  // They go before the getLoginState() read below because that read can spend
+  // ~1.25s retrying while storage is slow to come up (see readStoredAuth in
+  // menu.ts), and an Accounts Hub sign-in landing in that window must not be
+  // missed.
+  initStorageWatcher();
+  initAccountHubListener();
+  initTelemetryListener();
+  // Decide what to do with the Send cloudfile setup. cloudFileStartupAction()
+  // carries the full rationale (Bug 2036665, Bug 2064203 comment 4).
   const loginState = await getLoginState();
   switch (cloudFileStartupAction(loginState)) {
     case 'register':
       initCloudFile();
       break;
     case 'unregister':
-      // Signed out: the manifest `cloud_file` key makes Thunderbird register the
-      // Send provider on every startup, so on a fresh/never-signed-in profile it
-      // would still appear in the cloud file provider list and break Thunderbird's
-      // own cloudfile tests (Bug 2036665). Unregister it until the user signs in;
+      // The manifest `cloud_file` key re-registers the Send provider on every
+      // startup, so a signed-out profile must actively unregister it here;
       // initCloudFile() re-registers it on sign-in.
       try {
         await browser.CloudFileAccounts.unregisterProvider();
@@ -907,9 +922,6 @@ function initTelemetryListener() {
       );
       break;
   }
-  initStorageWatcher();
-  initAccountHubListener();
-  initTelemetryListener();
 })().catch((error) => {
   console.error('Error initializing background.js', error);
 });

--- a/packages/addon/src/background.ts
+++ b/packages/addon/src/background.ts
@@ -48,7 +48,7 @@ import {
   menuLoggedIn,
   menuLogout,
 } from './menu';
-import { shouldInitCloudFileOnStartup } from './cloudFileGate';
+import { cloudFileStartupAction } from './cloudFileGate';
 import { checkAndUninstallIfDeprecated } from './selfUninstall';
 
 // Initialize the shared Pinia instance that will be used by both
@@ -478,6 +478,10 @@ browser.runtime.onMessage.addListener(async (message, sender) => {
               type: LOGIN_STATE_RESPONSE,
               isLoggedIn: loginState.isLoggedIn,
               username: loginState.username,
+              // Forwarded so the Send app can tell "signed out" apart from "we
+              // could not read storage" and avoid bouncing a signed-in user to
+              // the login flow. See LoginState in menu.ts.
+              storageUnavailable: loginState.storageUnavailable ?? false,
             })
             .catch(() => {
               // Ignore errors for tabs that can't receive messages
@@ -875,20 +879,33 @@ function initTelemetryListener() {
   // automation) must leave the cloudfile account list untouched so it doesn't
   // pollute the default profile or break Thunderbird's cloudfile tests
   // (Bug 2036665). The account is otherwise created on explicit sign-in.
-  const { isLoggedIn } = await getLoginState();
-  if (shouldInitCloudFileOnStartup(isLoggedIn)) {
-    initCloudFile();
-  } else {
-    // Signed out: the manifest `cloud_file` key makes Thunderbird register the
-    // Send provider on every startup, so on a fresh/never-signed-in profile it
-    // would still appear in the cloud file provider list and break Thunderbird's
-    // own cloudfile tests (Bug 2036665). Unregister it until the user signs in;
-    // initCloudFile() re-registers it on sign-in.
-    try {
-      await browser.CloudFileAccounts.unregisterProvider();
-    } catch (error) {
-      console.warn('Error unregistering cloud file provider:', error);
-    }
+  const loginState = await getLoginState();
+  switch (cloudFileStartupAction(loginState)) {
+    case 'register':
+      initCloudFile();
+      break;
+    case 'unregister':
+      // Signed out: the manifest `cloud_file` key makes Thunderbird register the
+      // Send provider on every startup, so on a fresh/never-signed-in profile it
+      // would still appear in the cloud file provider list and break Thunderbird's
+      // own cloudfile tests (Bug 2036665). Unregister it until the user signs in;
+      // initCloudFile() re-registers it on sign-in.
+      try {
+        await browser.CloudFileAccounts.unregisterProvider();
+      } catch (error) {
+        console.warn('Error unregistering cloud file provider:', error);
+      }
+      break;
+    case 'leave-as-is':
+      // Storage could not be read, so we do not know whether anyone is signed
+      // in. Registering or unregistering on a guess is what took Send away from
+      // signed-in users during a Thunderbird storage failure (Bug 2064203
+      // comment 4), so leave the cloud file setup exactly as Thunderbird left it.
+      console.warn(
+        'Login state unknown (storage unavailable) — leaving the Send cloud ' +
+          'file provider registration untouched.'
+      );
+      break;
   }
   initStorageWatcher();
   initAccountHubListener();

--- a/packages/addon/src/cloudFileGate.ts
+++ b/packages/addon/src/cloudFileGate.ts
@@ -33,8 +33,16 @@ export type CloudFileStartupAction = 'register' | 'unregister' | 'leave-as-is';
  * failure (Bug 2067502) made the add-on unregister the provider for people who
  * were signed in — they simply lost the ability to send with Send until the
  * storage fault was repaired (Bug 2064203 comment 4). When we cannot tell, the
- * safe move is to touch nothing: a signed-in user keeps working, and a fresh
- * profile stays clean because nothing was registered there in the first place.
+ * least harmful move is to touch nothing.
+ *
+ * `leave-as-is` accepts a known, narrow regression against Bug 2036665: the
+ * manifest `cloud_file` key has already registered the provider by the time we
+ * run, so skipping the unregister leaves a Send entry visible in the provider
+ * list on a signed-out or fresh profile whose storage is broken. No cloudfile
+ * *account* is created (that is the `register` branch only), so the
+ * clean-account-baseline assertions quoted above still hold, and Thunderbird's
+ * own test runs use healthy profiles. Losing the ability to send for a whole
+ * session is the worse failure, so we take the visible-provider one.
  */
 export function cloudFileStartupAction(
   state: LoginState

--- a/packages/addon/src/cloudFileGate.ts
+++ b/packages/addon/src/cloudFileGate.ts
@@ -1,7 +1,16 @@
+import type { LoginState } from './menu';
+
 /**
- * Whether to create/register the Thunderbird Send cloudfile account eagerly on
- * background startup.
+ * What background startup should do with the Thunderbird Send cloudfile
+ * provider, given what the login probe managed to find out.
  *
+ * - `register`   — the user is signed in; create/register the Send account.
+ * - `unregister` — the user is definitely signed out; hide Send entirely.
+ * - `leave-as-is` — we could not read storage, so we do not know. Change nothing.
+ */
+export type CloudFileStartupAction = 'register' | 'unregister' | 'leave-as-is';
+
+/**
  * The Send cloudfile account must only exist once the user has actually signed
  * in. The built-in system add-on is enabled by default for every Thunderbird
  * user, so on a fresh, never-signed-in profile (including under automation) it
@@ -11,16 +20,28 @@
  * addRemoveAccounts checks — which assert a clean account baseline (e.g.
  * "Should have no cloudfile accounts starting off. - 1 == 0"). See Bug 2036665.
  *
- * The account is still created on explicit sign-in via the SIGN_IN_COMPLETE
- * flow in background.ts, so signed-in users (standalone or system) keep the Send
- * cloudfile provider configured.
- *
  * The manifest `cloud_file` key also makes Thunderbird register the Send
- * provider itself on every startup, independently of the account. When this
- * returns false, background.ts additionally unregisters that provider (via the
+ * provider itself on every startup, independently of the account. On
+ * `unregister`, background.ts additionally unregisters that provider (via the
  * CloudFileAccounts experiment API) so a signed-out profile shows no Send entry
- * in the cloud file provider list at all; it is re-registered on sign-in.
+ * in the cloud file provider list at all; it is re-registered on sign-in via the
+ * SIGN_IN_COMPLETE flow.
+ *
+ * `leave-as-is` is the third answer, and the reason this function exists rather
+ * than a boolean. A failed storage read used to arrive here as `isLoggedIn:
+ * false`, indistinguishable from a fresh profile, so a Thunderbird-wide storage
+ * failure (Bug 2067502) made the add-on unregister the provider for people who
+ * were signed in — they simply lost the ability to send with Send until the
+ * storage fault was repaired (Bug 2064203 comment 4). When we cannot tell, the
+ * safe move is to touch nothing: a signed-in user keeps working, and a fresh
+ * profile stays clean because nothing was registered there in the first place.
  */
-export function shouldInitCloudFileOnStartup(isLoggedIn: boolean): boolean {
-  return isLoggedIn;
+export function cloudFileStartupAction(
+  state: LoginState
+): CloudFileStartupAction {
+  if (state.storageUnavailable) {
+    return 'leave-as-is';
+  }
+
+  return state.isLoggedIn ? 'register' : 'unregister';
 }

--- a/packages/addon/src/menu.ts
+++ b/packages/addon/src/menu.ts
@@ -195,7 +195,7 @@ export async function menuLogout() {
   //
   // This blanket clear() is ONLY reached from a genuine logout (menuLogout(),
   // driven by the LOGOUT menu action / the SIGN_OUT message). The read-only
-  // getLoginState() probe (60s timer + route guard) MUST NOT reach this and
+  // getLoginState() probe (periodic probe + route guard) MUST NOT reach this and
   // does not -- it only ever calls storage.local.get(). See #948/#949.
   await browser.storage.local.clear();
 
@@ -245,6 +245,10 @@ async function closeAllAddOnTabs() {
  * still signed in (Bug 2064203 comment 4). Callers that act on a signed-out
  * result -- unregistering the provider, redirecting, closing a window -- must
  * check this flag first and do nothing when it is set.
+ *
+ * The flag is simply absent on any answer read from working storage;
+ * background.ts normalizes it to a plain boolean before the answer crosses the
+ * token bridge to the Send web app.
  */
 export type LoginState = {
   isLoggedIn: boolean;
@@ -258,47 +262,39 @@ type StoredAuth = {
   profile?: { preferred_username?: string; email?: string };
 };
 
-type AuthRead =
-  | { ok: true; auth: StoredAuth | undefined }
-  | { ok: false; error: unknown };
-
 /**
- * Backoff between attempts at reading the stored session. Its length also sets
- * the number of retries.
+ * Waits between retries of the stored-session read. Its length also sets the
+ * number of retries.
  *
- * A single read is enough on a healthy profile, but it makes startup a coin
+ * A single read is enough on a healthy profile, but it made startup a coin
  * flip on a slow or still-initializing storage backend: background's main()
- * reads once, and if that one read loses the race the add-on spends the whole
- * session believing the user is signed out. These retries are deliberately
- * short -- they cover a storage layer that is coming up, not one that is broken.
+ * reads once, and when that read lost the race the add-on used to spend the
+ * whole session treating the user as signed out. (Today it would spend it in
+ * the "storage unavailable" state instead -- better, but the cloud file
+ * decision made at startup would still be wrong.) These retries are
+ * deliberately short -- they cover a storage layer that is coming up, not one
+ * that is broken.
  */
 const AUTH_READ_RETRY_DELAYS_MS = [250, 1000];
 
 const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
-async function readStoredAuth(): Promise<AuthRead> {
-  let lastError: unknown;
-
-  for (
-    let attempt = 0;
-    attempt <= AUTH_READ_RETRY_DELAYS_MS.length;
-    attempt++
-  ) {
+/**
+ * Reads the stored session, retrying briefly; rethrows the last error once the
+ * retries are spent.
+ */
+async function readStoredAuth(): Promise<StoredAuth | undefined> {
+  for (let attempt = 0; ; attempt++) {
     try {
       const authStorageData = await browser.storage.local.get(STORAGE_KEY_AUTH);
-      return {
-        ok: true,
-        auth: authStorageData[STORAGE_KEY_AUTH] as StoredAuth,
-      };
+      return authStorageData[STORAGE_KEY_AUTH] as StoredAuth | undefined;
     } catch (error) {
-      lastError = error;
-      if (attempt < AUTH_READ_RETRY_DELAYS_MS.length) {
-        await wait(AUTH_READ_RETRY_DELAYS_MS[attempt]);
+      if (attempt === AUTH_READ_RETRY_DELAYS_MS.length) {
+        throw error;
       }
+      await wait(AUTH_READ_RETRY_DELAYS_MS[attempt]);
     }
   }
-
-  return { ok: false, error: lastError };
 }
 
 /**
@@ -325,7 +321,7 @@ function noteStorageFailure(error: unknown) {
 function noteStorageRecovered() {
   if (storageFailureStreak > 0) {
     console.info(
-      `Storage is readable again after ${storageFailureStreak} failed attempt(s).`
+      `Storage is readable again after ${storageFailureStreak} failed check(s).`
     );
     storageFailureStreak = 0;
   }
@@ -334,8 +330,9 @@ function noteStorageRecovered() {
 /*
   Checks if the add-on is logged in, this is separate from the web context.
   It's a read-only probe: it's called by the Send route guard (via GET_LOGIN_STATE)
-  and by a 60s timer, so it MUST NOT have destructive side effects (closing tabs,
-  wiping storage, forcing the menu to log out).
+  and by a periodic probe (60s base, backing off while storage is unreadable --
+  see startLoginStateChecks), so it MUST NOT have destructive side effects
+  (closing tabs, wiping storage, forcing the menu to log out).
 
   Note on `expires_at`: that field is the short-lived OIDC *access token* expiry. An
   expired access token does NOT mean the session is over — the Send web app refreshes
@@ -345,19 +342,15 @@ function noteStorageRecovered() {
   SIGN_OUT message path, which calls menuLogout().
  */
 export async function getLoginState(): Promise<LoginState> {
-  const read = await readStoredAuth();
-
-  // `=== false` rather than `!read.ok`: this package compiles with
-  // strictNullChecks off, where only the explicit comparison narrows AuthRead
-  // to its failure branch.
-  if (read.ok === false) {
-    noteStorageFailure(read.error);
+  let auth: StoredAuth | undefined;
+  try {
+    auth = await readStoredAuth();
+  } catch (error) {
+    noteStorageFailure(error);
     return { isLoggedIn: false, username: null, storageUnavailable: true };
   }
 
   noteStorageRecovered();
-
-  const { auth } = read;
 
   if (!auth) {
     return { isLoggedIn: false, username: null };
@@ -409,19 +402,22 @@ export async function closeLoginTab() {
  * (Bug 2064203 comment 4 / Bug 2067502). Backing off costs us nothing: there is
  * no session change to notice while storage cannot be read, and the very next
  * successful probe drops straight back to the normal interval.
+ *
+ * Exported only so tests can drive the schedule with fake timers; init() is
+ * the real caller.
  */
-function checkLoginStateOnInterval() {
-  const CHECK_INTERVAL_MS = 60 * 1000; // Check every 60 seconds
+export function startLoginStateChecks() {
+  const BASE_CHECK_INTERVAL_MS = 60 * 1000;
   const MAX_CHECK_INTERVAL_MS = 15 * 60 * 1000;
 
-  let intervalMs = CHECK_INTERVAL_MS;
+  let intervalMs = BASE_CHECK_INTERVAL_MS;
 
   const scheduleNextCheck = () => {
     setTimeout(async () => {
       const state = await getLoginState().catch(() => null);
       intervalMs = state?.storageUnavailable
         ? Math.min(intervalMs * 2, MAX_CHECK_INTERVAL_MS)
-        : CHECK_INTERVAL_MS;
+        : BASE_CHECK_INTERVAL_MS;
       scheduleNextCheck();
     }, intervalMs);
   };
@@ -483,6 +479,6 @@ export function init() {
   // But we do not need to wait for it synchronously.
   getLoginState();
 
-  // Start interval to check login state periodically
-  checkLoginStateOnInterval();
+  // Keep the login state in sync with the web context on a schedule.
+  startLoginStateChecks();
 }

--- a/packages/addon/src/menu.ts
+++ b/packages/addon/src/menu.ts
@@ -234,6 +234,103 @@ async function closeAllAddOnTabs() {
   }
 }
 
+/**
+ * What the read-only login probe found.
+ *
+ * `storageUnavailable` exists because "we could not read storage" and "the user
+ * is signed out" are different answers that used to look identical. When
+ * Thunderbird's QuotaManager fails, every `browser.storage.local` call in every
+ * add-on rejects (Bug 2067502); reporting that as a plain signed-out state made
+ * the add-on tear down the Send cloud file provider underneath a user who was
+ * still signed in (Bug 2064203 comment 4). Callers that act on a signed-out
+ * result -- unregistering the provider, redirecting, closing a window -- must
+ * check this flag first and do nothing when it is set.
+ */
+export type LoginState = {
+  isLoggedIn: boolean;
+  username: string | null;
+  storageUnavailable?: true;
+};
+
+/** The subset of the stored OIDC session that decides the login state. */
+type StoredAuth = {
+  refresh_token?: string;
+  profile?: { preferred_username?: string; email?: string };
+};
+
+type AuthRead =
+  | { ok: true; auth: StoredAuth | undefined }
+  | { ok: false; error: unknown };
+
+/**
+ * Backoff between attempts at reading the stored session. Its length also sets
+ * the number of retries.
+ *
+ * A single read is enough on a healthy profile, but it makes startup a coin
+ * flip on a slow or still-initializing storage backend: background's main()
+ * reads once, and if that one read loses the race the add-on spends the whole
+ * session believing the user is signed out. These retries are deliberately
+ * short -- they cover a storage layer that is coming up, not one that is broken.
+ */
+const AUTH_READ_RETRY_DELAYS_MS = [250, 1000];
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function readStoredAuth(): Promise<AuthRead> {
+  let lastError: unknown;
+
+  for (
+    let attempt = 0;
+    attempt <= AUTH_READ_RETRY_DELAYS_MS.length;
+    attempt++
+  ) {
+    try {
+      const authStorageData = await browser.storage.local.get(STORAGE_KEY_AUTH);
+      return {
+        ok: true,
+        auth: authStorageData[STORAGE_KEY_AUTH] as StoredAuth,
+      };
+    } catch (error) {
+      lastError = error;
+      if (attempt < AUTH_READ_RETRY_DELAYS_MS.length) {
+        await wait(AUTH_READ_RETRY_DELAYS_MS[attempt]);
+      }
+    }
+  }
+
+  return { ok: false, error: lastError };
+}
+
+/**
+ * How many probes in a row have failed to read storage. Only the first failure
+ * of a streak is logged: the underlying fault lasts for the whole session, so
+ * repeating it every probe buries everything else in the Error Console without
+ * adding a single new fact.
+ */
+let storageFailureStreak = 0;
+
+function noteStorageFailure(error: unknown) {
+  storageFailureStreak++;
+
+  if (storageFailureStreak === 1) {
+    console.error('Error retrieving auth state from storage:', error);
+    console.error(
+      'Thunderbird storage is unavailable, so the add-on cannot tell whether ' +
+        'anyone is signed in. Leaving the current setup untouched and retrying ' +
+        'quietly; further failures will not be logged until storage recovers.'
+    );
+  }
+}
+
+function noteStorageRecovered() {
+  if (storageFailureStreak > 0) {
+    console.info(
+      `Storage is readable again after ${storageFailureStreak} failed attempt(s).`
+    );
+    storageFailureStreak = 0;
+  }
+}
+
 /*
   Checks if the add-on is logged in, this is separate from the web context.
   It's a read-only probe: it's called by the Send route guard (via GET_LOGIN_STATE)
@@ -247,16 +344,20 @@ async function closeAllAddOnTabs() {
   of a refresh_token, not by access-token expiry. Genuine logout flows through the
   SIGN_OUT message path, which calls menuLogout().
  */
-export async function getLoginState() {
-  let auth;
-  try {
-    // Get the auth token from browser storage (this is a copy of the auth token stored in the web context, used to determine login state in the add-on context)
-    const authStorageData = await browser.storage.local.get(STORAGE_KEY_AUTH);
-    auth = authStorageData[STORAGE_KEY_AUTH];
-  } catch (error) {
-    console.error('Error retrieving auth state from storage:', error);
-    return { isLoggedIn: false, username: null };
+export async function getLoginState(): Promise<LoginState> {
+  const read = await readStoredAuth();
+
+  // `=== false` rather than `!read.ok`: this package compiles with
+  // strictNullChecks off, where only the explicit comparison narrows AuthRead
+  // to its failure branch.
+  if (read.ok === false) {
+    noteStorageFailure(read.error);
+    return { isLoggedIn: false, username: null, storageUnavailable: true };
   }
+
+  noteStorageRecovered();
+
+  const { auth } = read;
 
   if (!auth) {
     return { isLoggedIn: false, username: null };
@@ -297,12 +398,35 @@ export async function closeLoginTab() {
   }
 }
 
-// To make sure that the login state is in sync with the web context token, we run this every minute
+/**
+ * Keeps the add-on's idea of the login state in sync with the web context's
+ * token by re-probing on a timer.
+ *
+ * The delay backs off while storage is unavailable. With a broken QuotaManager
+ * every probe fails, and a fixed 60s tick meant three lines in the Error Console
+ * every single minute for as long as Thunderbird stayed open -- which is how
+ * this Thunderbird-wide storage failure came to be reported as a Thundermail bug
+ * (Bug 2064203 comment 4 / Bug 2067502). Backing off costs us nothing: there is
+ * no session change to notice while storage cannot be read, and the very next
+ * successful probe drops straight back to the normal interval.
+ */
 function checkLoginStateOnInterval() {
   const CHECK_INTERVAL_MS = 60 * 1000; // Check every 60 seconds
-  setInterval(async () => {
-    await getLoginState();
-  }, CHECK_INTERVAL_MS);
+  const MAX_CHECK_INTERVAL_MS = 15 * 60 * 1000;
+
+  let intervalMs = CHECK_INTERVAL_MS;
+
+  const scheduleNextCheck = () => {
+    setTimeout(async () => {
+      const state = await getLoginState().catch(() => null);
+      intervalMs = state?.storageUnavailable
+        ? Math.min(intervalMs * 2, MAX_CHECK_INTERVAL_MS)
+        : CHECK_INTERVAL_MS;
+      scheduleNextCheck();
+    }, intervalMs);
+  };
+
+  scheduleNextCheck();
 }
 
 /**

--- a/packages/addon/src/test/cloudFileGate.test.ts
+++ b/packages/addon/src/test/cloudFileGate.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { shouldInitCloudFileOnStartup } from '../cloudFileGate';
+import { cloudFileStartupAction } from '../cloudFileGate';
 
 /**
  * Regression guard for Bug 2036665: a fresh, never-signed-in profile must not
@@ -9,13 +9,32 @@ import { shouldInitCloudFileOnStartup } from '../cloudFileGate';
  * creating an account there pollutes the default profile and breaks
  * Thunderbird's own cloudfile tests (browser_ext_cloudFile.js,
  * browser_repeat_upload.js, addRemoveAccounts), which assert a clean baseline.
+ *
+ * And regression guard for Bug 2064203 comment 4 / Bug 2067502: when the login
+ * probe could not read storage, startup must change nothing. Treating that as
+ * "signed out" unregistered the Send provider for signed-in users and took
+ * sending away from them for the rest of the session.
  */
-describe('shouldInitCloudFileOnStartup', () => {
-  it('does NOT init the cloudfile account when signed out', () => {
-    expect(shouldInitCloudFileOnStartup(false)).toBe(false);
+describe('cloudFileStartupAction', () => {
+  it('unregisters the provider when the user is signed out', () => {
+    expect(cloudFileStartupAction({ isLoggedIn: false, username: null })).toBe(
+      'unregister'
+    );
   });
 
-  it('inits the cloudfile account when already signed in', () => {
-    expect(shouldInitCloudFileOnStartup(true)).toBe(true);
+  it('registers the cloudfile account when already signed in', () => {
+    expect(
+      cloudFileStartupAction({ isLoggedIn: true, username: 'user@example.com' })
+    ).toBe('register');
+  });
+
+  it('changes nothing when storage could not be read', () => {
+    expect(
+      cloudFileStartupAction({
+        isLoggedIn: false,
+        username: null,
+        storageUnavailable: true,
+      })
+    ).toBe('leave-as-is');
   });
 });

--- a/packages/addon/src/test/integration/c2-reenable-trusts-stale-auth.test.ts
+++ b/packages/addon/src/test/integration/c2-reenable-trusts-stale-auth.test.ts
@@ -12,8 +12,10 @@
  *     STORAGE READ -- it checks only for the presence of `refresh_token` in
  *     `browser.storage.local[STORAGE_KEY_AUTH]`, with zero network call to
  *     validate that token against the backend.
- *   - `shouldInitCloudFileOnStartup(isLoggedIn)` is a pure boolean
- *     passthrough of whatever `getLoginState()` produced.
+ *   - `cloudFileStartupAction(state)` maps a successful read straight
+ *     through: isLoggedIn true means 'register'. (Its 'leave-as-is' answer
+ *     only applies when storage could not be read, which is not this
+ *     scenario.)
  *   - If `isLoggedIn` is (falsely) true, `initCloudFile()` runs, which
  *     re-registers the cloud file provider and creates/reactivates a cloud
  *     file account -- fully re-activating cloud-file features for a session
@@ -62,7 +64,8 @@ describe('C2: add-on re-enable trusts stale STORAGE_KEY_AUTH without backend rev
 
     // THE BUG: getLoginState() trusted the stale refresh_token's mere
     // presence and returned isLoggedIn: true purely from local storage, so
-    // shouldInitCloudFileOnStartup() green-lit initCloudFile(), which:
+    // cloudFileStartupAction() answered 'register' and initCloudFile() ran,
+    // which:
     //   1. re-registered the cloud file provider,
     await vi.waitFor(() =>
       expect(ctx.browser.CloudFileAccounts.registerProvider).toHaveBeenCalled()
@@ -79,6 +82,8 @@ describe('C2: add-on re-enable trusts stale STORAGE_KEY_AUTH without backend rev
     //
     // (unregisterProvider is the "signed out" branch and must NOT have run,
     // confirming the code took the "trust local storage" happy path.)
-    expect(ctx.browser.CloudFileAccounts.unregisterProvider).not.toHaveBeenCalled();
+    expect(
+      ctx.browser.CloudFileAccounts.unregisterProvider
+    ).not.toHaveBeenCalled();
   });
 });

--- a/packages/addon/src/test/integration/startup-missing-accounthub.test.ts
+++ b/packages/addon/src/test/integration/startup-missing-accounthub.test.ts
@@ -1,0 +1,55 @@
+/**
+ * A missing AccountHub experiment API must not abort startup.
+ *
+ * Experiment APIs can genuinely be absent at runtime (initTelemetryListener
+ * carries the same guard for the same reason), and since the listener
+ * registrations moved ahead of the cloud file gate in main(), an unguarded
+ * throw there would skip the gate entirely: a signed-in user would never get
+ * initCloudFile() (no Send attachments that session), and a fresh profile
+ * would never get the Bug 2036665 unregister. This spec pins the guard:
+ * with AccountHub absent and a valid stored session, startup must still reach
+ * the gate and register the cloud file account.
+ */
+import { STORAGE_KEY_AUTH } from '@send-frontend/lib/const';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type FakeHost } from './fakeThunderbirdHost';
+import { setupHost, stubContext, teardownHost } from './testHelpers';
+
+describe('startup with a missing AccountHub experiment API', () => {
+  let host: FakeHost;
+
+  beforeEach(() => {
+    host = setupHost();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    teardownHost();
+  });
+
+  it('still reaches the cloud file gate for a signed-in user', async () => {
+    const ctx = stubContext(host);
+
+    // The build shipped without the AccountHub experiment API.
+    delete (ctx.browser as { AccountHub?: unknown }).AccountHub;
+
+    // A stored session that getLoginState() accepts.
+    ctx.browser.storage.local.get = vi.fn(async () => ({
+      [STORAGE_KEY_AUTH]: {
+        refresh_token: 'refresh-abc',
+        profile: { preferred_username: 'user@example.com' },
+      },
+    }));
+
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await import('../../background');
+
+    // The gate ran and took the 'register' branch — startup was not aborted
+    // by the missing experiment API.
+    await vi.waitFor(() =>
+      expect(ctx.browser.CloudFileAccounts.createAccount).toHaveBeenCalled()
+    );
+  });
+});

--- a/packages/addon/src/test/integration/startup-storage-unreadable.test.ts
+++ b/packages/addon/src/test/integration/startup-storage-unreadable.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Startup must leave the Send cloud file setup alone when it cannot read
+ * storage.
+ *
+ * With Thunderbird's QuotaManager broken (Bug 2067502), every
+ * browser.storage.local call rejects, for every add-on in the profile.
+ * background.ts's main() used to read that as "signed out" and unregister the
+ * Send cloud file provider — taking sending away from users who were still
+ * signed in, for the rest of the session (Bug 2064203 comment 4). Now
+ * cloudFileStartupAction() answers 'leave-as-is' when storage is unreadable,
+ * and main() must touch neither the provider registration nor the account
+ * list.
+ *
+ * Uses real timers: main() retries the read (250ms + 1000ms, see
+ * readStoredAuth in menu.ts) before concluding storage is unavailable, so this
+ * spec takes ~1.3s of wall clock by design.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type FakeHost } from './fakeThunderbirdHost';
+import { setupHost, stubContext, teardownHost } from './testHelpers';
+
+describe('startup with unreadable storage leaves the cloud file setup alone', () => {
+  let host: FakeHost;
+
+  beforeEach(() => {
+    host = setupHost();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    teardownHost();
+  });
+
+  it('neither registers nor unregisters the provider when storage cannot be read', async () => {
+    const ctx = stubContext(host);
+
+    // Every read rejects, exactly as under a broken QuotaManager. (Nothing in
+    // this startup path writes.)
+    ctx.browser.storage.local.get = vi
+      .fn()
+      .mockRejectedValue(new Error('An unexpected error occurred'));
+
+    // The leave-as-is branch announces itself with a console.warn; that call
+    // is the deterministic signal that main()'s switch has completed.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await import('../../background');
+
+    // The add-on's logger (lib/logger) prefixes every console call with the
+    // version, so match any argument rather than a fixed position.
+    await vi.waitFor(
+      () =>
+        expect(
+          warn.mock.calls.some((call) =>
+            call.some((arg) => String(arg).includes('leaving the Send cloud'))
+          )
+        ).toBe(true),
+      { timeout: 4000 }
+    );
+
+    expect(
+      ctx.browser.CloudFileAccounts.registerProvider
+    ).not.toHaveBeenCalled();
+    expect(
+      ctx.browser.CloudFileAccounts.unregisterProvider
+    ).not.toHaveBeenCalled();
+    expect(ctx.browser.CloudFileAccounts.createAccount).not.toHaveBeenCalled();
+  });
+});

--- a/packages/addon/src/test/menu.test.ts
+++ b/packages/addon/src/test/menu.test.ts
@@ -1,6 +1,6 @@
 import { BASE_URL } from '@send-frontend/apps/common/constants';
 import { STORAGE_KEY_AUTH } from '@send-frontend/lib/const';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Safe to import statically: MENU_ACTIONS is frozen string constants, so it
 // carries none of the module state that loadMenu() exists to reset.
@@ -161,6 +161,112 @@ describe('getLoginState', () => {
 
     expect(state).toEqual({ isLoggedIn: false, username: null });
     expect(browser.tabs.remove).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Regression guard for Bug 2064203 comment 4 / Bug 2067502. When Thunderbird's
+ * QuotaManager fails, every browser.storage.local call rejects. The probe used
+ * to swallow that and answer "signed out", which is a different statement than
+ * "I could not tell" — and callers acted on it, unregistering the Send cloud
+ * file provider for people who were still signed in.
+ */
+describe('getLoginState when storage is unavailable', () => {
+  const storageError = () => new Error('An unexpected error occurred');
+
+  /** Drives the retry backoff without spending real time on it. */
+  async function settle<T>(pending: Promise<T>): Promise<T> {
+    await vi.advanceTimersByTimeAsync(5000);
+    return pending;
+  }
+
+  function setupFailingStorage(get: unknown) {
+    setupBrowserMock(undefined);
+    (browser.storage.local as { get: unknown }).get = get;
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('reports storageUnavailable instead of a bare signed-out state', async () => {
+    setupFailingStorage(vi.fn().mockRejectedValue(storageError()));
+
+    const { getLoginState } = await loadMenu();
+
+    const state = await settle(getLoginState());
+
+    expect(state).toEqual({
+      isLoggedIn: false,
+      username: null,
+      storageUnavailable: true,
+    });
+  });
+
+  it('retries a failing read before giving up', async () => {
+    const get = vi.fn().mockRejectedValue(storageError());
+    setupFailingStorage(get);
+
+    const { getLoginState } = await loadMenu();
+
+    await settle(getLoginState());
+
+    expect(get.mock.calls.length).toBeGreaterThan(1);
+  });
+
+  it('recovers the session when a retry succeeds', async () => {
+    const get = vi
+      .fn()
+      .mockRejectedValueOnce(storageError())
+      .mockResolvedValue({ [STORAGE_KEY_AUTH]: authWith() });
+    setupFailingStorage(get);
+
+    const { getLoginState } = await loadMenu();
+
+    const state = await settle(getLoginState());
+
+    expect(state).toEqual({ isLoggedIn: true, username: USERNAME });
+  });
+
+  it('logs the storage error once per failure streak, not once per probe', async () => {
+    setupFailingStorage(vi.fn().mockRejectedValue(storageError()));
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    const { getLoginState } = await loadMenu();
+
+    await settle(getLoginState());
+    const afterFirstProbe = consoleError.mock.calls.length;
+    await settle(getLoginState());
+    await settle(getLoginState());
+
+    expect(consoleError.mock.calls.length).toBe(afterFirstProbe);
+  });
+
+  it('logs again once storage has recovered and failed anew', async () => {
+    const get = vi.fn().mockRejectedValue(storageError());
+    setupFailingStorage(get);
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    const { getLoginState } = await loadMenu();
+
+    await settle(getLoginState());
+    const afterFirstStreak = consoleError.mock.calls.length;
+
+    get.mockResolvedValueOnce({});
+    await settle(getLoginState());
+
+    get.mockRejectedValue(storageError());
+    await settle(getLoginState());
+
+    expect(consoleError.mock.calls.length).toBeGreaterThan(afterFirstStreak);
   });
 });
 

--- a/packages/addon/src/test/menu.test.ts
+++ b/packages/addon/src/test/menu.test.ts
@@ -174,15 +174,20 @@ describe('getLoginState', () => {
 describe('getLoginState when storage is unavailable', () => {
   const storageError = () => new Error('An unexpected error occurred');
 
-  /** Drives the retry backoff without spending real time on it. */
+  /**
+   * Drives readStoredAuth's retry waits without spending real time on them.
+   * These specs never start the probe timer, so the retry waits are the only
+   * timers pending and running them all terminates.
+   */
   async function settle<T>(pending: Promise<T>): Promise<T> {
-    await vi.advanceTimersByTimeAsync(5000);
+    await vi.runAllTimersAsync();
     return pending;
   }
 
-  function setupFailingStorage(get: unknown) {
+  /** Replaces storage.local.get with the given behavior (failing or not). */
+  function setupStorage(getImpl: () => Promise<Record<string, unknown>>) {
     setupBrowserMock(undefined);
-    (browser.storage.local as { get: unknown }).get = get;
+    browser.storage.local.get = getImpl as typeof browser.storage.local.get;
   }
 
   beforeEach(() => {
@@ -194,7 +199,7 @@ describe('getLoginState when storage is unavailable', () => {
   });
 
   it('reports storageUnavailable instead of a bare signed-out state', async () => {
-    setupFailingStorage(vi.fn().mockRejectedValue(storageError()));
+    setupStorage(vi.fn().mockRejectedValue(storageError()));
 
     const { getLoginState } = await loadMenu();
 
@@ -209,13 +214,14 @@ describe('getLoginState when storage is unavailable', () => {
 
   it('retries a failing read before giving up', async () => {
     const get = vi.fn().mockRejectedValue(storageError());
-    setupFailingStorage(get);
+    setupStorage(get);
 
     const { getLoginState } = await loadMenu();
 
     await settle(getLoginState());
 
-    expect(get.mock.calls.length).toBeGreaterThan(1);
+    // One initial read plus one per entry in AUTH_READ_RETRY_DELAYS_MS.
+    expect(get).toHaveBeenCalledTimes(3);
   });
 
   it('recovers the session when a retry succeeds', async () => {
@@ -223,7 +229,7 @@ describe('getLoginState when storage is unavailable', () => {
       .fn()
       .mockRejectedValueOnce(storageError())
       .mockResolvedValue({ [STORAGE_KEY_AUTH]: authWith() });
-    setupFailingStorage(get);
+    setupStorage(get);
 
     const { getLoginState } = await loadMenu();
 
@@ -233,7 +239,7 @@ describe('getLoginState when storage is unavailable', () => {
   });
 
   it('logs the storage error once per failure streak, not once per probe', async () => {
-    setupFailingStorage(vi.fn().mockRejectedValue(storageError()));
+    setupStorage(vi.fn().mockRejectedValue(storageError()));
     const consoleError = vi
       .spyOn(console, 'error')
       .mockImplementation(() => {});
@@ -250,7 +256,7 @@ describe('getLoginState when storage is unavailable', () => {
 
   it('logs again once storage has recovered and failed anew', async () => {
     const get = vi.fn().mockRejectedValue(storageError());
-    setupFailingStorage(get);
+    setupStorage(get);
     const consoleError = vi
       .spyOn(console, 'error')
       .mockImplementation(() => {});
@@ -267,6 +273,59 @@ describe('getLoginState when storage is unavailable', () => {
     await settle(getLoginState());
 
     expect(consoleError.mock.calls.length).toBeGreaterThan(afterFirstStreak);
+  });
+});
+
+/**
+ * The probe schedule is the other half of the storage-failure fix: with
+ * storage broken, a fixed 60s tick reprinted the error group every minute for
+ * the whole session (Bug 2064203 comment 4). The schedule must back off while
+ * storage is unreadable and snap back to the base interval on the first
+ * successful probe.
+ */
+describe('startLoginStateChecks', () => {
+  const BASE_INTERVAL = 60_000;
+  // One probe's worth of failing reads: the 250ms + 1000ms waits in
+  // AUTH_READ_RETRY_DELAYS_MS. Keep in step with menu.ts.
+  const RETRY_TIME = 1_250;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('backs off while storage is unreadable and recovers to the base interval', async () => {
+    const get = vi.fn().mockRejectedValue(new Error('unavailable'));
+    setupBrowserMock(undefined);
+    browser.storage.local.get = get as typeof browser.storage.local.get;
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { startLoginStateChecks } = await loadMenu();
+    startLoginStateChecks();
+
+    // The first probe fires at the base interval and burns 3 reads retrying.
+    await vi.advanceTimersByTimeAsync(BASE_INTERVAL + RETRY_TIME);
+    expect(get).toHaveBeenCalledTimes(3);
+
+    // Backed off: one base interval later, no second probe has fired.
+    await vi.advanceTimersByTimeAsync(BASE_INTERVAL);
+    expect(get).toHaveBeenCalledTimes(3);
+
+    // The second probe arrives after the doubled (2x base) delay.
+    await vi.advanceTimersByTimeAsync(BASE_INTERVAL + RETRY_TIME);
+    expect(get).toHaveBeenCalledTimes(6);
+
+    // Storage recovers: the third probe (after a 4x base delay) reads once...
+    get.mockResolvedValue({});
+    await vi.advanceTimersByTimeAsync(4 * BASE_INTERVAL);
+    expect(get).toHaveBeenCalledTimes(7);
+
+    // ...and the schedule is back at the base interval.
+    await vi.advanceTimersByTimeAsync(BASE_INTERVAL);
+    expect(get).toHaveBeenCalledTimes(8);
   });
 });
 

--- a/packages/send/frontend/src/apps/send/router.ts
+++ b/packages/send/frontend/src/apps/send/router.ts
@@ -15,7 +15,10 @@ import {
   validateToken,
 } from '@send-frontend/lib/validations';
 
-import { useSendConfig } from '@send-frontend/composables/useSendConfig';
+import {
+  isKnownSignedOut,
+  useSendConfig,
+} from '@send-frontend/composables/useSendConfig';
 import { restoreKeysUsingLocalStorage } from '@send-frontend/lib/keychain';
 import {
   useApiStore,
@@ -299,11 +302,10 @@ router.beforeEach(async (to, from, next) => {
   if (requiresExtensionLogin && isThunderbirdHost) {
     try {
       const addonLoginState = await queryAddonLoginState();
-      // A storage failure in the add-on reports isLoggedIn: false without
-      // knowing anything. Bouncing to the login flow on that guess logs out a
-      // user who never signed out (see Bug 2064203 comment 4), so treat an
-      // unknown answer the same as the query failing below: carry on.
-      if (!addonLoginState.isLoggedIn && !addonLoginState.storageUnavailable) {
+      // Known signed-out only: when the add-on couldn't read its storage, we
+      // carry on rather than bounce a possibly signed-in user to the login
+      // flow (see isKnownSignedOut).
+      if (isKnownSignedOut(addonLoginState)) {
         return next('/auto-login');
       }
     } catch (error) {

--- a/packages/send/frontend/src/apps/send/router.ts
+++ b/packages/send/frontend/src/apps/send/router.ts
@@ -299,7 +299,11 @@ router.beforeEach(async (to, from, next) => {
   if (requiresExtensionLogin && isThunderbirdHost) {
     try {
       const addonLoginState = await queryAddonLoginState();
-      if (!addonLoginState.isLoggedIn) {
+      // A storage failure in the add-on reports isLoggedIn: false without
+      // knowing anything. Bouncing to the login flow on that guess logs out a
+      // user who never signed out (see Bug 2064203 comment 4), so treat an
+      // unknown answer the same as the query failing below: carry on.
+      if (!addonLoginState.isLoggedIn && !addonLoginState.storageUnavailable) {
         return next('/auto-login');
       }
     } catch (error) {

--- a/packages/send/frontend/src/apps/send/views/BackupKeys.vue
+++ b/packages/send/frontend/src/apps/send/views/BackupKeys.vue
@@ -11,7 +11,10 @@ import {
 } from '@send-frontend/stores';
 import { computed, onMounted, ref } from 'vue';
 import KeysTemplate from './KeysTemplate.vue';
-import { useSendConfig } from '@send-frontend/composables/useSendConfig';
+import {
+  isKnownSignedOut,
+  useSendConfig,
+} from '@send-frontend/composables/useSendConfig';
 import { useRouter } from 'vue-router';
 import { useIsExtension } from '@send-frontend/composables/useIsExtension';
 import RenderOnEnvironment from '@send-frontend/apps/common/RenderOnEnvironment.vue';
@@ -70,10 +73,9 @@ const handleLogout = async () => {
 onMounted(async () => {
   if (isRunningInsideThunderbird.value) {
     const addonLoginState = await queryAddonLoginState();
-    // Only close on a *known* signed-out state — when the add-on could not read
-    // its storage it reports signed out without knowing, and closing the window
-    // on that guess strands a signed-in user (see Bug 2064203 comment 4).
-    if (!addonLoginState.isLoggedIn && !addonLoginState.storageUnavailable) {
+    // Known signed-out only: don't close the window on a storage failure the
+    // add-on couldn't see past (see isKnownSignedOut).
+    if (isKnownSignedOut(addonLoginState)) {
       console.log('[router] User not logged in to addon, closing window');
       window.close();
       router.push('/force-close');

--- a/packages/send/frontend/src/apps/send/views/BackupKeys.vue
+++ b/packages/send/frontend/src/apps/send/views/BackupKeys.vue
@@ -70,7 +70,10 @@ const handleLogout = async () => {
 onMounted(async () => {
   if (isRunningInsideThunderbird.value) {
     const addonLoginState = await queryAddonLoginState();
-    if (!addonLoginState.isLoggedIn) {
+    // Only close on a *known* signed-out state — when the add-on could not read
+    // its storage it reports signed out without knowing, and closing the window
+    // on that guess strands a signed-in user (see Bug 2064203 comment 4).
+    if (!addonLoginState.isLoggedIn && !addonLoginState.storageUnavailable) {
       console.log('[router] User not logged in to addon, closing window');
       window.close();
       router.push('/force-close');

--- a/packages/send/frontend/src/composables/useSendConfig.ts
+++ b/packages/send/frontend/src/composables/useSendConfig.ts
@@ -1,4 +1,7 @@
-import { GET_LOGIN_STATE, LOGIN_STATE_RESPONSE } from '@send-frontend/lib/const';
+import {
+  GET_LOGIN_STATE,
+  LOGIN_STATE_RESPONSE,
+} from '@send-frontend/lib/const';
 import { pullBridgedPassphrase } from '@send-frontend/lib/bridgePassphrase';
 import { dbUserSetup } from '@send-frontend/lib/helpers';
 import init from '@send-frontend/lib/init';
@@ -130,6 +133,13 @@ export function useSendConfig() {
   const queryAddonLoginState = (): Promise<{
     isLoggedIn: boolean;
     username: string | null;
+    /**
+     * True when the add-on could not read its storage and therefore does not
+     * know whether anyone is signed in. `isLoggedIn` is false in that case too,
+     * so any caller that redirects or closes a window on a signed-out answer
+     * must check this first and stay put.
+     */
+    storageUnavailable: boolean;
   }> => {
     return new Promise((resolve, reject) => {
       // Guards against the token-bridge content script being absent or
@@ -147,6 +157,7 @@ export function useSendConfig() {
           resolve({
             isLoggedIn: event.data.isLoggedIn,
             username: event.data.username,
+            storageUnavailable: event.data.storageUnavailable ?? false,
           });
         }
       };

--- a/packages/send/frontend/src/composables/useSendConfig.ts
+++ b/packages/send/frontend/src/composables/useSendConfig.ts
@@ -19,6 +19,30 @@ import useMetricsStore from '@send-frontend/stores/metrics';
 import { useQuery } from '@tanstack/vue-query';
 import { storeToRefs } from 'pinia';
 
+/**
+ * The add-on's answer to GET_LOGIN_STATE, relayed through the token bridge.
+ *
+ * `storageUnavailable` is true when the add-on could not read its storage and
+ * therefore does not know whether anyone is signed in. `isLoggedIn` is false
+ * in that case too, so a bare `!isLoggedIn` check cannot tell the two apart --
+ * use isKnownSignedOut() for anything that acts on a signed-out answer.
+ */
+export type AddonLoginState = {
+  isLoggedIn: boolean;
+  username: string | null;
+  storageUnavailable: boolean;
+};
+
+/**
+ * True only when the add-on positively read "no session" -- not when it merely
+ * failed to read storage. Anything that redirects, closes a window, or logs
+ * the user out on a signed-out answer must use this instead of `!isLoggedIn`,
+ * or a Thunderbird-wide storage failure turns into a forced logout for a user
+ * who never signed out (Bug 2064203 comment 4).
+ */
+export const isKnownSignedOut = (state: AddonLoginState) =>
+  !state.isLoggedIn && !state.storageUnavailable;
+
 export function useSendConfig() {
   const userStore = useUserStore();
   const { keychain } = useKeychainStore();
@@ -127,20 +151,10 @@ export function useSendConfig() {
 
   /**
    * Queries the addon's login state via bidirectional message passing.
-   * Returns a promise that resolves with the login state or times out after 5 seconds.
-   * @returns Promise<{isLoggedIn: boolean, username: string | null}>
+   * Resolves with an AddonLoginState (see its doc for the storageUnavailable
+   * flag) or rejects after a 5 second timeout.
    */
-  const queryAddonLoginState = (): Promise<{
-    isLoggedIn: boolean;
-    username: string | null;
-    /**
-     * True when the add-on could not read its storage and therefore does not
-     * know whether anyone is signed in. `isLoggedIn` is false in that case too,
-     * so any caller that redirects or closes a window on a signed-out answer
-     * must check this first and stay put.
-     */
-    storageUnavailable: boolean;
-  }> => {
+  const queryAddonLoginState = (): Promise<AddonLoginState> => {
     return new Promise((resolve, reject) => {
       // Guards against the token-bridge content script being absent or
       // unresponsive (e.g. the page is open outside of Thunderbird, or the


### PR DESCRIPTION
## What changed?

The add-on can now tell "I could not read storage" apart from "the user is signed out." Those used to be the same answer, and acting on the wrong one is what took Send away from signed-in users (#1178).

`getLoginState()` (`packages/addon/src/menu.ts`) returns a third result, `storageUnavailable`, and everything that acts on a signed-out answer checks it first:

- **`menu.ts`** — the stored-session read retries briefly (250 ms, then 1 s) before giving up, so one lost race against a slow storage backend no longer costs a signed-in user the whole session. Failures are logged once per streak instead of once per probe, with a line when storage recovers. The probe schedule (`startLoginStateChecks`) doubles its delay up to 15 minutes while storage is unreadable and returns to 60 s on the first success.
- **`cloudFileGate.ts`** — `shouldInitCloudFileOnStartup(boolean)` became `cloudFileStartupAction(state)`, which answers `register`, `unregister`, or `leave-as-is`. A boolean had no way to say "change nothing," and "change nothing" is the only safe answer when the login state is unknown.
- **`background.ts`** — startup switches on that action and leaves the cloud file setup untouched when the login state is unknown. The three listener registrations (`initStorageWatcher`, `initAccountHubListener`, `initTelemetryListener`) moved above the login-state read, so an Accounts Hub sign-in can't land unheard while that read spends up to ~1.25 s retrying. The AccountHub registration is now guarded the same way the telemetry one already was: a build missing that experiment API disables Hub auto-login instead of throwing and aborting startup before the cloud file gate.
- **Send frontend** — the flag crosses the token bridge, and the two places that act on a signed-out answer (the router redirect to `/auto-login`, the `BackupKeys.vue` window close) now share one predicate, `isKnownSignedOut()`, instead of two copies of the same condition and comment.

Two review passes ran over this work — a senior code review of the first commit, then an adversarial verification round (four independent reviewers plus mutation testing) of the second. The second commit applies their findings: it corrects a factually wrong code comment about Bug 2036665 (see Limitations), fixes stale comments in an integration test, adds three missing tests, moves the listener registrations as described above, guards the AccountHub experiment API, simplifies the retry loop, and renames for clarity.

**AI disclosure:** agent-written (Claude) end to end — investigation, code, tests, and this description — under my direction. I asked for the root-cause investigation of the Bugzilla report, reviewed the findings and the diff at each step, and directed the fix and the review round.

## Why?

Thunderbird 154 users reported Thundermail spamming the Error Console and then refusing to send ([Bug 2064203 comment 4](https://bugzilla.mozilla.org/show_bug.cgi?id=2064203#c4)).

The underlying fault is not ours: [Bug 2067502](https://bugzilla.mozilla.org/show_bug.cgi?id=2067502) is a Core QuotaManager failure that makes `browser.storage.local` fail across every add-on in the profile. It broke unrelated add-ons (QuickFolders, quickFilters) in the same profiles, survived uninstalls and a newly created profile (with imported mail accounts), and was only repaired by reinstalling Thunderbird.

But our reaction to it is what actually broke Send for those users:

1. `getLoginState()` swallowed the storage rejection and answered "signed out" — indistinguishable from a real logout.
2. Background startup acted on that answer and **unregistered the Send cloud file provider** for users who were still signed in. That's the "you can't send any more" symptom.
3. The 60-second login probe reprinted the same three-line error group every minute, forever. Our log line is the only readable one in the group, which is how a Thunderbird-wide failure got filed against Thundermail.

None of this changed between add-on 2.0.5 and 2.0.11, so until this PR the honest answer to "does the new version fix it?" was no.

## Limitations and Notes

- **This does not fix the Core bug.** An add-on cannot repair a broken QuotaManager. It stops us turning that fault into a broken Send experience and into console noise that reads as our fault. A user whose storage is persistently broken still can't upload — the Send popup needs storage too — but now that failure is Thunderbird's, visibly, not a feature we silently removed.
- **A deliberate, narrow trade-off against [Bug 2036665](https://bugzilla.mozilla.org/show_bug.cgi?id=2036665):** the manifest `cloud_file` key registers the Send provider before our code runs. On `leave-as-is` we skip the unregister, so a signed-out or fresh profile *whose storage is broken at startup* keeps a visible Send entry in the provider list for that session. No cloudfile **account** is created (that's the `register` branch only), so the clean-account-baseline assertions in Thunderbird's cloudfile tests still hold — and those tests run on healthy profiles. Losing the ability to send for a whole session is the worse failure, so we take the cosmetic one. (The first version of this PR wrongly claimed there was no exposure at all; the code comment in `cloudFileGate.ts` and this description now state the actual trade-off.)
- **Retrying cuts both ways.** The startup read now touches storage up to three times instead of once. If the hypothesis below is right, that's more attempts inside the fragile window — but retries are also exactly what rides out a backend that is merely slow to come up, which is the recoverable case worth optimizing for.
- **Hypothesis worth checking separately:** every affected report is TB 154, where this add-on ships built-in and enabled for everyone. If built-in extensions start before regular ones, our unconditional startup read may be the profile's first storage access — the one that trips the QuotaManager initialization whose failure then persists. That would make us the trigger while the root cause stays in Core. Startup ordering hasn't been verified.
- Replies to the two Bugzilla bugs still need to be posted once this lands.

### Verification

- Addon suite: **135 passed**, 1 skipped. Send frontend: **330 passed**.
- New tests, all failing without the fix:
  - `menu.test.ts` — a storage failure reports `storageUnavailable` instead of a bare signed-out state; the read is attempted exactly 3 times (one initial read plus two retries); a successful retry recovers the session; the error logs once per failure streak; it logs again after a recovery and a fresh failure; and the probe schedule backs off (no probe one base interval after a failure, probe after the doubled delay) then snaps back to the base interval on success. All on fake timers.
  - `startup-storage-unreadable.test.ts` (integration) — runs the real `background.ts` against the fake Thunderbird host with every read rejecting, and asserts startup neither registers nor unregisters the provider nor creates an account. This is the exact regression from the bug report.
  - `startup-missing-accounthub.test.ts` (integration) — a build without the AccountHub experiment API must still reach the cloud file gate for a signed-in user.
  - `cloudFileGate.test.ts` — the three-way decision, including the Bug 2036665 signed-out case.
  - The behavior tests were mutation-tested: the five failure-mode specs during review, then the backoff and integration specs against five targeted mutations (no backoff, no reset-on-success, leave-as-is unregisters, gate answers unregister, AccountHub guard removed). Each mutation was caught by exactly the intended test.
- `tsc --noEmit`: same pre-existing error counts as `main` (8 addon / 3 frontend), none added. Prettier clean on all changed files; ESLint zero errors and no new warnings on every changed file the lint setup covers (`token-bridge.js` and `.vue` files sit outside the project's ESLint scope).
- CI on the first commit: all green (addon, frontend, integration, both e2e suites, CodeQL).

## Applicable Issues

Closes #1178

## Screenshots

No UI changes. The console output this PR silences is in [attachment 9628109 on Bug 2064203](https://bugzilla.mozilla.org/attachment.cgi?id=9628109).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
