### PR TITLE
fix(send): stop routing the UI to an orphaned root container (#1116)

### DIFF
--- a/packages/send/frontend/src/apps/send/stores/folder-store.ts
+++ b/packages/send/frontend/src/apps/send/stores/folder-store.ts
@@ -76,6 +76,31 @@ export interface FolderStore {
   ) => Promise<boolean>;
 }
 
+/**
+ * Picks the folder to treat as the user's default (root) folder.
+ *
+ * Prefers the newest folder whose key is present in the keychain so we never
+ * route the UI to an orphaned container (one whose key was lost, e.g. after a
+ * failed provisioning — #1116) while init.ts reconciles it. Falls back to the
+ * newest folder when none are openable, which lets the existing
+ * delete-and-recreate branch in init.ts detect the missing key and repair it.
+ */
+export function selectDefaultFolder(
+  folders: Container[],
+  keychainKeys: Record<string, string>
+): Container | null {
+  const total = folders.length;
+  if (total === 0) {
+    return null;
+  }
+  for (let i = total - 1; i >= 0; i--) {
+    if (keychainKeys[folders[i].id]) {
+      return folders[i];
+    }
+  }
+  return folders[total - 1];
+}
+
 const useFolderStore = defineStore('folderManager', () => {
   const { api } = useApiStore();
   const { user, populateFromBackend } = useUserStore();
@@ -115,8 +140,7 @@ const useFolderStore = defineStore('folderManager', () => {
     if (!folders?.value) {
       return null;
     }
-    const total = folders.value.length;
-    return total === 0 ? null : folders.value[total - 1];
+    return selectDefaultFolder(folders.value, keychain.keys);
   });
 
   const visibleFolders = computed(() => {

--- a/packages/send/frontend/src/test/stores/folder-store.test.ts
+++ b/packages/send/frontend/src/test/stores/folder-store.test.ts
@@ -1,4 +1,7 @@
-import useFolderStore from '@send-frontend/apps/send/stores/folder-store';
+import useFolderStore, {
+  selectDefaultFolder,
+} from '@send-frontend/apps/send/stores/folder-store';
+import type { Container } from '@send-frontend/apps/send/stores/folder-store.types';
 import useApiStore from '@send-frontend/stores/api-store';
 import useKeychainStore from '@send-frontend/stores/keychain-store';
 import { createPinia, setActivePinia } from 'pinia';
@@ -233,5 +236,69 @@ describe('FolderStore — createFolder()', () => {
 
     expect(result).toBeNull();
     expect(newKeySpy).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #1116 — defaultFolder must never route the UI to an orphaned container
+// (a root folder whose key is missing from the keychain).
+// ---------------------------------------------------------------------------
+
+const asContainer = (id: string) => ({ id, name: id }) as Container;
+
+describe('selectDefaultFolder — orphan-aware default folder selection (#1116)', () => {
+  const OPENABLE = asContainer('openable-folder');
+  const ORPHAN = asContainer('orphan-folder');
+
+  it('prefers the folder whose key exists in the keychain over a newer orphan', () => {
+    const result = selectDefaultFolder([OPENABLE, ORPHAN], {
+      [OPENABLE.id]: 'wrapped-key',
+    });
+
+    expect(result?.id).toBe(OPENABLE.id);
+  });
+
+  it('returns the newest folder when multiple folders are openable', () => {
+    const result = selectDefaultFolder([OPENABLE, ORPHAN], {
+      [OPENABLE.id]: 'wrapped-key-1',
+      [ORPHAN.id]: 'wrapped-key-2',
+    });
+
+    expect(result?.id).toBe(ORPHAN.id);
+  });
+
+  it('falls back to the newest folder when NO folder is openable (init.ts reconciles it)', () => {
+    const result = selectDefaultFolder([OPENABLE, ORPHAN], {});
+
+    expect(result?.id).toBe(ORPHAN.id);
+  });
+
+  it('returns null for an empty folder list', () => {
+    expect(selectDefaultFolder([], {})).toBeNull();
+  });
+});
+
+describe('FolderStore — defaultFolder routes to a keychain-openable container (#1116)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('picks the openable root container instead of the newest orphan', async () => {
+    const openable = asContainer('openable-folder');
+    const orphan = asContainer('orphan-folder');
+    // `users/folders` response: the orphan is the NEWEST (last) entry.
+    vi.spyOn(useApiStore().api, 'call').mockResolvedValue([openable, orphan]);
+    // Only the openable container's key is present in the keychain.
+    useKeychainStore().keychain.keys = { [openable.id]: 'wrapped-key' };
+
+    const folderStore = useFolderStore();
+    await folderStore.sync();
+
+    expect(folderStore.defaultFolder?.id).toBe(openable.id);
   });
 });


### PR DESCRIPTION
## What changed?

Fixed a case where the Send account could get stuck unable to upload because the app was pointing at a folder it couldn't actually open.

Provisioning could leave a user owning a root folder whose encryption key never made it into their keychain. The account looked healthy — keys set, folder renders — but the app routed to that unusable ("orphaned") folder, so every upload failed. The old logic simply picked the newest folder, which could be the orphan.

- The app now prefers the newest root folder whose key it actually holds, so it stops routing to an orphan while the existing startup logic reconciles/repairs it. If none are openable, it falls back to the newest folder so that existing delete-and-recreate repair still kicks in.

_AI disclosure: implemented by an AI agent with human direction and a human-run senior review (diff read, tests re-run) before opening this PR._

## Why?

Reproduced in #1116: an account could accumulate root containers where the one the UI routed to had no matching keychain key, making every upload fail client-side. Preferring a keychain-openable container fixes the routing half of that bug.

## Limitations and Notes

- **Scope reduced during review.** #1116 also described a data-loss bug where "Reset Access" wiped the recovery blob before a replacement existed. An initial attempt to fix that here changed the post-reset re-backup flow and broke the "Reset keys" end-to-end test, so it was pulled out of this PR. This PR now contains **only** the self-contained, safe orphan-routing fix. The reset-flow hardening will be reworked in a separate PR that doesn't alter that UX (follow-up issue linked below).
- This is the routing fix; the companion crash/self-recovery fix for a phantom cached container is in #1115 (stacked on this branch).

## Applicable Issues

Partially addresses #1116 (orphan-routing half). Reset-flow hardening tracked as a follow-up.

## Screenshots

N/A. Covered by tests in `folder-store.test.ts`: `defaultFolder` selects the keychain-openable container over a newer orphan, plus unit coverage of the selection helper (openable preferred, newest-of-openable, fallback when none openable, empty list).