### PR TITLE
fix(addon): don't drop a genuine token refresh in the OIDC_USER handler (#1053)

### DIFF
--- a/packages/addon/src/background.ts
+++ b/packages/addon/src/background.ts
@@ -279,6 +279,29 @@ async function openUnifiedPopup() {
   }
 }
 
+// Metadata about the last accepted OIDC_USER write, stored alongside
+// STORAGE_KEY_AUTH so the handler can tell a concurrent duplicate-login race
+// (drop, see #1025) from a genuine later token refresh for the same account
+// (accept, see #1053). Shape: { subject: string, writtenAt: number }.
+const STORAGE_KEY_AUTH_META = 'STORAGE_KEY_AUTH_META';
+
+// Two OIDC_USER writes for the SAME subject landing within this window are
+// treated as the concurrent AccountHub-vs-web login race from #1025 and the
+// second is dropped. A same-subject write arriving AFTER this window is a
+// genuine token refresh / intentional re-auth and is accepted (#1053).
+const OIDC_USER_RACE_WINDOW_MS = 10_000;
+
+// Derive a stable per-account subject from an oidc-client-ts User object.
+// Prefer the OIDC subject; fall back to the identifiers menu.ts already uses.
+function oidcSubject(user): string | undefined {
+  return (
+    user?.profile?.sub ||
+    user?.profile?.preferred_username ||
+    user?.profile?.email ||
+    undefined
+  );
+}
+
 const THUNDERMAIL_HOST = `mail.${!isProd ? 'stage-' : ''}thundermail.com`;
 const THUNDERMAIL_DISPLAY_NAME = 'Thundermail';
 
