### PR TITLE
fix(send): recover from a phantom cached root container instead of crashing (#1115)

### DIFF
--- a/packages/send/frontend/src/apps/send/stores/folder-store.ts
+++ b/packages/send/frontend/src/apps/send/stores/folder-store.ts
@@ -16,7 +16,7 @@ import {
   ItemResponse,
 } from '@send-frontend/apps/send/stores/folder-store.types';
 import { ProgressTracker } from '@send-frontend/apps/send/stores/status-store';
-import { ApiConnection } from '@send-frontend/lib/api';
+import { ApiCallFailure, ApiConnection } from '@send-frontend/lib/api';
 import { NamedBlob } from '@send-frontend/lib/filesync';
 import { backupKeys } from '@send-frontend/lib/keychain';
 import { CLIENT_MESSAGES } from '@send-frontend/lib/messages';
@@ -169,10 +169,50 @@ const useFolderStore = defineStore('folderManager', () => {
     selectedFileId.value = null;
   }
 
-  async function fetchSubtree(rootFolderId: string): Promise<void> {
+  async function fetchSubtree(folderId: string): Promise<void> {
+    let failure: ApiCallFailure | null = null;
     const tree = await api.call<ContainerResponse>(
-      `containers/${rootFolderId}/`
+      `containers/${folderId}/`,
+      {},
+      'GET',
+      {},
+      {
+        onFailure: (f) => {
+          failure = f;
+        },
+      }
     );
+
+    // `api.call` returns null on any failure (403/404 included). Never
+    // dereference it (#1115) — leave the store in a consistent empty state
+    // instead of crashing the folder view.
+    if (!tree || !tree.children) {
+      console.error(
+        `Failed to fetch subtree for container ${folderId}`,
+        failure
+      );
+      folders.value = [];
+      rootFolder.value = null;
+
+      // Self-recovery (#1115): a 403/404 on the cached root means the server
+      // never created / no longer has that container (a phantom id). Clear the
+      // stale cache so sync stops looping on the dead id, and fall back to the
+      // user's folder list so init.ts's default-folder reconciliation can
+      // re-provision.
+      const status: number | null =
+        failure && (failure as ApiCallFailure).kind === 'http'
+          ? (failure as ApiCallFailure & { kind: 'http' }).status
+          : null;
+      if (
+        (status === 403 || status === 404) &&
+        rootFolderId.value === folderId
+      ) {
+        rootFolderId.value = null;
+        await fetchUserFolders();
+      }
+      return;
+    }
+
     folders.value = tree.children;
     rootFolder.value = tree;
   }

--- a/packages/send/frontend/src/test/stores/folder-store.test.ts
+++ b/packages/send/frontend/src/test/stores/folder-store.test.ts
@@ -244,6 +244,8 @@ describe('FolderStore — createFolder()', () => {
 // (a root folder whose key is missing from the keychain).
 // ---------------------------------------------------------------------------
 
+import { trpc } from '@send-frontend/lib/trpc';
+
 const asContainer = (id: string) => ({ id, name: id }) as Container;
 
 describe('selectDefaultFolder — orphan-aware default folder selection (#1116)', () => {
@@ -300,5 +302,94 @@ describe('FolderStore — defaultFolder routes to a keychain-openable container 
     await folderStore.sync();
 
     expect(folderStore.defaultFolder?.id).toBe(openable.id);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #1115 — phantom cached root container must not crash the folder view and
+// must self-recover instead of looping on the dead id.
+// ---------------------------------------------------------------------------
+
+describe('FolderStore — fetchSubtree null-guard & phantom-root recovery (#1115)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does not throw and leaves an empty/error state when api.call resolves null', async () => {
+    vi.spyOn(useApiStore().api, 'call').mockResolvedValue(null);
+
+    const folderStore = useFolderStore();
+    await expect(
+      folderStore.fetchSubtree('dead-container')
+    ).resolves.not.toThrow();
+
+    expect(folderStore.visibleFolders).toEqual([]);
+    expect(folderStore.rootFolder).toBeNull();
+  });
+
+  it('clears the cached rootFolderId and falls back to users/folders on a 403 for the cached root', async () => {
+    const PHANTOM_ID = 'phantom-container';
+    vi.mocked(trpc.getDefaultFolder.query).mockResolvedValue({
+      id: PHANTOM_ID,
+    } as never);
+
+    const apiCallSpy = vi
+      .spyOn(useApiStore().api, 'call')
+      .mockImplementation(async (path, _body, _method, _headers, options) => {
+        if (typeof path === 'string' && path.startsWith('containers/')) {
+          (options as { onFailure?: (f: unknown) => void })?.onFailure?.({
+            kind: 'http',
+            status: 403,
+            statusText: 'Forbidden',
+          });
+          return null;
+        }
+        // users/folders fallback
+        return [];
+      });
+
+    const folderStore = useFolderStore();
+    await folderStore.getDefaultFolderId();
+    expect(folderStore.rootFolderId).toBe(PHANTOM_ID);
+
+    await folderStore.fetchSubtree(PHANTOM_ID);
+
+    // The dead id is invalidated so sync won't re-request it in a loop.
+    expect(folderStore.rootFolderId).toBeNull();
+    // It fell back to the user's folder list (re-provisioning path).
+    expect(apiCallSpy).toHaveBeenCalledWith(`users/folders`);
+    expect(folderStore.rootFolder).toBeNull();
+  });
+
+  it('does NOT clear the cached rootFolderId when a non-root subtree fetch 404s', async () => {
+    const ROOT_ID = 'real-root';
+    vi.mocked(trpc.getDefaultFolder.query).mockResolvedValue({
+      id: ROOT_ID,
+    } as never);
+
+    const apiCallSpy = vi
+      .spyOn(useApiStore().api, 'call')
+      .mockImplementation(async (_path, _body, _method, _headers, options) => {
+        (options as { onFailure?: (f: unknown) => void })?.onFailure?.({
+          kind: 'http',
+          status: 404,
+          statusText: 'Not Found',
+        });
+        return null;
+      });
+
+    const folderStore = useFolderStore();
+    await folderStore.getDefaultFolderId();
+
+    await folderStore.fetchSubtree('some-other-folder');
+
+    expect(folderStore.rootFolderId).toBe(ROOT_ID);
+    expect(apiCallSpy).not.toHaveBeenCalledWith(`users/folders`);
   });
 });


### PR DESCRIPTION
## What changed?

Fixed a state where a Send account could get permanently stuck on a folder it could never load, with the folder view crashing instead of showing an error.

The client could end up remembering a folder id that the server had never actually created. Every attempt to open that folder failed, the app crashed on the empty response ("can't access property children"), and — because the bad id was never forgotten — it kept retrying the same dead id forever. In that state uploads were impossible and the only workaround was manually clearing site data.

Two changes to `folder-store.ts`:
- **No more crash.** Loading a folder subtree now handles a failed/empty response instead of assuming it succeeded. On failure it leaves the view in a clean empty state and logs the real underlying error (e.g. the 403/404) rather than throwing.
- **Self-recovery.** A 403/404 on the *remembered* root folder is treated as "this folder no longer exists": the app forgets the stale id and falls back to the user's folder list, letting the existing startup logic re-provision a good folder. No more infinite retry loop.

_AI disclosure: implemented by an AI agent with human direction and a human-run senior review (diff read, tests re-run, typecheck verified) before opening this PR._

## Why?

Reproduced in #1115 on a freshly OIDC-provisioned account: the client cached a container id absent from the database, every `GET /api/containers/<id>/` returned 403, and `FolderView` crashed on a null folder so the real error never reached the user. Re-running key setup didn't clear the bad id. This makes the app self-heal instead of dead-ending.

## Limitations and Notes

- Recovery clears the client-side cache and defers re-provisioning to the existing startup reconciliation (in `init.ts`); it deliberately does not duplicate that delete/recreate logic.
- A non-root subtree fetch that 404s does **not** clear the cached root — only a failure on the cached root triggers recovery (covered by a test).
- `createFolder()` already trusts only server-confirmed ids (no optimistic caching), so no change was needed there — verified.
- The atomic-provisioning half of this bug class (orphaned keychain / reset data loss) is handled in #1116.

## Applicable Issues

Closes #1115

## Screenshots

N/A — behavior covered by tests in `folder-store.test.ts`: null-guard no-throw, 403-on-cached-root recovery + fallback to `users/folders`, and a non-root 404 that must not clear the cache.
