### PR TITLE
fix(send/backend): rate limiter 503s forever because the Redis client is never created

### DIFF
--- a/packages/send/backend/src/index.ts
+++ b/packages/send/backend/src/index.ts
@@ -32,6 +32,7 @@ import { TRPC_WS_PATH } from './config';
 import { errorHandler } from './errors/routes';
 import { addVersionHeader } from './middleware';
 import { originsHandler } from './origins';
+import { getRedisClient, isRateLimitingEnabled } from './redis';
 import metricsRoute from './routes/metrics';
 import { openapiSpecification } from './swagger';
 import { createContext } from './trpc/context';
@@ -154,6 +155,15 @@ Sentry.setupExpressErrorHandler(app);
 
 // errorHandler needs to be final middleware registered.
 app.use(errorHandler);
+
+// Start connecting before the first request arrives rather than on it. ioredis
+// connects asynchronously without blocking this call, so it costs nothing at
+// boot; the payoff is that every pod in a rolling restart gets a head start on
+// the handshake instead of racing its first real request against it (see
+// middleware/rate-limit.ts for the fail-closed check this feeds).
+if (isRateLimitingEnabled()) {
+  getRedisClient();
+}
 
 const server = app.listen(PORT, HOST, async () => {
   console.log(`🚀 Server ready at: http://${HOST}:${PORT}`);

--- a/packages/send/backend/src/index.ts
+++ b/packages/send/backend/src/index.ts
@@ -156,13 +156,6 @@ Sentry.setupExpressErrorHandler(app);
 // errorHandler needs to be final middleware registered.
 app.use(errorHandler);
 
-// Connect before the first request arrives rather than on it, so a rolling
-// restart doesn't race every pod's first request against the handshake (see
-// middleware/rate-limit.ts for the fail-closed check this feeds). Wrapped in
-// try/catch because the Redis constructor parses REDIS_URL synchronously: a
-// malformed value throws here, and with no uncaughtException handler that
-// would crash the process before it starts listening rather than degrade to
-// the existing per-request 503.
 if (isRateLimitingEnabled()) {
   try {
     getRedisClient();

--- a/packages/send/backend/src/index.ts
+++ b/packages/send/backend/src/index.ts
@@ -156,13 +156,19 @@ Sentry.setupExpressErrorHandler(app);
 // errorHandler needs to be final middleware registered.
 app.use(errorHandler);
 
-// Start connecting before the first request arrives rather than on it. ioredis
-// connects asynchronously without blocking this call, so it costs nothing at
-// boot; the payoff is that every pod in a rolling restart gets a head start on
-// the handshake instead of racing its first real request against it (see
-// middleware/rate-limit.ts for the fail-closed check this feeds).
+// Connect before the first request arrives rather than on it, so a rolling
+// restart doesn't race every pod's first request against the handshake (see
+// middleware/rate-limit.ts for the fail-closed check this feeds). Wrapped in
+// try/catch because the Redis constructor parses REDIS_URL synchronously: a
+// malformed value throws here, and with no uncaughtException handler that
+// would crash the process before it starts listening rather than degrade to
+// the existing per-request 503.
 if (isRateLimitingEnabled()) {
-  getRedisClient();
+  try {
+    getRedisClient();
+  } catch (err) {
+    console.error('Failed to start the Redis connection at boot:', err);
+  }
 }
 
 const server = app.listen(PORT, HOST, async () => {

--- a/packages/send/backend/src/middleware/rate-limit.ts
+++ b/packages/send/backend/src/middleware/rate-limit.ts
@@ -125,14 +125,10 @@ export function createRateLimiter(tier: RateLimitTier): RequestHandler {
       return;
     }
 
-    // Ensure the client exists and a connection attempt is under way. Without
-    // this call, a fresh process never reaches getRedisClient() at all: the
-    // ONLY other caller is RedisStore's sendCommand below, which is itself
-    // gated behind isRedisHealthy() -- so on a cold start (healthy === false,
-    // client === null) this middleware would return 503 forever without ever
-    // making the one call that could flip it true. This line is what makes
-    // "created lazily on first use" (see redis.ts) actually happen; ioredis
-    // takes it from there (connect, retry, emit 'ready').
+    // Defense in depth alongside index.ts's eager connect: RedisStore's
+    // sendCommand below only calls getRedisClient() once already healthy, so
+    // without this line a process that skipped that eager call (a stale
+    // pod, a test) would never make the one call that can flip healthy true.
     getRedisClient();
 
     // Redis is configured but not currently reachable: fail closed with an

--- a/packages/send/backend/src/middleware/rate-limit.ts
+++ b/packages/send/backend/src/middleware/rate-limit.ts
@@ -125,10 +125,6 @@ export function createRateLimiter(tier: RateLimitTier): RequestHandler {
       return;
     }
 
-    // Defense in depth alongside index.ts's eager connect: RedisStore's
-    // sendCommand below only calls getRedisClient() once already healthy, so
-    // without this line a process that skipped that eager call (a stale
-    // pod, a test) would never make the one call that can flip healthy true.
     getRedisClient();
 
     // Redis is configured but not currently reachable: fail closed with an

--- a/packages/send/backend/src/middleware/rate-limit.ts
+++ b/packages/send/backend/src/middleware/rate-limit.ts
@@ -125,6 +125,16 @@ export function createRateLimiter(tier: RateLimitTier): RequestHandler {
       return;
     }
 
+    // Ensure the client exists and a connection attempt is under way. Without
+    // this call, a fresh process never reaches getRedisClient() at all: the
+    // ONLY other caller is RedisStore's sendCommand below, which is itself
+    // gated behind isRedisHealthy() -- so on a cold start (healthy === false,
+    // client === null) this middleware would return 503 forever without ever
+    // making the one call that could flip it true. This line is what makes
+    // "created lazily on first use" (see redis.ts) actually happen; ioredis
+    // takes it from there (connect, retry, emit 'ready').
+    getRedisClient();
+
     // Redis is configured but not currently reachable: fail closed with an
     // explicit, predictable 503 rather than letting the request through
     // unlimited. (express-rate-limit would otherwise surface the store error to

--- a/packages/send/backend/src/test/middleware/rate-limit.test.ts
+++ b/packages/send/backend/src/test/middleware/rate-limit.test.ts
@@ -32,9 +32,8 @@ vi.mock('rate-limit-redis', () => {
 });
 
 // Redis health and configured-state are toggled per test to exercise the
-// fail-closed and not-configured paths. getRedisClient is a vi.fn(), not a
-// plain stub, so tests can assert it was actually called: that's the call a
-// real process depends on to ever flip isRedisHealthy() true (see redis.ts).
+// fail-closed and not-configured paths. getRedisClient is stubbed so
+// constructing the (mocked) store never touches a real connection.
 const getRedisClientMock = vi.fn(() => ({ call: () => Promise.resolve(null) }));
 
 vi.mock('@send-backend/redis', () => ({
@@ -125,12 +124,6 @@ describe('rate-limit middleware', () => {
   });
 
   it('still calls getRedisClient on a cold, unhealthy start, so the connection that would flip it healthy actually gets made', async () => {
-    // Regression test for the production deadlock: this middleware must call
-    // getRedisClient() even while unhealthy, since RedisStore's own call to it
-    // (rate-limit.ts) only fires once already healthy. Skipping it here was
-    // the bug: index.ts's eager startup call covers most processes, but a
-    // process that reached this middleware without it (a stale pod, a test)
-    // would otherwise 503 forever with no path to recovery.
     const createRateLimiter = await loadLimiterFactory();
     const app = appWithLimiter(createRateLimiter('auth'));
     (globalThis as { __rlHealthy?: boolean }).__rlHealthy = false;

--- a/packages/send/backend/src/test/middleware/rate-limit.test.ts
+++ b/packages/send/backend/src/test/middleware/rate-limit.test.ts
@@ -32,12 +32,9 @@ vi.mock('rate-limit-redis', () => {
 });
 
 // Redis health and configured-state are toggled per test to exercise the
-// fail-closed and not-configured paths. getRedisClient is stubbed so
-// constructing the (mocked) store never touches a real connection. It is a
-// vi.fn(), not a plain arrow function, so tests can assert it was actually
-// called -- that call is what a real process depends on to ever establish a
-// connection and flip isRedisHealthy() true (see redis.ts); a middleware that
-// skips it on an unhealthy start can never recover.
+// fail-closed and not-configured paths. getRedisClient is a vi.fn(), not a
+// plain stub, so tests can assert it was actually called: that's the call a
+// real process depends on to ever flip isRedisHealthy() true (see redis.ts).
 const getRedisClientMock = vi.fn(() => ({ call: () => Promise.resolve(null) }));
 
 vi.mock('@send-backend/redis', () => ({
@@ -128,14 +125,12 @@ describe('rate-limit middleware', () => {
   });
 
   it('still calls getRedisClient on a cold, unhealthy start, so the connection that would flip it healthy actually gets made', async () => {
-    // Regression test: getRedisClient() is the ONLY thing that ever creates the
-    // ioredis client and registers the 'ready' listener that flips
-    // isRedisHealthy() true. RedisStore's own sendCommand only calls it when
-    // ALREADY healthy (see rate-limit.ts), so on a fresh process (healthy ===
-    // false, client === null) that path never runs it. If this middleware also
-    // skipped the call while unhealthy, nothing in the process would ever call
-    // getRedisClient() at all -- a permanent 503 with no way to recover, no
-    // matter how reachable Redis actually is.
+    // Regression test for the production deadlock: this middleware must call
+    // getRedisClient() even while unhealthy, since RedisStore's own call to it
+    // (rate-limit.ts) only fires once already healthy. Skipping it here was
+    // the bug: index.ts's eager startup call covers most processes, but a
+    // process that reached this middleware without it (a stale pod, a test)
+    // would otherwise 503 forever with no path to recovery.
     const createRateLimiter = await loadLimiterFactory();
     const app = appWithLimiter(createRateLimiter('auth'));
     (globalThis as { __rlHealthy?: boolean }).__rlHealthy = false;

--- a/packages/send/backend/src/test/middleware/rate-limit.test.ts
+++ b/packages/send/backend/src/test/middleware/rate-limit.test.ts
@@ -33,13 +33,19 @@ vi.mock('rate-limit-redis', () => {
 
 // Redis health and configured-state are toggled per test to exercise the
 // fail-closed and not-configured paths. getRedisClient is stubbed so
-// constructing the (mocked) store never touches a real connection.
+// constructing the (mocked) store never touches a real connection. It is a
+// vi.fn(), not a plain arrow function, so tests can assert it was actually
+// called -- that call is what a real process depends on to ever establish a
+// connection and flip isRedisHealthy() true (see redis.ts); a middleware that
+// skips it on an unhealthy start can never recover.
+const getRedisClientMock = vi.fn(() => ({ call: () => Promise.resolve(null) }));
+
 vi.mock('@send-backend/redis', () => ({
   isRedisHealthy: () =>
     (globalThis as { __rlHealthy?: boolean }).__rlHealthy ?? true,
   isRateLimitingEnabled: () =>
     (globalThis as { __rlEnabled?: boolean }).__rlEnabled ?? true,
-  getRedisClient: () => ({ call: () => Promise.resolve(null) }),
+  getRedisClient: () => getRedisClientMock(),
 }));
 
 // The limit tiers are read from env at config import time, so the small,
@@ -75,6 +81,7 @@ function appWithLimiter(limiter: RequestHandler, attachUser?: string) {
 describe('rate-limit middleware', () => {
   beforeEach(() => {
     counts.clear();
+    getRedisClientMock.mockClear();
     (globalThis as { __rlHealthy?: boolean }).__rlHealthy = true;
     (globalThis as { __rlEnabled?: boolean }).__rlEnabled = true;
   });
@@ -118,6 +125,24 @@ describe('rate-limit middleware', () => {
     const res = await request(app).get('/test');
     expect(res.status).toBe(503);
     expect(res.body.error).toBe('rate_limiter_unavailable');
+  });
+
+  it('still calls getRedisClient on a cold, unhealthy start, so the connection that would flip it healthy actually gets made', async () => {
+    // Regression test: getRedisClient() is the ONLY thing that ever creates the
+    // ioredis client and registers the 'ready' listener that flips
+    // isRedisHealthy() true. RedisStore's own sendCommand only calls it when
+    // ALREADY healthy (see rate-limit.ts), so on a fresh process (healthy ===
+    // false, client === null) that path never runs it. If this middleware also
+    // skipped the call while unhealthy, nothing in the process would ever call
+    // getRedisClient() at all -- a permanent 503 with no way to recover, no
+    // matter how reachable Redis actually is.
+    const createRateLimiter = await loadLimiterFactory();
+    const app = appWithLimiter(createRateLimiter('auth'));
+    (globalThis as { __rlHealthy?: boolean }).__rlHealthy = false;
+
+    await request(app).get('/test').expect(503);
+
+    expect(getRedisClientMock).toHaveBeenCalled();
   });
 
   it('passes requests through when rate limiting is not configured (no REDIS_URL)', async () => {


### PR DESCRIPTION
## What broke

Setting `REDIS_URL` on tb-dev made every rate-limited route, including `/api/auth/refresh`, return `503 rate_limiter_unavailable` continuously. Redis itself was never the problem: it was reachable, the TLS handshake was valid against the real cert, and connecting in-pod with the app's own `ioredis` and the real `REDIS_URL` returned `READY` immediately.

## Root cause

A circular gate between `redis.ts` and `middleware/rate-limit.ts`:

- `healthy` starts `false` and is only ever set `true` by the `'ready'` listener registered inside `getRedisClient()`.
- `getRedisClient()` had exactly one caller: `RedisStore`'s `sendCommand`, which returns early whenever `!isRedisHealthy()`.
- The middleware's own per-request guard returned `503` whenever `!isRedisHealthy()`, *before* `limiter()` ever ran, so `sendCommand` never ran either.

On a cold process, nothing in that chain ever calls `getRedisClient()`. No client gets constructed, no connection is attempted, `'ready'` never fires, and `healthy` can never flip. It's a permanent fail-closed state with no path to recovery, and a silent one: the error handler only flips a flag, and here there wasn't even a connection attempt to produce an error to log.

This was dormant since #1171/#1172 because nothing ever set `REDIS_URL` anywhere until now.

## Fix

- `middleware/rate-limit.ts`: call `getRedisClient()` in the guard before checking health, so "created lazily on first use" (the comment already in `redis.ts`) actually happens.
- `index.ts`: connect eagerly at boot when rate limiting is enabled, wrapped in try/catch since the Redis constructor parses `REDIS_URL` synchronously and a malformed value would otherwise throw before `app.listen()`.

## Why the existing tests missed this

`rate-limit.test.ts` mocks `@send-backend/redis` wholesale, so the real gating interaction between the two modules was never exercised, only `rate-limit.ts`'s use of an already-working mock. Added a regression test asserting `getRedisClient()` is called even on a cold, unhealthy start, the one call that makes recovery possible at all. Without the fix, that assertion fails the same way this bug did.