@@ -302,21 +325,58 @@ browser.runtime.onMessage.addListener(async (message, sender) => {
     //     it only has a refresh token and needs a fresh access_token.
     case OIDC_USER: {
       // Mutual exclusion: if STORAGE_KEY_AUTH already holds a session,
-      // this OIDC_USER is a concurrent login flow (e.g. an AccountHub
+      // this OIDC_USER may be a concurrent login flow (e.g. an AccountHub
       // login racing a hamburger-menu web login for the same account)
       // and silently overwriting would clobber the in-flight session.
-      // Drop the incoming write to preserve the existing session.
       // See https://github.com/thunderbird/tbpro-add-on/issues/1025.
-      const existingAuth = await browser.storage.local.get(STORAGE_KEY_AUTH);
-      if (existingAuth[STORAGE_KEY_AUTH]) {
-        console.warn(
-          '[onMessage] Dropping OIDC_USER: STORAGE_KEY_AUTH already holds a session'
-        );
-        break;
+      //
+      // However, a same-subject write arriving well AFTER the stored
+      // session (outside OIDC_USER_RACE_WINDOW_MS) is a genuine token
+      // refresh / intentional re-auth and must be accepted, or the add-on
+      // is left holding a stale token.
+      // See https://github.com/thunderbird/tbpro-add-on/issues/1053.
+      const existing = await browser.storage.local.get([
+        STORAGE_KEY_AUTH,
+        STORAGE_KEY_AUTH_META,
+      ]);
+      if (existing[STORAGE_KEY_AUTH]) {
+        const incomingSubject = oidcSubject(message.user);
+        const storedSubject =
+          existing[STORAGE_KEY_AUTH_META]?.subject ??
+          oidcSubject(existing[STORAGE_KEY_AUTH]);
+
+        if (!incomingSubject || !storedSubject) {
+          // Can't compare identities; keep the conservative #1025 behavior.
+          console.warn(
+            '[onMessage] Dropping OIDC_USER: existing session present and no subject to compare'
+          );
+          break;
+        }
+
+        if (incomingSubject !== storedSubject) {
+          console.warn(
+            '[onMessage] Dropping OIDC_USER: different subject than the in-flight session'
+          );
+          break;
+        }
+
+        const writtenAt = existing[STORAGE_KEY_AUTH_META]?.writtenAt ?? 0;
+        if (Date.now() - writtenAt < OIDC_USER_RACE_WINDOW_MS) {
+          console.warn(
+            '[onMessage] Dropping OIDC_USER: same-subject write within the race window (concurrent duplicate login)'
+          );
+          break;
+        }
+        // Same subject, outside the race window: fall through and accept
+        // the write as a genuine refresh/replacement (#1053).
       }
 
       await browser.storage.local.set({
         [STORAGE_KEY_AUTH]: message.user,
+        [STORAGE_KEY_AUTH_META]: {
+          subject: oidcSubject(message.user),
+          writtenAt: Date.now(),
+        },
       });
 
       console.log(`🎯 user auth stored in add-on context.`);

--- a/packages/addon/src/test/integration/a8-oidc-user-refresh-not-dropped.test.ts
+++ b/packages/addon/src/test/integration/a8-oidc-user-refresh-not-dropped.test.ts
@@ -1,0 +1,129 @@
+/**
+ * A8 — a genuine later token refresh / re-auth for the SAME account is no
+ * longer silently dropped by the OIDC_USER mutual-exclusion guard.
+ *
+ * The #1025 fix (see a7-accounthub-login-races-web-login.test.ts) made the
+ * OIDC_USER handler drop any incoming write when STORAGE_KEY_AUTH already
+ * held a session. That unconditional drop also discarded a genuine later
+ * token refresh for the same account arriving without a preceding SIGN_OUT,
+ * leaving the add-on holding a stale/expired token while the UI still looked
+ * authenticated. See https://github.com/thunderbird/tbpro-add-on/issues/1053.
+ *
+ * Fix under test: the handler now records { subject, writtenAt } under
+ * STORAGE_KEY_AUTH_META on every accepted write and, when a session already
+ * exists:
+ *   - different subject            → drop (protects an in-flight login, #1025)
+ *   - same subject, within the     → drop (concurrent duplicate race, a7)
+ *     OIDC_USER_RACE_WINDOW_MS
+ *   - same subject, older than the → accept (genuine refresh, #1053)
+ *     race window
+ */
+import { OIDC_USER } from '@send-frontend/lib/const';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { type FakeHost } from './fakeThunderbirdHost';
+import { setupHost, stubContext, teardownHost } from './testHelpers';
+
+const OIDC_USER_RACE_WINDOW_MS = 10_000; // mirrors background.ts
+
+function makeUser(username: string, refreshToken: string) {
+  return {
+    profile: { preferred_username: username },
+    refresh_token: refreshToken,
+    expires_at: Math.floor(Date.now() / 1000) + 3600,
+  };
+}
+
+describe('A8: OIDC_USER same-subject refresh outside the race window is accepted', () => {
+  let host: FakeHost;
+
+  beforeEach(() => {
+    host = setupHost();
+  });
+
+  afterEach(() => {
+    teardownHost();
+  });
+
+  it('FIXED (#1053): a same-account OIDC_USER arriving after the race window overwrites the stale session', async () => {
+    const bg = stubContext(host);
+    await import('../../background');
+
+    await bg.deliverMessage({
+      type: OIDC_USER,
+      user: makeUser('user@example.com', 'token-1'),
+    });
+
+    const afterFirst = await bg.browser.storage.local.get('STORAGE_KEY_AUTH');
+    expect(afterFirst['STORAGE_KEY_AUTH'].refresh_token).toBe('token-1');
+
+    // Simulate time passing beyond the race window: age the stored meta
+    // timestamp instead of mocking Date.now(), so the handler's own clock
+    // reads stay real.
+    await bg.browser.storage.local.set({
+      STORAGE_KEY_AUTH_META: {
+        subject: 'user@example.com',
+        writtenAt: Date.now() - (OIDC_USER_RACE_WINDOW_MS + 60_000),
+      },
+    });
+
+    // A genuine token refresh for the SAME account arrives later.
+    await bg.deliverMessage({
+      type: OIDC_USER,
+      user: makeUser('user@example.com', 'token-2'),
+    });
+
+    const afterRefresh = await bg.browser.storage.local.get(
+      'STORAGE_KEY_AUTH'
+    );
+    expect(afterRefresh['STORAGE_KEY_AUTH'].refresh_token).toBe('token-2');
+  });
+
+  it('still drops an OIDC_USER for a DIFFERENT subject while a session exists (#1025 intent preserved)', async () => {
+    const bg = stubContext(host);
+    await import('../../background');
+
+    await bg.deliverMessage({
+      type: OIDC_USER,
+      user: makeUser('user-x@example.com', 'token-x'),
+    });
+
+    // Even well outside the race window, a different account must not
+    // clobber the in-flight session.
+    await bg.browser.storage.local.set({
+      STORAGE_KEY_AUTH_META: {
+        subject: 'user-x@example.com',
+        writtenAt: Date.now() - (OIDC_USER_RACE_WINDOW_MS + 60_000),
+      },
+    });
+
+    await bg.deliverMessage({
+      type: OIDC_USER,
+      user: makeUser('user-y@example.com', 'token-y'),
+    });
+
+    const after = await bg.browser.storage.local.get('STORAGE_KEY_AUTH');
+    expect(after['STORAGE_KEY_AUTH'].refresh_token).toBe('token-x');
+    expect(after['STORAGE_KEY_AUTH'].profile.preferred_username).toBe(
+      'user-x@example.com'
+    );
+  });
+
+  it('still drops a same-subject OIDC_USER arriving within the race window (a7 boundary)', async () => {
+    const bg = stubContext(host);
+    await import('../../background');
+
+    // Back-to-back same-account writes, no time passing between them:
+    // exactly the concurrent duplicate-login race from a7/#1025.
+    await bg.deliverMessage({
+      type: OIDC_USER,
+      user: makeUser('user@example.com', 'token-1'),
+    });
+    await bg.deliverMessage({
+      type: OIDC_USER,
+      user: makeUser('user@example.com', 'token-2'),
+    });
+
+    const after = await bg.browser.storage.local.get('STORAGE_KEY_AUTH');
+    expect(after['STORAGE_KEY_AUTH'].refresh_token).toBe('token-1');
+  });
+});


### PR DESCRIPTION
## What changed?

Fixed a case where the add-on could silently ignore a valid new sign-in token and keep using a stale one.

A previous fix (#1025) made the add-on's login handler ignore an incoming sign-in whenever it already had a session stored — that stopped two logins racing each other from clobbering one another. But it ignored the incoming login *unconditionally*, which also threw away a legitimate token refresh for the same account. The result: the UI looked signed in, but the add-on was holding an old/expired token underneath.

The handler now tells the two situations apart:
- **Different account** than the one stored → still ignored (keeps the #1025 protection).
- **Same account, arriving within ~10s** of the stored session → still ignored (this is the concurrent duplicate-login race #1025 was about).
- **Same account, arriving later** → accepted as a genuine refresh/re-login.

To do this it derives a stable account identity from the login (OIDC `sub`, falling back to username/email) and records it alongside the stored session with a timestamp (`STORAGE_KEY_AUTH_META`). If it can't determine the identity, it keeps the old conservative "ignore when a session already exists" behavior.

_AI disclosure: implemented by an AI agent with human direction and a human-run senior review (diff read, full integration suite re-run) before opening this PR._

## Why?

Per #1053, the #1025 drop logic assumed every legitimate re-auth first clears the stored session via `SIGN_OUT` — but nothing enforces that. A silent token refresh (or an intentional re-login) that re-broadcasts the login without a preceding sign-out was silently dropped, so the add-on could end up authenticated in the UI with a stale token in storage.

## Limitations and Notes

- The race window is a fixed 10s constant (`OIDC_USER_RACE_WINDOW_MS`). It comfortably covers the near-simultaneous login race while letting any real later refresh through.
- Legacy sessions stored before this change have no metadata record; the first same-subject write after upgrade is treated as outside the window (accepted as a refresh) and its stored subject is read from the existing session object. This is the intended #1053 behavior; it just means those sessions don't get the race guard on that very first post-upgrade write.
- The metadata isn't cleared on `SIGN_OUT` — harmless, since the guard only applies while a session exists and every accepted write refreshes it.

## Applicable Issues

Closes #1053

## Screenshots

N/A. Behavior covered by new integration tests (`a8-oidc-user-refresh-not-dropped.test.ts`): same-subject refresh outside the window is accepted, a different subject is dropped, and a same-subject write inside the window is still dropped (the #1025 / a7 boundary). The existing a7 race test stays green; full integration suite: 30 passed.
