### PR TITLE
fix(addon): revalidate a stored session against the backend on re-enable (#1030)

### DIFF
--- a/packages/addon/src/background.ts
+++ b/packages/addon/src/background.ts
@@ -36,6 +36,7 @@ import {
   TELEMETRY_STATE_RESPONSE,
 } from '@send-frontend/lib/const';
 
+import config from '@send-frontend/config';
 import init from '@send-frontend/lib/init';
 import { restoreKeysUsingLocalStorage } from '@send-frontend/lib/keychain';
 
@@ -47,6 +48,7 @@ import {
   init as initMenu,
   menuLoggedIn,
   menuLogout,
+  menuSignedOut,
 } from './menu';
 import { shouldInitCloudFileOnStartup } from './cloudFileGate';
 import { checkAndUninstallIfDeprecated } from './selfUninstall';
@@ -867,6 +869,79 @@ function initTelemetryListener() {
   });
 }
 
+// #1030: getLoginState() is (deliberately) a pure local-storage read, so a
+// startup/re-enable trusts a stored session that may have been revoked
+// server-side. This fires ONE non-blocking backend check of the stored access
+// token (the same GET /api/auth/oidc/me the web app's checkAuthStatus() uses)
+// and, ONLY on a definitive auth rejection (401/403/404), silently tears the
+// stale session down: clear STORAGE_KEY_AUTH (the storage watcher then
+// broadcasts SIGN_OUT to any live popup/web contexts), flip the menu to
+// signed-out, and unregister the cloud file provider that main() had already
+// re-activated. Transient/network errors change nothing (fail-open) — mirror
+// of auth-store's refreshAccessToken()/isGenuineAuthFailure() philosophy:
+// never end a session over a network blip.
+async function validateStoredSessionOnStartup() {
+  try {
+    const serverUrl = (config.sendServerUrl ?? '').trim();
+    if (!serverUrl) {
+      // Unconfigured build (e.g. CI/automation): skip, never break startup.
+      return;
+    }
+    const authStorageData = await browser.storage.local.get(STORAGE_KEY_AUTH);
+    const auth = authStorageData[STORAGE_KEY_AUTH];
+    if (!auth?.access_token) {
+      return;
+    }
+    // Only a NON-expired access token that the backend rejects proves the
+    // session was revoked. A merely-expired access token (very common: the
+    // extension sat idle past the ~5min token lifetime) is NOT proof of
+    // revocation — the web app silently refreshes it via the refresh_token on
+    // next use, and the background can't easily do that here. Treating a 401
+    // on an already-expired token as "revoked" would sign out a perfectly
+    // valid idle user at startup. So if the stored token is already expired,
+    // skip the check and let the normal refresh path handle it.
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    if (typeof auth.expires_at === 'number' && auth.expires_at <= nowSeconds) {
+      return;
+    }
+    const response = await fetch(`${serverUrl}/api/auth/oidc/me`, {
+      headers: {
+        Authorization: `Bearer ${auth.access_token}`,
+      },
+    });
+    if ([401, 403, 404].includes(response.status)) {
+      console.warn(
+        '[background] Stored session was rejected by the backend ' +
+          `(HTTP ${response.status}); signing out.`
+      );
+      // Silent forced logout — intentionally NOT menuLogout(), which closes
+      // Send tabs and opens a /logout tab; a background revalidation must not
+      // pop UI at the user.
+      try {
+        await browser.storage.local.remove(STORAGE_KEY_AUTH);
+      } catch (e) {
+        console.warn('Error clearing stale auth on revoked session:', e);
+      }
+      await menuSignedOut();
+      try {
+        await browser.CloudFileAccounts.unregisterProvider();
+      } catch (e) {
+        console.warn(
+          'Error unregistering cloud file provider on revoked session:',
+          e
+        );
+      }
+    }
+  } catch (error) {
+    // Fail-open: a network error / server hiccup is NOT proof the session is
+    // dead. Keep the user signed in; a later genuine 401 will handle it.
+    console.warn(
+      '[background] Startup session validation skipped (transient error):',
+      error
+    );
+  }
+}
+
 (async function main() {
   await checkAndUninstallIfDeprecated();
   initMenu();
@@ -893,6 +968,13 @@ function initTelemetryListener() {
   initStorageWatcher();
   initAccountHubListener();
   initTelemetryListener();
+  // Fire-and-forget (#1030): main() already proceeded on the locally-stored
+  // login state above; this check tears that back down if the backend says
+  // the session is revoked. Runs after the watchers so the cleanup's storage
+  // change is observed and broadcast.
+  if (isLoggedIn) {
+    void validateStoredSessionOnStartup();
+  }
 })().catch((error) => {
   console.error('Error initializing background.js', error);
 });

--- a/packages/addon/src/menu.ts
+++ b/packages/addon/src/menu.ts
@@ -157,12 +157,13 @@ async function buildSignedInMenu(username: string) {
 }
 
 /**
- * Handles logout process by resetting menu to logged-out state and opening logout page.
- * Clears the username and removes authenticated menu items.
- * Also clears all localStorage and extension storage data.
+ * Resets the menu to its signed-out state WITHOUT any of menuLogout()'s other
+ * side effects (no storage wipe, no tab closing, no /logout tab). Used both by
+ * menuLogout() itself and by background.ts's silent startup revalidation
+ * (#1030), which must flip the menu for a server-side-revoked session without
+ * surprising the user with a browser tab.
  */
-export async function menuLogout() {
-  console.log('🧹 Clearing menu items and storage');
+export async function menuSignedOut() {
   await queueMenuWork(async () => {
     // Dropped before the teardown, the mirror of buildSignedInMenu() committing
     // it after the build: if either call below fails the menu is in an unknown
@@ -177,6 +178,16 @@ export async function menuLogout() {
     });
     await browser.TBProMenu.clear(MENU_ACTIONS.ROOT);
   });
+}
+
+/**
+ * Handles logout process by resetting menu to logged-out state and opening logout page.
+ * Clears the username and removes authenticated menu items.
+ * Also clears all localStorage and extension storage data.
+ */
+export async function menuLogout() {
+  console.log('🧹 Clearing menu items and storage');
+  await menuSignedOut();
 
   // Full wipe of the add-on's storage to a clean, logged-out state.
   //

--- a/packages/addon/src/test/integration/c2-reenable-trusts-stale-auth.test.ts
+++ b/packages/addon/src/test/integration/c2-reenable-trusts-stale-auth.test.ts
@@ -1,6 +1,6 @@
 /**
- * C2 — Add-on re-enable trusts stale `STORAGE_KEY_AUTH` without
- * re-validating against the backend.
+ * C2 — Add-on re-enable no longer blindly trusts stale `STORAGE_KEY_AUTH`
+ * (fixed: #1030).
  *
  * See ADDON-BUG-REPORTS-2026-07-22.md #C2 and
  * ADDON-SYNC-VERIFIED-FINDINGS-2026-07-21.md §C2.
@@ -8,29 +8,72 @@
  * Mechanism under test:
  *   - Re-enabling the add-on re-runs background.ts's top-level `main()` IIFE
  *     from scratch, identically to a cold start.
- *   - `main()` calls `getLoginState()` (menu.ts), which is a PURE LOCAL
- *     STORAGE READ -- it checks only for the presence of `refresh_token` in
- *     `browser.storage.local[STORAGE_KEY_AUTH]`, with zero network call to
- *     validate that token against the backend.
- *   - `shouldInitCloudFileOnStartup(isLoggedIn)` is a pure boolean
- *     passthrough of whatever `getLoginState()` produced.
- *   - If `isLoggedIn` is (falsely) true, `initCloudFile()` runs, which
- *     re-registers the cloud file provider and creates/reactivates a cloud
- *     file account -- fully re-activating cloud-file features for a session
- *     that may have been revoked entirely server-side.
- *
- * This test seeds a stale (but locally well-formed) auth object into shared
- * storage, imports background.ts fresh (simulating a re-enable / cold
- * start), and confirms initCloudFile()'s effects run (CloudFileAccounts
- * re-registration + account creation) with ZERO network/API validation call
- * having occurred anywhere in the process.
+ *   - `main()` still calls `getLoginState()` (menu.ts), which stays a PURE
+ *     LOCAL STORAGE READ (the 60s timer and the route guard depend on it
+ *     being cheap), so `initCloudFile()` still runs first on the locally
+ *     stored state.
+ *   - THE FIX: after the watchers are up, `main()` fires a non-blocking
+ *     `validateStoredSessionOnStartup()`, which GETs
+ *     `{sendServerUrl}/api/auth/oidc/me` with the stored access token (the
+ *     same check the web app's auth-store `checkAuthStatus()` performs).
+ *   - On a definitive auth rejection (401/403/404 — a revoked/invalid
+ *     session) of a token that is NOT merely expired, the silent
+ *     forced-logout cleanup runs: STORAGE_KEY_AUTH is removed, the menu
+ *     flips to signed-out, and the cloud file provider that startup had
+ *     just re-activated is unregistered. No tabs are opened.
+ *   - On a 200 (still-valid session) — or any transient/network error
+ *     (fail-open) — nothing is torn down and the user stays signed in.
+ *   - If the stored access token is ALREADY EXPIRED, the check is skipped
+ *     entirely: a merely-expired token is not proof of revocation (the web
+ *     app refreshes it on next use), so we must not sign out a valid idle
+ *     user at startup.
  */
 import { STORAGE_KEY_AUTH } from '@send-frontend/lib/const';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { type FakeHost } from './fakeThunderbirdHost';
 import { setupHost, stubContext, teardownHost } from './testHelpers';
 
-describe('C2: add-on re-enable trusts stale STORAGE_KEY_AUTH without backend revalidation', () => {
+// A stored session whose access token is still WITHIN its lifetime. Only a
+// backend rejection of a non-expired token proves the session was revoked, so
+// this is the shape that must trigger the forced-logout path.
+const STALE_AUTH = {
+  access_token: 'potentially-revoked-access-token',
+  refresh_token: 'potentially-revoked-refresh-token',
+  expires_at: Math.floor(Date.now() / 1000) + 3600, // access token still valid
+  profile: { preferred_username: 'user@example.com' },
+};
+
+// Same session but with an already-expired access token: a merely-expired
+// token is refreshable and must NOT be treated as revoked.
+const EXPIRED_AUTH = {
+  ...STALE_AUTH,
+  expires_at: Math.floor(Date.now() / 1000) - 999999,
+};
+
+/** Seeds a previously-stored session — exactly the shape getLoginState()
+ * checks (refresh_token + resolvable username). */
+function seedStaleAuth(
+  ctx: ReturnType<typeof stubContext>,
+  auth: typeof STALE_AUTH = STALE_AUTH
+) {
+  ctx.browser.storage.local.get = vi.fn(async () => ({
+    [STORAGE_KEY_AUTH]: auth,
+  }));
+}
+
+/** Stubs global fetch so the startup /api/auth/oidc/me validation call
+ * resolves with the given HTTP status. Returns the mock for assertions. */
+function stubValidationFetch(status: number) {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: vi.fn().mockResolvedValue(status === 200 ? { user: {} } : {}),
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+describe('C2 (fixed, #1030): add-on re-enable revalidates stored STORAGE_KEY_AUTH against the backend', () => {
   let host: FakeHost;
 
   beforeEach(() => {
@@ -41,44 +84,111 @@ describe('C2: add-on re-enable trusts stale STORAGE_KEY_AUTH without backend rev
     teardownHost();
   });
 
-  it('CONFIRMED BUG: re-enable (fresh module load) re-activates cloud file with no backend validation call', async () => {
+  it('re-enable validates the stored session with the backend and, on 401 (revoked), silently tears it down', async () => {
     const ctx = stubContext(host);
+    seedStaleAuth(ctx);
+    const fetchMock = stubValidationFetch(401);
 
-    // Seed a previously-stored session -- this is exactly the shape
-    // getLoginState() checks: refresh_token + a resolvable username. In
-    // reality this token may have been revoked/expired server-side at any
-    // point after it was stored; nothing here re-checks that.
-    ctx.browser.storage.local.get = vi.fn(async () => ({
-      [STORAGE_KEY_AUTH]: {
-        refresh_token: 'potentially-revoked-refresh-token',
-        expires_at: Math.floor(Date.now() / 1000) - 999999, // long expired access token
-        profile: { preferred_username: 'user@example.com' },
-      },
-    }));
-
-    // Simulate re-enable: this is functionally identical to a cold start --
+    // Simulate re-enable: this is functionally identical to a cold start —
     // the add-on's background page re-runs main() from scratch.
     await import('../../background');
 
-    // THE BUG: getLoginState() trusted the stale refresh_token's mere
-    // presence and returned isLoggedIn: true purely from local storage, so
-    // shouldInitCloudFileOnStartup() green-lit initCloudFile(), which:
-    //   1. re-registered the cloud file provider,
+    // Startup still proceeds optimistically on the local state first
+    // (getLoginState() stays a cheap local read by design), so the cloud
+    // file provider is re-activated...
     await vi.waitFor(() =>
       expect(ctx.browser.CloudFileAccounts.registerProvider).toHaveBeenCalled()
     );
-    //   2. created/reactivated a cloud file account,
+
+    // ...but THE FIX then validates the stored access token against the
+    // backend, exactly like auth-store's checkAuthStatus():
+    await vi.waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringMatching(/\/api\/auth\/oidc\/me$/),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: `Bearer ${STALE_AUTH.access_token}`,
+          }),
+        })
+      )
+    );
+
+    // The 401 is a definitive "session revoked", so the silent forced-logout
+    // cleanup runs: the stale stored session is cleared...
+    await vi.waitFor(() =>
+      expect(ctx.browser.storage.local.remove).toHaveBeenCalledWith(
+        STORAGE_KEY_AUTH
+      )
+    );
+    // ...and the provider that startup had just re-activated is torn back
+    // down (unregisterProvider is otherwise only the signed-out startup
+    // branch, which did NOT run here).
+    await vi.waitFor(() =>
+      expect(
+        ctx.browser.CloudFileAccounts.unregisterProvider
+      ).toHaveBeenCalled()
+    );
+    // Silent means silent: no /logout tab (menuLogout() would open one).
+    expect(ctx.browser.tabs.create).not.toHaveBeenCalled();
+  });
+
+  it('re-enable with a still-valid session (200 from /oidc/me) keeps the user signed in and cloud file active', async () => {
+    const ctx = stubContext(host);
+    seedStaleAuth(ctx);
+    const fetchMock = stubValidationFetch(200);
+
+    await import('../../background');
+
+    await vi.waitFor(() =>
+      expect(ctx.browser.CloudFileAccounts.registerProvider).toHaveBeenCalled()
+    );
     expect(ctx.browser.CloudFileAccounts.createAccount).toHaveBeenCalled();
 
-    // ...all without a SINGLE call that could have validated the refresh
-    // token against the backend (e.g. no auth/oidc/me equivalent, no
-    // api.call at all during this startup path). If a validation call
-    // existed, it would have to go through browser.storage.local (there is
-    // no other backend interface mocked here) or an explicit fetch --
-    // neither happened.
-    //
-    // (unregisterProvider is the "signed out" branch and must NOT have run,
-    // confirming the code took the "trust local storage" happy path.)
-    expect(ctx.browser.CloudFileAccounts.unregisterProvider).not.toHaveBeenCalled();
+    // The validation call still happens...
+    await vi.waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringMatching(/\/api\/auth\/oidc\/me$/),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: `Bearer ${STALE_AUTH.access_token}`,
+          }),
+        })
+      )
+    );
+
+    // ...but a 200 means the session is genuinely alive: NO forced logout.
+    // Give the (async, fire-and-forget) validation a beat to have run.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(ctx.browser.storage.local.remove).not.toHaveBeenCalledWith(
+      STORAGE_KEY_AUTH
+    );
+    expect(
+      ctx.browser.CloudFileAccounts.unregisterProvider
+    ).not.toHaveBeenCalled();
+  });
+
+  it('re-enable with an already-expired access token SKIPS validation (a refreshable token is not proof of revocation)', async () => {
+    const ctx = stubContext(host);
+    seedStaleAuth(ctx, EXPIRED_AUTH);
+    const fetchMock = stubValidationFetch(401);
+
+    await import('../../background');
+
+    // Startup still activates cloud file on the local state.
+    await vi.waitFor(() =>
+      expect(ctx.browser.CloudFileAccounts.registerProvider).toHaveBeenCalled()
+    );
+
+    // The expired token is not sent for validation at all — the web app's
+    // refresh path owns that case, so a 401 here would be a false positive.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(fetchMock).not.toHaveBeenCalled();
+    // And the idle-but-valid user is NOT torn down.
+    expect(ctx.browser.storage.local.remove).not.toHaveBeenCalledWith(
+      STORAGE_KEY_AUTH
+    );
+    expect(
+      ctx.browser.CloudFileAccounts.unregisterProvider
+    ).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## What changed?

The add-on now checks with the server whether a saved login is still valid when it starts up or is re-enabled, instead of blindly trusting it.

Previously, on every startup the add-on decided "am I signed in?" purely by looking at whether a login was saved locally — no check against the server. So if your session had been revoked (e.g. you signed out elsewhere, or an admin ended it), the add-on kept showing you as signed in and kept cloud-file features active until some unrelated action happened to fail.

Now, right after startup, the add-on makes one quiet background check (`GET /api/auth/oidc/me`) with the stored token. If the server says the session is gone (401/403/404), it silently signs out: it clears the saved session, flips the account menu to signed-out, and turns the cloud-file provider back off. No browser tabs or popups — it's a silent correction, not a user-facing logout.

Because startup still proceeds optimistically on the local state first (that read is intentionally kept cheap, since a 60-second timer and a route guard rely on it), the cloud-file provider may briefly re-activate and then get torn back down a moment later if the session turns out to be dead.

_AI disclosure: implemented by an AI agent with human direction; a human reviewer caught and fixed a false-logout edge case (see below) and re-ran the suite before opening this PR._

## Why?

Per #1030, re-enabling the add-on trusted the mere presence of a stored refresh token with no backend check, so a revoked session appeared active. This makes the add-on's "signed in" state match reality at startup — part of the auth/session-integrity milestone (#1082).

## Limitations and Notes

- **Fail-open on transient errors:** a network blip or server hiccup never signs you out — only a definitive 401/403/404 does. We don't end a session over a flaky connection.
- **Expired-but-refreshable tokens are left alone:** if the stored access token is already expired, the add-on skips this check entirely. An expired access token is normal for an idle extension and is refreshable by the web app on next use, so treating a 401 on it as "revoked" would wrongly sign out a valid user. Only a *non-expired* token the server rejects is treated as proof of revocation. (This edge case was flagged and fixed during review — see the `expires_at` gate.)
- **Silent cleanup, not full logout:** it removes the stored session key rather than wiping all storage, so a concurrent in-flight login isn't clobbered. It deliberately does not open a `/logout` tab the way user-initiated logout does.
- **Brief re-activation window:** a revoked session gets a one-request window where cloud file is registered before teardown; harmless, since any real upload would be rejected server-side anyway.
- `getLoginState()`'s contract is unchanged — no network I/O was added to it; the check lives only in the startup path.

## Applicable Issues

Closes #1030

## Screenshots

N/A. Covered by the rewritten `c2-reenable-trusts-stale-auth.test.ts` (formerly a "confirmed bug" test): a revoked non-expired token triggers the silent teardown with no tab opened, a valid session (200) stays signed in with cloud file active, and an already-expired token skips validation. Full addon integration suite: 29 passed.
