### PR TITLE
fix(addon): make Send work with third-party cookies blocked, and explain it when it can't

### DIFF
--- a/packages/addon/public/manifest.json
+++ b/packages/addon/public/manifest.json
@@ -43,7 +43,7 @@
     "tabs",
     "activeTab",
     "https://*.backblazeb2.com/*",
-    "http://localhost:5173/*"
+    "https://send-backend.tb.pro/*"
   ],
   "experiment_apis": {
     "AccountHub": {

--- a/packages/addon/public/manifest.json
+++ b/packages/addon/public/manifest.json
@@ -43,7 +43,9 @@
     "tabs",
     "activeTab",
     "https://*.backblazeb2.com/*",
-    "https://send-backend.tb.pro/*"
+    "https://send-backend.tb.pro/*",
+    "http://localhost/*",
+    "https://localhost/*"
   ],
   "experiment_apis": {
     "AccountHub": {

--- a/packages/addon/src/test/manifest-match-patterns.test.ts
+++ b/packages/addon/src/test/manifest-match-patterns.test.ts
@@ -71,9 +71,26 @@ describe('manifest.json match patterns', () => {
     });
 
     it('carries no port in any host permission, since Firefox silently drops such patterns', () => {
+      // A host permission like `http://localhost:5173/*` is not a narrower
+      // grant -- Firefox rejects the whole pattern (bug 1362809), so it grants
+      // nothing. The dev localhost permissions below are portless on purpose;
+      // this pins that they stay that way.
       expect(hostPermissions.filter((p) => /:\d+$/.test(hostOf(p)))).toEqual(
         []
       );
+    });
+  });
+
+  /**
+   * Local dev builds run the Send app from http(s)://localhost, so the add-on
+   * needs a host permission for it -- portless, since a port makes the whole
+   * pattern inert (bug 1362809). Kept out of shipped builds separately: prod
+   * strips localhost from content_scripts in build.sh.
+   */
+  describe('localhost host permission — dev', () => {
+    it('grants portless localhost host permissions for local development', () => {
+      expect(hostPermissions).toContain('http://localhost/*');
+      expect(hostPermissions).toContain('https://localhost/*');
     });
   });
 });

--- a/packages/addon/src/test/manifest-match-patterns.test.ts
+++ b/packages/addon/src/test/manifest-match-patterns.test.ts
@@ -58,4 +58,22 @@ describe('manifest.json match patterns', () => {
     expect(LEGAL_HOST.test(hostOf('https://*.tb.pro/*'))).toBe(true);
     expect(LEGAL_HOST.test(hostOf('https://send-stage.tb.pro/*'))).toBe(true);
   });
+
+  /**
+   * Without this permission Thunderbird strips the Send session cookie as soon
+   * as third-party cookies are blocked -- see send/frontend/src/lib/cookieAccess.ts
+   * for why. CORS lets the fetches through regardless, which is how it went
+   * missing unnoticed. Bugzilla 2064458.
+   */
+  describe('Send backend host permission — Bugzilla 2064458', () => {
+    it('grants a host permission for the production Send backend', () => {
+      expect(hostPermissions).toContain('https://send-backend.tb.pro/*');
+    });
+
+    it('carries no port in any host permission, since Firefox silently drops such patterns', () => {
+      expect(hostPermissions.filter((p) => /:\d+$/.test(hostOf(p)))).toEqual(
+        []
+      );
+    });
+  });
 });

--- a/packages/send/backend/src/middleware.ts
+++ b/packages/send/backend/src/middleware.ts
@@ -235,7 +235,15 @@ export async function requireJWT(
   const validationResult = validateJWT({ jwtToken, jwtRefreshToken });
 
   if (!validationResult) {
-    return res.status(403).json({ message: `Not authorized: Token not found` });
+    // No cookie reached us at all. `error` is the machine-readable half, and
+    // exists for the add-on: this is the only answer here that means "the
+    // cookie is missing" rather than "the cookie is stale", and telling those
+    // apart is what lets the add-on say Thunderbird is blocking cookies.
+    // See send/frontend/src/lib/cookieAccess.ts (Bugzilla 2064458).
+    return res.status(403).json({
+      message: `Not authorized: Token not found`,
+      error: 'token_not_found',
+    });
   }
 
   if (validationResult === 'valid') {
@@ -244,8 +252,11 @@ export async function requireJWT(
 
   // When refresh token is invalid, we should return 403 and ask to login
   if (validationResult === 'shouldLogin') {
+    // The refresh cookie did arrive; it just failed to verify. Cookies work,
+    // they are only too old -- hence a different code to the case above.
     return res.status(403).json({
       message: `Not authorized: Refresh token expired`,
+      error: 'refresh_token_expired',
     });
   }
 
@@ -254,6 +265,7 @@ export async function requireJWT(
   if (validationResult === 'shouldRefresh') {
     return res.status(401).json({
       message: `Not authorized: Token expired`,
+      error: 'access_token_expired',
     });
   }
 }

--- a/packages/send/backend/src/middleware.ts
+++ b/packages/send/backend/src/middleware.ts
@@ -239,7 +239,8 @@ export async function requireJWT(
     // exists for the add-on: this is the only answer here that means "the
     // cookie is missing" rather than "the cookie is stale", and telling those
     // apart is what lets the add-on say Thunderbird is blocking cookies.
-    // See send/frontend/src/lib/cookieAccess.ts (Bugzilla 2064458).
+    // See send/frontend/src/lib/cookieAccess.ts (Bugzilla 2064458). These
+    // codes have no other consumer, so they go when #1191 does.
     return res.status(403).json({
       message: `Not authorized: Token not found`,
       error: 'token_not_found',

--- a/packages/send/backend/src/routes/index.ts
+++ b/packages/send/backend/src/routes/index.ts
@@ -98,4 +98,78 @@ router.get('/api/health', (_, res) => {
   });
 });
 
+// Bugzilla 2064458: when Thunderbird refuses third-party cookies, the httpOnly
+// SameSite=None session cookie (see auth/client.ts registerAuthToken) never
+// reaches the backend and the entire app is non-functional. Pre-login there is
+// no session to infer from, so the frontend performs a positive round-trip
+// probe: `set` plants a throwaway cookie with the *same* SameSite=None; Secure
+// attributes as the real session cookie, and `verify` reports whether it came
+// back. Both routes are unauthenticated by design.
+const COOKIE_PROBE_NAME = 'send_cookie_probe';
+const COOKIE_PROBE_MAX_AGE_MS = 60_000;
+
+/**
+ * @openapi
+ * /api/cookie-check/set:
+ *   get:
+ *     tags:
+ *       - Health
+ *     summary: Set the cookie probe
+ *     description: >
+ *       Sets a short-lived probe cookie with the same SameSite=None; Secure
+ *       attributes as the session cookie, so the client can verify whether
+ *       cookies for this backend are being blocked (Bugzilla 2064458).
+ *     responses:
+ *       200:
+ *         description: Probe cookie set
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 ok:
+ *                   type: boolean
+ *                   example: true
+ */
+router.get('/api/cookie-check/set', (_, res) => {
+  res.cookie(COOKIE_PROBE_NAME, '1', {
+    maxAge: COOKIE_PROBE_MAX_AGE_MS,
+    // Matches the session cookie's attributes as closely as possible so the
+    // probe faithfully tests the same blocking behavior.
+    httpOnly: true,
+    sameSite: 'none',
+    secure: true,
+  });
+  res.status(200).json({ ok: true });
+});
+
+/**
+ * @openapi
+ * /api/cookie-check/verify:
+ *   get:
+ *     tags:
+ *       - Health
+ *     summary: Verify the cookie probe round-trip
+ *     description: >
+ *       Reports whether the probe cookie set by /api/cookie-check/set was sent
+ *       back by the client, i.e. whether cookies for this backend are enabled
+ *       (Bugzilla 2064458).
+ *     responses:
+ *       200:
+ *         description: Probe result
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 cookiesEnabled:
+ *                   type: boolean
+ *                   example: true
+ */
+router.get('/api/cookie-check/verify', (req, res) => {
+  res.status(200).json({
+    cookiesEnabled: Boolean(req.cookies?.[COOKIE_PROBE_NAME]),
+  });
+});
+
 export default router;

--- a/packages/send/backend/src/test/middleware.test.ts
+++ b/packages/send/backend/src/test/middleware.test.ts
@@ -170,8 +170,12 @@ describe('requireJWT', () => {
     );
 
     expect(mockResponse.status).toHaveBeenCalledWith(403);
+    // `error` is what the add-on's blocked-cookie check reads: this is the
+    // only answer here that means the cookie never arrived, as opposed to
+    // arriving stale. See send/frontend/src/lib/cookieAccess.ts (Bugzilla 2064458).
     expect(mockResponse.json).toHaveBeenCalledWith({
       message: 'Not authorized: Token not found',
+      error: 'token_not_found',
     });
   });
 
@@ -189,8 +193,11 @@ describe('requireJWT', () => {
     );
 
     expect(mockResponse.status).toHaveBeenCalledWith(401);
+    // A distinct code from token_not_found on purpose: reaching here means
+    // the refresh cookie verified, so the cookie is arriving.
     expect(mockResponse.json).toBeCalledWith({
       message: `Not authorized: Token expired`,
+      error: 'access_token_expired',
     });
   });
 
@@ -208,8 +215,10 @@ describe('requireJWT', () => {
     );
 
     expect(mockResponse.status).toHaveBeenCalledWith(403);
+    // Also arriving, just too old -- so also not a blocked cookie.
     expect(mockResponse.json).toBeCalledWith({
       message: `Not authorized: Refresh token expired`,
+      error: 'refresh_token_expired',
     });
   });
 });

--- a/packages/send/backend/src/test/routes/cookie-check.routes.test.ts
+++ b/packages/send/backend/src/test/routes/cookie-check.routes.test.ts
@@ -1,0 +1,57 @@
+import cookieParser from 'cookie-parser';
+import express from 'express';
+import request from 'supertest';
+import { describe, expect, it } from 'vitest';
+
+import router from '../../routes';
+
+// Mirrors the real app: cookieParser is applied app-wide (src/index.ts) and the
+// index router is mounted at '/'. These routes need no DB, auth or storage.
+const app = express();
+app.use(cookieParser());
+app.use('/', router);
+
+/**
+ * Bugzilla 2064458: pre-login there is no session to infer blocked cookies
+ * from, so the frontend runs a positive round-trip probe against these two
+ * unauthenticated routes. The probe cookie must carry the same SameSite=None;
+ * Secure attributes as the real session cookie (auth/client.ts
+ * registerAuthToken) or it would not test the same blocking behavior — the
+ * attribute assertions below pin that.
+ */
+describe('GET /api/cookie-check', () => {
+  it('set plants the probe cookie with the session cookie attributes', async () => {
+    const response = await request(app).get('/api/cookie-check/set');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ ok: true });
+
+    const setCookie = response.headers['set-cookie'];
+    expect(setCookie).toBeDefined();
+    const probeCookie = [setCookie]
+      .flat()
+      .find((cookie) => cookie.startsWith('send_cookie_probe='));
+    expect(probeCookie).toBeDefined();
+    // Same attributes as the real session cookie, so the probe faithfully
+    // tests the same blocking behavior.
+    expect(probeCookie).toContain('SameSite=None');
+    expect(probeCookie).toContain('Secure');
+    expect(probeCookie).toContain('HttpOnly');
+  });
+
+  it('verify answers cookiesEnabled:true when the probe cookie comes back', async () => {
+    const response = await request(app)
+      .get('/api/cookie-check/verify')
+      .set('Cookie', 'send_cookie_probe=1');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ cookiesEnabled: true });
+  });
+
+  it('verify answers cookiesEnabled:false when no probe cookie arrives', async () => {
+    const response = await request(app).get('/api/cookie-check/verify');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ cookiesEnabled: false });
+  });
+});

--- a/packages/send/backend/src/test/routes/uploads.can-upload.routes.test.ts
+++ b/packages/send/backend/src/test/routes/uploads.can-upload.routes.test.ts
@@ -65,12 +65,14 @@ describe('GET /api/uploads/can-upload', () => {
       expect(response.status).toBe(403);
 
       // The assertion that pins the ordering. Both orders now answer 403 --
-      // `checkStorageLimit` fails closed too -- so only the message says which
+      // `checkStorageLimit` fails closed too -- so only the body says which
       // middleware got there first. This one is `requireJWT`'s; running
       // `checkStorageLimit` first yields the bare 'Not authorized' from
-      // `reject()`.
+      // `reject()`. `error` is read by the add-on's blocked-cookie check
+      // (send/frontend/src/lib/cookieAccess.ts), so it is pinned here too.
       expect(response.body).toEqual({
         message: 'Not authorized: Token not found',
+        error: 'token_not_found',
       });
 
       // And the storage read stays out of reach of an anonymous caller.

--- a/packages/send/frontend/src/apps/common/CookiesBlockedBanner.test.ts
+++ b/packages/send/frontend/src/apps/common/CookiesBlockedBanner.test.ts
@@ -1,0 +1,94 @@
+import { getByTestId } from '@send-frontend/lib/testUtils';
+import { mount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import CookiesBlockedBanner from './CookiesBlockedBanner.vue';
+
+const { probeResult, refetchMock } = vi.hoisted(() => {
+  return { probeResult: vi.fn(), refetchMock: vi.fn() };
+});
+
+vi.mock('@send-frontend/stores/api-store', () => ({
+  default: () => ({
+    api: { call: vi.fn() },
+  }),
+}));
+
+// Mock vue-query — the component only reads `data` and calls `refetch`.
+vi.mock('@tanstack/vue-query', () => ({
+  useQuery: () => {
+    return {
+      data: { value: probeResult() },
+      refetch: refetchMock,
+    };
+  },
+}));
+
+/**
+ * Bugzilla 2064458: the banner must only ever appear on a *positive* 'blocked'
+ * probe answer. 'unknown' (offline user, older backend) and loading states
+ * stay hidden — a false blocked-cookies warning sends users to change a
+ * Thunderbird setting that was never the problem.
+ */
+describe('CookiesBlockedBanner.vue', () => {
+  beforeEach(() => {
+    probeResult.mockReturnValue('blocked');
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows the banner when the probe answers blocked', () => {
+    const wrapper = mount(CookiesBlockedBanner);
+
+    expect(wrapper.find(getByTestId('cookies-blocked-banner')).exists()).toBe(
+      true
+    );
+    expect(
+      wrapper.find(getByTestId('cookies-blocked-banner-body')).exists()
+    ).toBe(true);
+  });
+
+  it('hides the banner when the probe answers enabled', () => {
+    probeResult.mockReturnValue('enabled');
+    const wrapper = mount(CookiesBlockedBanner);
+
+    expect(wrapper.find(getByTestId('cookies-blocked-banner')).exists()).toBe(
+      false
+    );
+  });
+
+  it('hides the banner when the probe is inconclusive (unknown)', () => {
+    probeResult.mockReturnValue('unknown');
+    const wrapper = mount(CookiesBlockedBanner);
+
+    expect(wrapper.find(getByTestId('cookies-blocked-banner')).exists()).toBe(
+      false
+    );
+  });
+
+  it('hides the banner while the probe is still loading', () => {
+    probeResult.mockReturnValue(undefined);
+    const wrapper = mount(CookiesBlockedBanner);
+
+    expect(wrapper.find(getByTestId('cookies-blocked-banner')).exists()).toBe(
+      false
+    );
+  });
+
+  it('is not dismissible (no close button)', () => {
+    const wrapper = mount(CookiesBlockedBanner);
+
+    expect(wrapper.find(getByTestId('close-button')).exists()).toBe(false);
+  });
+
+  it('retry button refetches the probe query', async () => {
+    const wrapper = mount(CookiesBlockedBanner);
+
+    await wrapper
+      .find(getByTestId('cookies-blocked-banner-retry'))
+      .trigger('click');
+
+    expect(refetchMock).toHaveBeenCalled();
+  });
+});

--- a/packages/send/frontend/src/apps/common/CookiesBlockedBanner.vue
+++ b/packages/send/frontend/src/apps/common/CookiesBlockedBanner.vue
@@ -1,0 +1,68 @@
+<script lang="ts" setup>
+/**
+ * Login-screen banner for blocked cookies (Bugzilla 2064458).
+ *
+ * The Send backend keeps the session in an httpOnly, SameSite=None cookie;
+ * when the browser/Thunderbird refuses it, the entire app is non-functional.
+ * The post-login detection in `cookieAccess.ts` needs a live session to infer
+ * from, so this banner runs the positive pre-login round-trip probe in
+ * `cookieProbe.ts` instead and warns before the user even attempts to log in.
+ *
+ * Deliberately NOT dismissible: unlike the update prompt in
+ * CompatibilityBanner, there is nothing useful the user can do in the app
+ * while cookies are blocked. The banner only shows on a *positive* 'blocked'
+ * answer — 'unknown' and loading states stay hidden, so an offline user or an
+ * older backend never sees a false warning.
+ */
+import { probeCookiesEnabled } from '@send-frontend/lib/cookieProbe';
+import { CLIENT_MESSAGES } from '@send-frontend/lib/messages';
+import useApiStore from '@send-frontend/stores/api-store';
+import { useQuery } from '@tanstack/vue-query';
+import { computed } from 'vue';
+
+const { api } = useApiStore();
+
+const { data, refetch } = useQuery({
+  queryKey: ['cookie-probe'],
+  queryFn: async () => await probeCookiesEnabled(api),
+});
+
+const isBlocked = computed(() => data?.value === 'blocked');
+</script>
+
+<template>
+  <header v-if="isBlocked" data-testid="cookies-blocked-banner">
+    <div class="warning">
+      <p class="title">{{ CLIENT_MESSAGES.COOKIES_BLOCKED_TITLE }}</p>
+      <p data-testid="cookies-blocked-banner-body">
+        {{ CLIENT_MESSAGES.COOKIES_BLOCKED_BANNER_BODY }}
+      </p>
+      <button
+        type="button"
+        data-testid="cookies-blocked-banner-retry"
+        @click="refetch()"
+      >
+        Retry
+      </button>
+    </div>
+  </header>
+</template>
+
+<style scoped>
+header {
+  position: relative;
+}
+.warning {
+  background: var(--colour-warning-default);
+  padding: 1rem;
+}
+.title {
+  font-weight: bold;
+}
+button {
+  margin-top: 0.5rem;
+  padding: 0.25rem 0.75rem;
+  font-weight: bold;
+  cursor: pointer;
+}
+</style>

--- a/packages/send/frontend/src/apps/send/LoginPage.vue
+++ b/packages/send/frontend/src/apps/send/LoginPage.vue
@@ -37,6 +37,7 @@ import useKeychainStore from '@send-frontend/stores/keychain-store';
 import useUserStore from '@send-frontend/stores/user-store';
 import { onMounted, ref } from 'vue';
 import { useRouter } from 'vue-router';
+import CookiesBlockedBanner from '../common/CookiesBlockedBanner.vue';
 import FeedbackBox from '../common/FeedbackBox.vue';
 
 import PublicLogin from '../common/PublicLogin.vue';
@@ -98,9 +99,11 @@ async function _loginToOIDC() {
 <template>
   <main class="container">
     <div v-if="!isPublicLogin">
+      <CookiesBlockedBanner />
       <p>Redirecting to TB Pro login...</p>
     </div>
     <div v-else>
+      <CookiesBlockedBanner />
       <TBBanner />
       <PublicLogin v-if="isPublicLogin" :on-success="onSuccess" />
       <FeedbackBox />

--- a/packages/send/frontend/src/apps/send/views/PopupView.test.ts
+++ b/packages/send/frontend/src/apps/send/views/PopupView.test.ts
@@ -1,0 +1,346 @@
+import { CLIENT_MESSAGES } from '@send-frontend/lib/messages';
+import type { UploadReadiness } from '@send-frontend/lib/uploadReadiness';
+import { enableAutoUnmount, mount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { nextTick, ref, type Ref } from 'vue';
+import PopupView from './PopupView.vue';
+
+/**
+ * Bugzilla 2064458 -- with third-party cookies blocked the popup sat on
+ * "Finish setting up Send" and pushed the user into a passphrase window that
+ * closed itself instantly, over and over, with no error. Two things are pinned
+ * here: the readiness check must name blocked cookies *before* it blames a
+ * missing key backup, and the setup window must never open itself more than
+ * once.
+ */
+
+type Readiness = UploadReadiness | undefined;
+
+const { state } = vi.hoisted(() => ({
+  state: {
+    readiness: null as unknown as Ref<Readiness>,
+    // Captured from the useQuery mock so tests can drive the real query
+    // function with whatever the validator would have answered.
+    readinessQueryFn: null as unknown as () => Promise<UploadReadiness>,
+    isLoggedIn: null as unknown as Ref<boolean>,
+    refetch: vi.fn(),
+    validators: vi.fn(),
+    openPopup: vi.fn(),
+  },
+}));
+
+vi.mock('@tanstack/vue-query', () => {
+  state.readiness = ref<Readiness>(undefined);
+  return {
+    useQuery: (options: {
+      queryKey: string[];
+      queryFn: () => Promise<UploadReadiness>;
+    }) => {
+      if (options.queryKey[0] === 'is-configured-for-upload') {
+        state.readinessQueryFn = options.queryFn;
+        return {
+          data: state.readiness,
+          refetch: state.refetch,
+          isLoading: ref(false),
+        };
+      }
+      // The `can-upload` query -- never the subject of these tests.
+      return {
+        data: ref(null),
+        error: ref(null),
+        refetch: vi.fn(),
+        isLoading: ref(false),
+      };
+    },
+  };
+});
+
+vi.mock('@send-frontend/lib/auth', () => {
+  state.isLoggedIn = ref(true);
+  return {
+    useAuth: () => ({
+      isLoggedIn: state.isLoggedIn,
+      refetchAuth: vi.fn(),
+      isLoadingAuth: ref(false),
+      logOutAuth: vi.fn(),
+    }),
+  };
+});
+
+vi.mock('@send-frontend/lib/login', () => ({
+  openPopup: (...args: unknown[]) => state.openPopup(...args),
+}));
+
+vi.mock('@send-frontend/apps/send/stores/status-store', () => ({
+  useStatusStore: () => ({
+    validators: state.validators,
+    progress: { error: '', setText: vi.fn() },
+  }),
+}));
+
+vi.mock('@send-frontend/apps/send/composables/useUploadAndShare', () => ({
+  useUploadAndShare: () => ({ isError: ref(false), uploadAndShare: vi.fn() }),
+}));
+
+vi.mock('@send-frontend/lib/init', () => ({ default: vi.fn() }));
+vi.mock('@send-frontend/lib/keychain', () => ({
+  restoreKeysUsingLocalStorage: vi.fn(),
+}));
+vi.mock('@send-frontend/lib/queries', () => ({ canUploadQuery: vi.fn() }));
+vi.mock('@send-frontend/stores/api-store', () => ({
+  default: () => ({ api: {} }),
+}));
+vi.mock('@send-frontend/stores/user-store', () => ({ default: () => ({}) }));
+vi.mock('@send-frontend/stores/keychain-store', () => ({
+  default: () => ({ keychain: {} }),
+}));
+vi.mock('@send-frontend/apps/send/stores/folder-store', () => ({
+  default: () => ({}),
+}));
+
+const stubs = {
+  // Renders its slot, unlike a `true` stub -- everything under test lives inside it.
+  WithLoader: { props: ['isLoading'], template: '<div><slot /></div>' },
+  ProButton: { template: '<button><slot /></button>' },
+  UploadPage: { template: '<div data-testid="upload-page" />' },
+  ErrorUploading: true,
+  PromptPopupLogin: true,
+};
+
+const mountPopup = () => mount(PopupView, { global: { stubs } });
+
+/** What `validators()` answers on a fully healthy account. */
+const healthyValidators = {
+  hasBackedUpKeys: true,
+  isTokenValid: true,
+  hasForcedLogin: false,
+  cookieAccess: 'ok' as const,
+};
+
+// Components mounted here register watchers on the shared readiness ref, so
+// unmount between tests or a previous test's watcher answers the next test's
+// changes and the open-once assertions become meaningless.
+enableAutoUnmount(afterEach);
+
+beforeEach(() => {
+  state.readiness.value = undefined;
+  state.isLoggedIn.value = true;
+  state.openPopup.mockReset().mockResolvedValue(true);
+  state.refetch.mockReset();
+  state.validators.mockReset().mockResolvedValue(healthyValidators);
+});
+
+/**
+ * The precedence itself lives in lib/uploadReadiness.ts and is tested there.
+ * What needs the mounted component is the ready path, because it runs
+ * `initialize()` -- and it is the one outcome that gates uploading.
+ */
+describe('PopupView.vue — readiness check (Bugzilla 2064458)', () => {
+  it('reports ready when the cookie is fine, the session is live and the keys are backed up', async () => {
+    mountPopup();
+
+    await expect(state.readinessQueryFn()).resolves.toEqual({
+      status: 'ready',
+    });
+  });
+
+  it('reports the blocker the validator answer implies, rather than always blaming setup', async () => {
+    state.validators.mockResolvedValue({
+      ...healthyValidators,
+      hasBackedUpKeys: false,
+      cookieAccess: 'blocked',
+    });
+    mountPopup();
+
+    await expect(state.readinessQueryFn()).resolves.toEqual({
+      status: 'cookies-blocked',
+    });
+  });
+});
+
+describe('PopupView.vue — what the user is told (Bugzilla 2064458)', () => {
+  it('explains the blocked cookie instead of showing the passphrase setup prompt', async () => {
+    state.readiness.value = { status: 'cookies-blocked' };
+    const wrapper = mountPopup();
+    await nextTick();
+
+    expect(wrapper.find('[data-testid="cookies-blocked-body"]').exists()).toBe(
+      true
+    );
+    expect(wrapper.text()).not.toContain('Finish setting up Send');
+  });
+
+  it('names the Thunderbird cookie setting, so the message is something the user can act on', async () => {
+    state.readiness.value = { status: 'cookies-blocked' };
+    const wrapper = mountPopup();
+    await nextTick();
+
+    const body = wrapper.find('[data-testid="cookies-blocked-body"]').text();
+    expect(body).toBe(CLIENT_MESSAGES.COOKIES_BLOCKED_BODY);
+    expect(body).toContain('Privacy & Security');
+    expect(body).toContain('Accept cookies from sites');
+  });
+
+  it('offers no Continue Setup button when cookies are blocked, because that flow cannot fix it', async () => {
+    state.readiness.value = { status: 'cookies-blocked' };
+    const wrapper = mountPopup();
+    await nextTick();
+
+    expect(wrapper.find('[data-testid="continue-setup"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="recheck-readiness"]').exists()).toBe(
+      true
+    );
+  });
+
+  it('re-runs the readiness check when the user chooses Check again', async () => {
+    state.readiness.value = { status: 'cookies-blocked' };
+    const wrapper = mountPopup();
+    await nextTick();
+
+    await wrapper.find('[data-testid="recheck-readiness"]').trigger('click');
+
+    expect(state.refetch).toHaveBeenCalled();
+  });
+
+  it('still shows the passphrase setup prompt and its button when the key backup is genuinely missing', async () => {
+    state.readiness.value = { status: 'needs-setup' };
+    const wrapper = mountPopup();
+    await nextTick();
+
+    expect(wrapper.text()).toContain('Finish setting up Send');
+    expect(wrapper.find('[data-testid="continue-setup"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="cookies-blocked-body"]').exists()).toBe(
+      false
+    );
+  });
+
+  it('says setup did not finish once the setup window has been closed without completing it', async () => {
+    const wrapper = mountPopup();
+    state.readiness.value = { status: 'needs-setup' };
+    await nextTick();
+    expect(
+      wrapper.find('[data-testid="setup-did-not-complete"]').exists()
+    ).toBe(false);
+
+    // The auto-open already fired; run its close callback.
+    const [, onClose] = state.openPopup.mock.calls[0];
+    onClose();
+    await nextTick();
+
+    expect(
+      wrapper.find('[data-testid="setup-did-not-complete"]').exists()
+    ).toBe(true);
+  });
+
+  it('explains that the check itself failed, and opens no window, when readiness is undetermined', async () => {
+    state.readiness.value = { status: 'unknown' };
+    const wrapper = mountPopup();
+    await nextTick();
+
+    expect(wrapper.find('[data-testid="readiness-unknown"]').text()).toBe(
+      CLIENT_MESSAGES.SETUP_CHECK_FAILED
+    );
+    expect(state.openPopup).not.toHaveBeenCalled();
+  });
+
+  it('renders the upload page once everything is ready', async () => {
+    state.readiness.value = { status: 'ready' };
+    const wrapper = mountPopup();
+    await nextTick();
+
+    expect(wrapper.find('[data-testid="upload-page"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="finish-setup"]').exists()).toBe(false);
+  });
+});
+
+describe('PopupView.vue — the setup window must not flap (Bugzilla 2064458)', () => {
+  it('opens the setup window once when the key backup is genuinely missing', async () => {
+    mountPopup();
+    state.readiness.value = { status: 'needs-setup' };
+    await nextTick();
+
+    expect(state.openPopup).toHaveBeenCalledTimes(1);
+    expect(state.openPopup.mock.calls[0][0]).toContain(
+      '/send/security-and-privacy?closeOnComplete=true'
+    );
+  });
+
+  it('does not reopen the setup window when the check answers needs-setup again', async () => {
+    mountPopup();
+    state.readiness.value = { status: 'needs-setup' };
+    await nextTick();
+
+    // A refetch that reaches the same conclusion returns a fresh object.
+    state.readiness.value = { status: 'needs-setup' };
+    await nextTick();
+
+    expect(state.openPopup).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not reopen the setup window when the answer leaves needs-setup and comes back after the window was closed', async () => {
+    mountPopup();
+    state.readiness.value = { status: 'needs-setup' };
+    await nextTick();
+
+    // Close the window first. Without this the `isSecurityPopupOpen` guard
+    // masks everything and the test proves nothing: it is only once the window
+    // is gone that the auto-open latch is the thing standing in the way.
+    const [, onClose] = state.openPopup.mock.calls[0];
+    onClose();
+    await nextTick();
+
+    state.readiness.value = { status: 'unknown' };
+    await nextTick();
+    state.readiness.value = { status: 'needs-setup' };
+    await nextTick();
+
+    expect(state.openPopup).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not reopen the setup window when a later check answers needs-setup again after the window was closed', async () => {
+    mountPopup();
+    state.readiness.value = { status: 'needs-setup' };
+    await nextTick();
+
+    const [, onClose] = state.openPopup.mock.calls[0];
+    onClose();
+    await nextTick();
+
+    // A refetch reaching the same conclusion hands back a fresh object.
+    state.readiness.value = { status: 'needs-setup' };
+    await nextTick();
+
+    expect(state.openPopup).toHaveBeenCalledTimes(1);
+  });
+
+  it('never opens the setup window when cookies are blocked', async () => {
+    mountPopup();
+    state.readiness.value = { status: 'cookies-blocked' };
+    await nextTick();
+
+    expect(state.openPopup).not.toHaveBeenCalled();
+  });
+
+  it('does not open the setup window while the user is signed out', async () => {
+    state.isLoggedIn.value = false;
+    mountPopup();
+    state.readiness.value = { status: 'needs-setup' };
+    await nextTick();
+
+    expect(state.openPopup).not.toHaveBeenCalled();
+  });
+
+  it('still lets the user reopen the setup window by hand after it closed without completing setup', async () => {
+    const wrapper = mountPopup();
+    state.readiness.value = { status: 'needs-setup' };
+    await nextTick();
+
+    const [, onClose] = state.openPopup.mock.calls[0];
+    onClose();
+    await nextTick();
+
+    await wrapper.find('[data-testid="continue-setup"]').trigger('click');
+
+    expect(state.openPopup).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/send/frontend/src/apps/send/views/PopupView.vue
+++ b/packages/send/frontend/src/apps/send/views/PopupView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 
 import init from '@send-frontend/lib/init';
 
@@ -25,7 +25,12 @@ import {
 import { ERROR_MESSAGES } from '@send-frontend/lib/errorMessages';
 import { restoreKeysUsingLocalStorage } from '@send-frontend/lib/keychain';
 import { openPopup } from '@send-frontend/lib/login';
+import { CLIENT_MESSAGES } from '@send-frontend/lib/messages';
 import { canUploadQuery } from '@send-frontend/lib/queries';
+import {
+  findUploadBlocker,
+  type UploadReadiness,
+} from '@send-frontend/lib/uploadReadiness';
 import useApiStore from '@send-frontend/stores/api-store';
 import { useQuery } from '@tanstack/vue-query';
 import UploadPage from '../pages/UploadPage.vue';
@@ -47,7 +52,6 @@ const folderStore = useFolderStore();
 const { isError: uploadingError, uploadAndShare } = useUploadAndShare();
 
 const files = ref<FileItem[] | null>(null);
-const message = ref('');
 
 async function handleUploadAndShare(
   files: FileItem[],
@@ -70,35 +74,38 @@ const { error: uploadBlockedDuetoSize } = useQuery({
 });
 
 const {
-  data: isConfigured,
+  data: readiness,
   refetch,
   isLoading: isLoadingConfigured,
 } = useQuery({
   queryKey: ['is-configured-for-upload'],
-  queryFn: async () => {
+  queryFn: async (): Promise<UploadReadiness> => {
     await refetchAuth();
     // At the very end we have to validate that everything is in order for the upload to happen
-    const { hasBackedUpKeys, isTokenValid, hasForcedLogin } =
-      await validators();
-
-    if (!hasBackedUpKeys) {
-      message.value = `Please make sure you have backed up or restored your keys. Go back to the compositon panel and follow the instructions`;
-      // close this window and open the management page
-      return false;
-    }
-    if (!isTokenValid || hasForcedLogin) {
-      message.value = `You're not logged in properly. Please go back to the compositon panel to log back in`;
-      return false;
+    const blocker = findUploadBlocker(await validators());
+    if (blocker) {
+      return blocker;
     }
     // If everything is fine, we initialize the app
     await initialize();
-    return true;
+    return { status: 'ready' };
   },
   refetchOnWindowFocus: true,
   refetchOnMount: true,
 });
 
+const isConfigured = computed(() => readiness.value?.status === 'ready');
+
 const isSecurityPopupOpen = ref(false);
+
+// Latched, and deliberately never reset: the setup window may open itself at
+// most once per popup. `isSecurityPopupOpen` cannot do this job because the
+// close callback clears it, which is exactly how the window came to reopen
+// every time the readiness check answered "not set up" again (Bugzilla 2064458).
+const hasAutoOpenedSetup = ref(false);
+// Set when the setup window closes, so a second visit can say setup didn't
+// finish rather than silently showing the same prompt again.
+const hasClosedSetupWindow = ref(false);
 
 // When the user isn't set up for uploads, send them to the Security & Privacy
 // page in its own window instead of embedding the backup/restore flow in this
@@ -115,6 +122,7 @@ async function openSecurityPopup() {
     `${BASE_URL}/send/security-and-privacy?closeOnComplete=true`,
     () => {
       isSecurityPopupOpen.value = false;
+      hasClosedSetupWindow.value = true;
       refetch();
     }
   );
@@ -125,11 +133,23 @@ async function openSecurityPopup() {
   }
 }
 
-watch(isConfigured, (configured) => {
-  if (configured === false && isLoggedIn.value) {
+// Only the status matters; each refetch hands back a fresh object.
+watch(
+  () => readiness.value?.status,
+  (status) => {
+    // Only a positive "no key backup" answer may open the setup window: no
+    // other state is one the setup flow can resolve.
+    if (
+      status !== 'needs-setup' ||
+      !isLoggedIn.value ||
+      hasAutoOpenedSetup.value
+    ) {
+      return;
+    }
+    hasAutoOpenedSetup.value = true;
     openSecurityPopup();
   }
-});
+);
 
 const initialize = async () => {
   try {
@@ -186,15 +206,56 @@ const initialize = async () => {
   <WithLoader :is-loading="isLoadingAuth || isLoadingConfigured">
     <PromptPopupLogin v-if="!isLoggedIn" />
     <div v-else>
-      <div v-if="!isConfigured" class="finish-setup">
-        <h1>Finish setting up Send</h1>
-        <p>
-          To continue your upload, please complete your passphrase
-          setup/recovery.
-        </p>
-        <ProButton v-if="!isSecurityPopupOpen" @click="openSecurityPopup">
-          Continue Setup
-        </ProButton>
+      <div v-if="!isConfigured" class="finish-setup" data-testid="finish-setup">
+        <!-- No "Continue Setup" here: the passphrase flow cannot fix a
+             blocked cookie, and offering it is what left users clicking a
+             dialog that closed itself. -->
+        <template v-if="readiness?.status === 'cookies-blocked'">
+          <h1 data-testid="cookies-blocked-title">
+            {{ CLIENT_MESSAGES.COOKIES_BLOCKED_TITLE }}
+          </h1>
+          <p data-testid="cookies-blocked-body">
+            {{ CLIENT_MESSAGES.COOKIES_BLOCKED_BODY }}
+          </p>
+          <ProButton data-testid="recheck-readiness" @click="refetch">
+            Check again
+          </ProButton>
+        </template>
+
+        <template v-else-if="readiness?.status === 'needs-setup'">
+          <h1>Finish setting up Send</h1>
+          <p>
+            To continue your upload, please complete your passphrase
+            setup/recovery.
+          </p>
+          <p v-if="hasClosedSetupWindow" data-testid="setup-did-not-complete">
+            {{ CLIENT_MESSAGES.SETUP_DID_NOT_COMPLETE }}
+          </p>
+          <ProButton
+            v-if="!isSecurityPopupOpen"
+            data-testid="continue-setup"
+            @click="openSecurityPopup"
+          >
+            Continue Setup
+          </ProButton>
+        </template>
+
+        <template v-else-if="readiness?.status === 'signed-out'">
+          <h1>You're signed out</h1>
+          <p data-testid="signed-out-body">
+            {{ CLIENT_MESSAGES.SIGNED_OUT_RETURN_TO_COMPOSE }}
+          </p>
+        </template>
+
+        <template v-else>
+          <h1>Send couldn't check your setup</h1>
+          <p data-testid="readiness-unknown">
+            {{ CLIENT_MESSAGES.SETUP_CHECK_FAILED }}
+          </p>
+          <ProButton data-testid="recheck-readiness" @click="refetch">
+            Check again
+          </ProButton>
+        </template>
       </div>
       <div v-else>
         <!-- We only show the error message when storage limit has been exceeded -->

--- a/packages/send/frontend/src/lib/cookieAccess.ts
+++ b/packages/send/frontend/src/lib/cookieAccess.ts
@@ -1,0 +1,99 @@
+import type { ApiCallFailure } from './api';
+
+/**
+ * Whether Send's session cookie is actually reaching the backend.
+ *
+ * The add-on's pages run from a `moz-extension://` document and authenticate to
+ * the Send backend with an httpOnly, SameSite=None cookie. A moz-extension
+ * document only gets first-party cookie treatment when the extension holds a
+ * host permission for the target (Firefox bug 1629436), so when Thunderbird is
+ * set to refuse third-party cookies that cookie can simply vanish from the
+ * request -- and every requireJWT-gated route then answers as if nobody were
+ * signed in. Bugzilla 2064458.
+ *
+ * `unknown` is the third state, and the reason this is not a boolean: "we could
+ * not tell" must never be reported to the user as "your cookies are blocked",
+ * or we send someone to change a Thunderbird setting that was never the
+ * problem. A signed-out user, an offline user, a rate-limited user and a merely
+ * expired session all land here.
+ */
+export type CookieAccess = 'ok' | 'blocked' | 'unknown';
+
+/**
+ * True only when we positively determined the cookie is not arriving -- never
+ * on a guess. Anything that tells the user to change a cookie setting must go
+ * through this rather than comparing the string inline.
+ */
+export const isCookieAccessBlocked = (state: CookieAccess) =>
+  state === 'blocked';
+
+/**
+ * `requireJWT`'s code for "no cookie reached us", as opposed to the codes for a
+ * cookie that arrived and was too old. The distinction is the whole basis of
+ * this module and is easy to get wrong: `requireJWT` also answers 403 for an
+ * expired refresh token and 401 for an expired access token, and *both* of
+ * those prove the cookie arrived, because validateJWT only reaches them after
+ * reading it. Keying on the status alone would report a routine hour-old
+ * session as blocked cookies.
+ *
+ * Pinned on the backend side by send/backend/src/test/middleware.test.ts.
+ */
+const COOKIE_MISSING_ERROR = 'token_not_found';
+/**
+ * Fallback for a backend that predates the `error` code above. The add-on and
+ * the backend deploy separately, so an add-on build can reach an older server;
+ * without this the feature would silently do nothing there. Same test pins it.
+ */
+const COOKIE_MISSING_MESSAGE = 'Token not found';
+
+type CookieAccessEvidence = {
+  /** Did the cookie-gated call (`users/me`) come back with a body? */
+  cookieRouteSucceeded: boolean;
+  /** How the cookie-gated call failed, if it did. */
+  cookieRouteFailure: ApiCallFailure | null;
+  /** Did the Bearer-only call (`auth/oidc/me`) confirm a live session? */
+  bearerSessionValid: boolean;
+};
+
+/** Did the backend say, specifically, that no cookie arrived? */
+function saysCookieMissing(failure: ApiCallFailure | null): boolean {
+  if (failure?.kind !== 'http' || failure.status !== 403 || !failure.body) {
+    return false;
+  }
+  try {
+    if (JSON.parse(failure.body)?.error === COOKIE_MISSING_ERROR) {
+      return true;
+    }
+  } catch {
+    // Not JSON -- fall through to the message check.
+  }
+  return failure.body.includes(COOKIE_MISSING_MESSAGE);
+}
+
+/**
+ * Tells "the cookie is not reaching the backend" apart from "you are signed
+ * out", using two calls the validator already makes -- no extra request.
+ *
+ * The discriminator is the disagreement between them: `auth/oidc/me` accepts
+ * the OIDC Bearer token, while every requireJWT route reads the session
+ * exclusively from the cookie. A live Bearer session alongside a cookie route
+ * that reports no cookie at all means the session is fine and the cookie is
+ * the thing going missing.
+ */
+export function classifyCookieAccess({
+  cookieRouteSucceeded,
+  cookieRouteFailure,
+  bearerSessionValid,
+}: CookieAccessEvidence): CookieAccess {
+  if (cookieRouteSucceeded) {
+    return 'ok';
+  }
+
+  // Without a live Bearer session there is nothing to disagree with: a missing
+  // cookie is equally well explained by the user having signed out.
+  if (bearerSessionValid && saysCookieMissing(cookieRouteFailure)) {
+    return 'blocked';
+  }
+
+  return 'unknown';
+}

--- a/packages/send/frontend/src/lib/cookieAccess.ts
+++ b/packages/send/frontend/src/lib/cookieAccess.ts
@@ -97,6 +97,14 @@ export function classifyCookieAccess({
 
   // Without a live Bearer session there is nothing to disagree with: a missing
   // cookie is equally well explained by the user having signed out.
+  //
+  // Known accepted edge: immediately after a fresh OIDC login (Bearer live, but
+  // the JWT session cookie not yet minted by auth/oidc/me) or right after the
+  // user clears cookies, this also reads as 'blocked'. That is a transient,
+  // self-correcting state -- the next validator run after the cookie is minted
+  // answers 'ok' -- and the "Check again" button the blocked screen offers is
+  // exactly the recovery. Worth flagging rather than papering over with a
+  // heuristic that could suppress a genuine block.
   if (bearerSessionValid && saysCookieMissing(cookieRouteFailure)) {
     return 'blocked';
   }

--- a/packages/send/frontend/src/lib/cookieAccess.ts
+++ b/packages/send/frontend/src/lib/cookieAccess.ts
@@ -79,6 +79,12 @@ function saysCookieMissing(failure: ApiCallFailure | null): boolean {
  * exclusively from the cookie. A live Bearer session alongside a cookie route
  * that reports no cookie at all means the session is fine and the cookie is
  * the thing going missing.
+ *
+ * That last sentence is load-bearing and will stop being true: issue #1191
+ * proposes making those routes accept the Bearer token too, at which point the
+ * cookie leg succeeds on the token and this silently always answers 'ok'. If
+ * you are here doing that migration, this needs a Bearer-suppressed leg or
+ * deleting outright -- see #1191 for both options.
  */
 export function classifyCookieAccess({
   cookieRouteSucceeded,

--- a/packages/send/frontend/src/lib/cookieProbe.ts
+++ b/packages/send/frontend/src/lib/cookieProbe.ts
@@ -1,0 +1,56 @@
+import type { ApiConnection } from './api';
+
+/**
+ * Result of the pre-login cookie round-trip probe.
+ *
+ * Bugzilla 2064458: the Send backend keeps the session in an httpOnly,
+ * SameSite=None cookie. When Thunderbird (or a browser) is set to refuse
+ * third-party cookies, that cookie never reaches the backend and the entire
+ * app is non-functional — not just uploads. After login, `cookieAccess.ts`
+ * can infer a block from the disagreement between the cookie-gated route and
+ * the Bearer route; before login there is no session to infer from, so this
+ * module performs a *positive* round trip instead: ask the backend to set a
+ * throwaway probe cookie with the same SameSite=None; Secure attributes
+ * (`GET /api/cookie-check/set`), then ask whether it came back
+ * (`GET /api/cookie-check/verify`).
+ *
+ * `unknown` exists for the same reason it does in `cookieAccess.ts`: "we could
+ * not tell" must never be surfaced to the user as "your cookies are blocked",
+ * or we send someone off to change a Thunderbird setting that was never the
+ * problem. An offline user, a rate-limited user and a backend too old to have
+ * the probe endpoints all land on 'unknown', and callers must hide the
+ * blocked-cookies warning for it.
+ */
+export type CookieProbeResult = 'enabled' | 'blocked' | 'unknown';
+
+/**
+ * Positively determine whether cookies for the Send backend round-trip.
+ *
+ * Answers 'blocked' only when both probe calls succeeded and the backend
+ * affirmatively reported the probe cookie missing — never on a failed or
+ * inconclusive call. See {@link CookieProbeResult} for why.
+ */
+export async function probeCookiesEnabled(
+  api: ApiConnection
+): Promise<CookieProbeResult> {
+  try {
+    const setResponse = await api.call<{ ok: boolean }>('cookie-check/set');
+    if (!setResponse?.ok) {
+      // The set call failed or answered unexpectedly (e.g. an older backend
+      // without the endpoint): the probe is inconclusive, not a block.
+      return 'unknown';
+    }
+
+    const verifyResponse = await api.call<{ cookiesEnabled: boolean }>(
+      'cookie-check/verify'
+    );
+    if (verifyResponse === null || verifyResponse === undefined) {
+      return 'unknown';
+    }
+
+    return verifyResponse.cookiesEnabled ? 'enabled' : 'blocked';
+  } catch {
+    // Network failures and thrown errors are inconclusive by definition.
+    return 'unknown';
+  }
+}

--- a/packages/send/frontend/src/lib/messages.ts
+++ b/packages/send/frontend/src/lib/messages.ts
@@ -10,4 +10,17 @@ export const CLIENT_MESSAGES = {
   FILE_TOO_BIG: `Your file size is not supported, please try with files smaller than ${MAX_FILE_SIZE_HUMAN_READABLE}`,
   UPLOAD_FAILED: `Upload failed. Please try again.`,
   STORAGE_LIMIT_EXCEEDED: `Uploading this file would exceed your storage limit. Please delete some files and try again.`,
+
+  // Bugzilla 2064458. The backend host is deliberately not named: it changes
+  // between production, staging and local builds, and the setting path is the
+  // part the user can act on.
+  COOKIES_BLOCKED_TITLE: `Thunderbird is blocking cookies for Send`,
+  COOKIES_BLOCKED_BODY:
+    `Send stores a cookie to keep you signed in, and Thunderbird is currently ` +
+    `refusing it. Open Settings → Privacy & Security → Web Content and turn on ` +
+    `"Accept cookies from sites". If that is already on, also set "Accept ` +
+    `third-party cookies" to "From visited". Then choose "Check again".`,
+  SETUP_CHECK_FAILED: `Send couldn't check whether your account is ready to upload. Check your internet connection, then choose "Check again".`,
+  SETUP_DID_NOT_COMPLETE: `Setup didn't finish last time. Choose "Continue Setup" to try again.`,
+  SIGNED_OUT_RETURN_TO_COMPOSE: `You're not signed in to Send. Go back to the compose window and sign in again to continue this upload.`,
 };

--- a/packages/send/frontend/src/lib/messages.ts
+++ b/packages/send/frontend/src/lib/messages.ts
@@ -20,6 +20,13 @@ export const CLIENT_MESSAGES = {
     `refusing it. Open Settings → Privacy & Security → Web Content and turn on ` +
     `"Accept cookies from sites". If that is already on, also set "Accept ` +
     `third-party cookies" to "From visited". Then choose "Check again".`,
+  // Passive login-banner variant of COOKIES_BLOCKED_BODY: the banner offers a
+  // "Retry" button instead of the popup's "Check again" wording.
+  COOKIES_BLOCKED_BANNER_BODY:
+    `Send stores a cookie to keep you signed in, and your browser is currently ` +
+    `refusing it. Open Settings → Privacy & Security → Web Content and turn on ` +
+    `"Accept cookies from sites". If that is already on, also set "Accept ` +
+    `third-party cookies" to "From visited". Then choose "Retry".`,
   SETUP_CHECK_FAILED: `Send couldn't check whether your account is ready to upload. Check your internet connection, then choose "Check again".`,
   SETUP_DID_NOT_COMPLETE: `Setup didn't finish last time. Choose "Continue Setup" to try again.`,
   SIGNED_OUT_RETURN_TO_COMPOSE: `You're not signed in to Send. Go back to the compose window and sign in again to continue this upload.`,

--- a/packages/send/frontend/src/lib/uploadReadiness.ts
+++ b/packages/send/frontend/src/lib/uploadReadiness.ts
@@ -1,0 +1,65 @@
+import { CookieAccess, isCookieAccessBlocked } from './cookieAccess';
+
+/**
+ * Why the upload popup cannot start an upload yet.
+ *
+ * This used to be a boolean, which could only say "not ready" -- so every
+ * cause was funnelled into the passphrase setup flow, including the users
+ * whose problem that flow cannot fix. Bugzilla 2064458.
+ */
+export type UploadReadiness =
+  | { status: 'ready' }
+  // A live session, but the session cookie never reaches the backend.
+  | { status: 'cookies-blocked' }
+  | { status: 'signed-out' }
+  // Positively no key backup: the one state the setup window can fix.
+  | { status: 'needs-setup' }
+  // Could not determine: offline, a server error, or rate-limited.
+  | { status: 'unknown' };
+
+export type UploadBlocker = Exclude<UploadReadiness, { status: 'ready' }>;
+
+type ValidatorAnswer = {
+  hasBackedUpKeys: boolean;
+  isTokenValid: boolean;
+  hasForcedLogin: boolean;
+  cookieAccess: CookieAccess;
+};
+
+/**
+ * Picks which blocker to report from a `validator()` answer, or null when
+ * nothing is blocking the upload.
+ *
+ * The rule holding this together: no cookie-authenticated answer may be
+ * believed until we know the cookie is getting through, because when it is not,
+ * all of them are false -- `hasBackedUpKeys` included. Reading those first is
+ * what turned a cookie problem into a fabricated missing passphrase.
+ */
+export function findUploadBlocker({
+  hasBackedUpKeys,
+  isTokenValid,
+  hasForcedLogin,
+  cookieAccess,
+}: ValidatorAnswer): UploadBlocker | null {
+  if (isCookieAccessBlocked(cookieAccess)) {
+    return { status: 'cookies-blocked' };
+  }
+
+  // Only claim "signed out" on positive evidence: the validator forced a
+  // logout, or the cookie route answered fine while the token check did not.
+  // Otherwise it is the check itself that failed, and telling an offline user
+  // to sign in again sends them somewhere that cannot work.
+  if (hasForcedLogin || (cookieAccess === 'ok' && !isTokenValid)) {
+    return { status: 'signed-out' };
+  }
+
+  if (cookieAccess === 'unknown') {
+    return { status: 'unknown' };
+  }
+
+  if (!hasBackedUpKeys) {
+    return { status: 'needs-setup' };
+  }
+
+  return null;
+}

--- a/packages/send/frontend/src/lib/validations.ts
+++ b/packages/send/frontend/src/lib/validations.ts
@@ -1,7 +1,8 @@
 import type { UserStoreType as UserStore } from '@send-frontend/stores/user-store';
 import { UserType } from '@send-frontend/types';
-import { ApiConnection } from './api';
+import { ApiCallFailure, ApiConnection } from './api';
 import { MAX_ACCESS_LINK_RETRIES } from './const';
+import { CookieAccess, classifyCookieAccess } from './cookieAccess';
 import { Keychain, restoreKeysUsingLocalStorage } from './keychain';
 import { trpc } from './trpc';
 
@@ -78,10 +79,19 @@ export const validateToken = async (api: ApiConnection): Promise<boolean> => {
 };
 
 export const validateUser = async (
-  api: ApiConnection
+  api: ApiConnection,
+  // `call` returns a bare null on failure, so the caller has to be handed the
+  // reason: it is the evidence classifyCookieAccess needs.
+  onFailure?: (failure: ApiCallFailure) => void
 ): Promise<{ user: UserType } | null> => {
   try {
-    const userResponse = await api.call<{ user: UserType }>(`users/me`);
+    const userResponse = await api.call<{ user: UserType }>(
+      `users/me`,
+      {},
+      'GET',
+      {},
+      { onFailure }
+    );
     if (userResponse?.user) {
       return userResponse;
     }
@@ -129,11 +139,20 @@ export const validator = async ({
     hasCorrectKeys: false,
     // Flag used to force login
     hasForcedLogin: false,
+    // Whether the session cookie is reaching the backend at all. See
+    // classifyCookieAccess; stays 'unknown' on the paths that cannot tell.
+    cookieAccess: 'unknown' as CookieAccess,
   };
 
   let shouldClearSessionAndStorage = false;
 
-  const userResponse = await validateUser(api);
+  // A property rather than a plain `let`: TypeScript does not track assignments
+  // made inside a callback, so a `let` here would be narrowed to `null` at the
+  // point it is read below and any inspection of it would fail to compile.
+  const cookieRoute: { failure: ApiCallFailure | null } = { failure: null };
+  const userResponse = await validateUser(api, (failure) => {
+    cookieRoute.failure = failure;
+  });
   const userIDFromBackend = userResponse?.user?.id;
   const userIDFromStore = userStore?.user?.id;
 
@@ -175,6 +194,16 @@ export const validator = async ({
       userStore.getBackup,
       keychain
     );
+
+    // Must come after isTokenValid: the Bearer session is half of the evidence.
+    // On the user-ID-mismatch branch above isTokenValid is never assigned, so
+    // cookieAccess stays 'unknown' there -- that path already forces a logout
+    // and must not be relabelled a cookie problem.
+    validations.cookieAccess = classifyCookieAccess({
+      cookieRouteSucceeded: !!userResponse?.user,
+      cookieRouteFailure: cookieRoute.failure,
+      bearerSessionValid: validations.isTokenValid,
+    });
   }
 
   // Finally, if we should flush data, we will do so

--- a/packages/send/frontend/src/test/lib/cookieAccess.test.ts
+++ b/packages/send/frontend/src/test/lib/cookieAccess.test.ts
@@ -1,0 +1,199 @@
+import type { ApiCallFailure } from '@send-frontend/lib/api';
+import {
+  classifyCookieAccess,
+  isCookieAccessBlocked,
+} from '@send-frontend/lib/cookieAccess';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Bugzilla 2064458 -- the Send add-on showed "Finish setting up Send" forever,
+ * with no error, when Thunderbird blocked third-party cookies. Every
+ * requireJWT-gated route reads the session only from the `authorization`
+ * cookie, so a blocked cookie looks like a signed-out user unless something
+ * compares it against the Bearer route that still works.
+ *
+ * The trap these tests exist to guard is that requireJWT's *status* is not
+ * enough: it answers 403 for an expired refresh cookie and 401 for an expired
+ * access cookie, and both of those prove the cookie arrived. Only the
+ * `token_not_found` answer means no cookie reached the server.
+ */
+
+const httpFailure = (status: number, body?: string): ApiCallFailure => ({
+  kind: 'http',
+  status,
+  statusText: 'Forbidden',
+  body,
+});
+
+const noCookie = httpFailure(
+  403,
+  JSON.stringify({
+    message: 'Not authorized: Token not found',
+    error: 'token_not_found',
+  })
+);
+
+describe('classifyCookieAccess — Bugzilla 2064458 (session cookie never reaches the backend)', () => {
+  it('reports blocked when the Bearer session is live and the cookie route says no cookie arrived', () => {
+    expect(
+      classifyCookieAccess({
+        cookieRouteSucceeded: false,
+        cookieRouteFailure: noCookie,
+        bearerSessionValid: true,
+      })
+    ).toBe('blocked');
+  });
+
+  it('reports blocked from the message alone, for a backend too old to send the error code', () => {
+    expect(
+      classifyCookieAccess({
+        cookieRouteSucceeded: false,
+        cookieRouteFailure: httpFailure(
+          403,
+          JSON.stringify({ message: 'Not authorized: Token not found' })
+        ),
+        bearerSessionValid: true,
+      })
+    ).toBe('blocked');
+  });
+
+  it('reports unknown for a 401, because requireJWT only answers 401 after verifying a refresh cookie that did arrive', () => {
+    expect(
+      classifyCookieAccess({
+        cookieRouteSucceeded: false,
+        cookieRouteFailure: httpFailure(
+          401,
+          JSON.stringify({
+            message: 'Not authorized: Token expired',
+            error: 'access_token_expired',
+          })
+        ),
+        bearerSessionValid: true,
+      })
+    ).toBe('unknown');
+  });
+
+  it('reports unknown for a 401 even if its body mentions a missing token, because the message fallback is a substring match and only 403 can mean no cookie', () => {
+    expect(
+      classifyCookieAccess({
+        cookieRouteSucceeded: false,
+        cookieRouteFailure: httpFailure(401, 'Not authorized: Token not found'),
+        bearerSessionValid: true,
+      })
+    ).toBe('unknown');
+  });
+
+  it('reports unknown when the refresh cookie merely expired, since that cookie plainly reached the server', () => {
+    expect(
+      classifyCookieAccess({
+        cookieRouteSucceeded: false,
+        cookieRouteFailure: httpFailure(
+          403,
+          JSON.stringify({
+            message: 'Not authorized: Refresh token expired',
+            error: 'refresh_token_expired',
+          })
+        ),
+        bearerSessionValid: true,
+      })
+    ).toBe('unknown');
+  });
+
+  it('reports ok when the cookie-gated route returned a body', () => {
+    expect(
+      classifyCookieAccess({
+        cookieRouteSucceeded: true,
+        cookieRouteFailure: null,
+        bearerSessionValid: true,
+      })
+    ).toBe('ok');
+  });
+
+  it('reports ok even when the Bearer session looks dead, because a cookie that worked is proof enough on its own', () => {
+    expect(
+      classifyCookieAccess({
+        cookieRouteSucceeded: true,
+        cookieRouteFailure: null,
+        bearerSessionValid: false,
+      })
+    ).toBe('ok');
+  });
+
+  it('reports unknown when no cookie arrived but the Bearer session is not live either, so a signed-out user is never told to change a cookie setting', () => {
+    expect(
+      classifyCookieAccess({
+        cookieRouteSucceeded: false,
+        cookieRouteFailure: noCookie,
+        bearerSessionValid: false,
+      })
+    ).toBe('unknown');
+  });
+
+  it('reports unknown when the cookie-gated route failed with a status that says nothing about the cookie', () => {
+    for (const status of [404, 429, 500, 502]) {
+      expect(
+        classifyCookieAccess({
+          cookieRouteSucceeded: false,
+          cookieRouteFailure: httpFailure(status, 'Token not found'),
+          bearerSessionValid: true,
+        })
+      ).toBe('unknown');
+    }
+  });
+
+  it('reports unknown when the cookie-gated route failed with a network error rather than a response', () => {
+    expect(
+      classifyCookieAccess({
+        cookieRouteSucceeded: false,
+        cookieRouteFailure: {
+          kind: 'network',
+          status: null,
+          error: new Error('offline'),
+        },
+        bearerSessionValid: true,
+      })
+    ).toBe('unknown');
+  });
+
+  it('reports unknown when the cookie-gated route was rate limited', () => {
+    expect(
+      classifyCookieAccess({
+        cookieRouteSucceeded: false,
+        cookieRouteFailure: {
+          kind: 'rate_limited',
+          status: 429,
+          retryAfterMs: 1000,
+        },
+        bearerSessionValid: true,
+      })
+    ).toBe('unknown');
+  });
+
+  it('reports unknown when the cookie-gated route failed without recording why', () => {
+    expect(
+      classifyCookieAccess({
+        cookieRouteSucceeded: false,
+        cookieRouteFailure: null,
+        bearerSessionValid: true,
+      })
+    ).toBe('unknown');
+  });
+
+  it('reports unknown when a 403 carried no body to identify it', () => {
+    expect(
+      classifyCookieAccess({
+        cookieRouteSucceeded: false,
+        cookieRouteFailure: httpFailure(403),
+        bearerSessionValid: true,
+      })
+    ).toBe('unknown');
+  });
+});
+
+describe('isCookieAccessBlocked — Bugzilla 2064458', () => {
+  it('is true only for the blocked state, so an undetermined check never sends the user to change a setting', () => {
+    expect(isCookieAccessBlocked('blocked')).toBe(true);
+    expect(isCookieAccessBlocked('unknown')).toBe(false);
+    expect(isCookieAccessBlocked('ok')).toBe(false);
+  });
+});

--- a/packages/send/frontend/src/test/lib/uploadReadiness.test.ts
+++ b/packages/send/frontend/src/test/lib/uploadReadiness.test.ts
@@ -1,0 +1,75 @@
+import { findUploadBlocker } from '@send-frontend/lib/uploadReadiness';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Bugzilla 2064458. The order these are read in is the fix: when the session
+ * cookie is not reaching the backend, every cookie-authenticated answer the
+ * validator produces is false -- including `hasBackedUpKeys` -- so reading them
+ * in the wrong order reports a fabricated missing passphrase and opens a setup
+ * window that cannot help.
+ */
+
+const healthy = {
+  hasBackedUpKeys: true,
+  isTokenValid: true,
+  hasForcedLogin: false,
+  cookieAccess: 'ok' as const,
+};
+
+describe('findUploadBlocker — Bugzilla 2064458', () => {
+  it('lets a healthy account through with nothing blocking it', () => {
+    expect(findUploadBlocker(healthy)).toBeNull();
+  });
+
+  it('reports blocked cookies ahead of the missing key backup, which cannot be trusted while the cookie is missing', () => {
+    expect(
+      findUploadBlocker({
+        ...healthy,
+        cookieAccess: 'blocked',
+        hasBackedUpKeys: false,
+        isTokenValid: false,
+      })
+    ).toEqual({ status: 'cookies-blocked' });
+  });
+
+  it('reports signed out when the cookie route answered fine but the token check did not', () => {
+    expect(findUploadBlocker({ ...healthy, isTokenValid: false })).toEqual({
+      status: 'signed-out',
+    });
+  });
+
+  it('reports signed out when the validator forced a logout', () => {
+    expect(findUploadBlocker({ ...healthy, hasForcedLogin: true })).toEqual({
+      status: 'signed-out',
+    });
+  });
+
+  it('reports an undetermined check, not a signed-out session, when the checks themselves could not answer', () => {
+    // An offline user: nothing answered, so `isTokenValid` is false too.
+    // Telling them to sign in again sends them somewhere that cannot work.
+    expect(
+      findUploadBlocker({
+        ...healthy,
+        cookieAccess: 'unknown',
+        isTokenValid: false,
+        hasBackedUpKeys: false,
+      })
+    ).toEqual({ status: 'unknown' });
+  });
+
+  it('reports an undetermined check ahead of the missing key backup', () => {
+    expect(
+      findUploadBlocker({
+        ...healthy,
+        cookieAccess: 'unknown',
+        hasBackedUpKeys: false,
+      })
+    ).toEqual({ status: 'unknown' });
+  });
+
+  it('reports needs-setup only once the cookie is fine, the session is live and the key backup is genuinely missing', () => {
+    expect(findUploadBlocker({ ...healthy, hasBackedUpKeys: false })).toEqual({
+      status: 'needs-setup',
+    });
+  });
+});

--- a/packages/send/frontend/src/test/lib/validations.test.ts
+++ b/packages/send/frontend/src/test/lib/validations.test.ts
@@ -284,6 +284,7 @@ describe('validator', () => {
       isTokenValid: true,
       hasCorrectKeys: true,
       hasForcedLogin: false,
+      cookieAccess: 'ok',
     });
   });
 
@@ -350,9 +351,128 @@ describe('validator', () => {
       isTokenValid: false, // No auth validation done when keys are invalid
       hasCorrectKeys: false,
       hasForcedLogin: true,
+      cookieAccess: 'ok', // users/me answered, so the cookie is arriving
     });
 
     reloadSpy.mockRestore();
+  });
+
+  /**
+   * Bugzilla 2064458. `users/me` is gated by requireJWT, which reads the
+   * session only from the `authorization` cookie; `auth/me` / `auth/oidc/me`
+   * stand in for the leg that still answers. The validator's job here is to
+   * carry the *reason* users/me failed into the classifier -- it used to throw
+   * that away, which is why a blocked cookie was indistinguishable from a
+   * signed-out user.
+   */
+  describe('cookie access', () => {
+    /** requireJWT's answer when no cookie reached the server. */
+    const noCookieBody = JSON.stringify({
+      message: 'Not authorized: Token not found',
+      error: 'token_not_found',
+    });
+
+    /** Fails `users/me` as "no cookie", answers every other path successfully. */
+    const refuseUsersMe = () =>
+      vi.fn(
+        async (
+          path: string,
+          _body?: unknown,
+          _method?: string,
+          _headers?: unknown,
+          options?: { onFailure?: (f: unknown) => void }
+        ) => {
+          if (path === 'users/me') {
+            options?.onFailure?.({
+              kind: 'http',
+              status: 403,
+              statusText: 'Forbidden',
+              body: noCookieBody,
+            });
+            return null;
+          }
+          return true;
+        }
+      );
+
+    it('reports the cookie as blocked when users/me says no cookie arrived while the token check still passes', async () => {
+      mockApi.call = refuseUsersMe() as unknown as MockedFunction<
+        ApiConnection['call']
+      >;
+
+      const result = await (
+        await import('@send-frontend/lib/validations')
+      ).validator({
+        api: mockApi as unknown as ApiConnection,
+        userStore: mockUserStore as UserStore,
+        keychain: mockKeychain as unknown as Keychain,
+      });
+
+      expect(result.isTokenValid).toBe(true);
+      expect(result.cookieAccess).toBe('blocked');
+    });
+
+    it('reports the cookie as unknown when users/me says no cookie arrived and the token check fails too, because that is just a signed-out user', async () => {
+      mockApi.call = vi.fn(
+        async (
+          path: string,
+          _body?: unknown,
+          _method?: string,
+          _headers?: unknown,
+          options?: { onFailure?: (f: unknown) => void }
+        ) => {
+          if (path === 'users/me') {
+            options?.onFailure?.({
+              kind: 'http',
+              status: 403,
+              statusText: 'Forbidden',
+              body: noCookieBody,
+            });
+          }
+          return null;
+        }
+      ) as unknown as MockedFunction<ApiConnection['call']>;
+
+      const result = await (
+        await import('@send-frontend/lib/validations')
+      ).validator({
+        api: mockApi as unknown as ApiConnection,
+        userStore: mockUserStore as UserStore,
+        keychain: mockKeychain as unknown as Keychain,
+      });
+
+      expect(result.isTokenValid).toBe(false);
+      expect(result.cookieAccess).toBe('unknown');
+    });
+
+    it('determines cookie access without issuing any request beyond the ones the validator already made', async () => {
+      // The whole design rests on this: the answer is read off calls the
+      // validator makes anyway, so the popup pays nothing for it. If someone
+      // turns the classifier into an active probe, this is what fails.
+      const runWith = async (call: MockedFunction<ApiConnection['call']>) => {
+        mockApi.call = call;
+        await (
+          await import('@send-frontend/lib/validations')
+        ).validator({
+          api: mockApi as unknown as ApiConnection,
+          userStore: mockUserStore as UserStore,
+          keychain: mockKeychain as unknown as Keychain,
+        });
+        return call.mock.calls.length;
+      };
+
+      const okCalls = await runWith(
+        vi.fn().mockResolvedValue({ user: { id: '123' } }) as MockedFunction<
+          ApiConnection['call']
+        >
+      );
+      const blockedCalls = await runWith(
+        refuseUsersMe() as unknown as MockedFunction<ApiConnection['call']>
+      );
+
+      expect(okCalls).toBe(2); // users/me, then auth/me
+      expect(blockedCalls).toBe(okCalls);
+    });
   });
 
   // This tests the case where the user ID is not found in the backend.
@@ -371,6 +491,9 @@ describe('validator', () => {
       isTokenValid: false,
       hasCorrectKeys: true,
       hasForcedLogin: false,
+      // users/me threw, so onFailure never fired and there is no evidence
+      // either way -- never guess "blocked" from an absent failure.
+      cookieAccess: 'unknown',
     });
   });
 });


### PR DESCRIPTION
## What this fixes

When Thunderbird is set to refuse third-party cookies, Send's upload popup got stuck on "Finish setting up Send" forever — and kept reopening a passphrase window that closed itself instantly, with no error message. ([Bugzilla 2064458](https://bugzilla.mozilla.org/show_bug.cgi?id=2064458), full trace in #1192.)

This PR does two things:
1. **Makes Send work** when third-party cookies are blocked.
2. **Explains the problem clearly** in the one case that can't be fixed automatically (cookies turned off entirely), instead of trapping the user in a loop.

## Why it broke

The add-on's UI runs from a `moz-extension://` page and stays signed in with a session cookie. Firefox only treats that cookie as first-party if the extension declares a **host permission** for the backend ([Firefox bug 1629436](https://bugzilla.mozilla.org/show_bug.cgi?id=1629436)) — and we never declared one.

It went unnoticed because the backend allows any extension origin via CORS, so the network requests *succeeded* — only the cookie silently went missing. That's invisible until a user changes a cookie setting.

## The changes, in plain terms

**1. Add the missing host permission** (`manifest.json`)
Declares `https://send-backend.tb.pro/*`. This one line is the actual fix — with it, the session cookie survives even when third-party cookies are blocked.

- Production host only (the system add-on ships no staging build). A stage build would still need its own host added — one-line follow-up if we ever test stage with cookies blocked.
- Also restored the dev `localhost` host permissions, but **without a port** (`http://localhost/*`, `https://localhost/*`). Match patterns can't carry a port ([bug 1362809](https://bugzil.la/1362809)), so the old `http://localhost:5173/*` was silently granting nothing; the portless form actually works for local dev.

**2. Tell "blocked cookie" apart from "signed out"** (`cookieAccess.ts`)
The backend now returns distinct error codes so the add-on can tell *why* a request was rejected:
- `token_not_found` → no cookie arrived (this is the blocked-cookie case)
- `access_token_expired` / `refresh_token_expired` → a cookie *did* arrive, it's just stale

This matters: keying on the HTTP status alone would flag every routine hour-old session as "cookies blocked," because expired sessions also return 401/403. The check reuses two calls the app already makes, so it costs **zero extra network requests**.

**3. Fix the popup** (`PopupView.vue`)
- Blocked cookies now show a clear, actionable message instead of the passphrase prompt.
- An offline user is told to check their connection — not sent to sign in again.
- No "Continue Setup" button when cookies are blocked (that flow can't fix it).
- The setup window can now only auto-open **once**, so it can't flap.

## How to test this (reviewer checklist)

**Automated (already green):**
```
# from repo root
pnpm --filter send-frontend test    # 456 pass (62 in the new/changed suites)
pnpm --filter addon test            # manifest + addon suites
```

**Manual — in Thunderbird (this is the important part).**
The manifest fix is documented behavior but I haven't verified it on a running Thunderbird build. Please run these with a build of this branch. Set the cookie mode via `about:config` → `network.cookie.cookieBehavior`.

| # | `cookieBehavior` | What it means | Expected result |
|---|---|---|---|
| 1 | `1` on **current `main`** | block third-party cookies | Reproduces the bug: popup loops, `403` on `api/users/me`, `200` on `api/auth/oidc/me` in the Browser Console |
| 2 | `1` on **this branch** | block third-party cookies | `api/users/me` returns `200` and an upload **runs to completion** — actually attach a file (uploads use the same auth, so a partial fix only shows here) |
| 3 | `2` on this branch | cookies off entirely | Host permission can't help; the **new blocked-cookies message** appears, with no window flapping |
| 4 | `0` on this branch | allow all cookies | Happy path, unaffected |

> If step 2 fails, the manifest half is worthless and the real fix is #1191. Steps 2 and 3 (the detection + messaging) are worth keeping either way.

**Also please check the copy against the real Settings pane.** The blocked-cookies message names "Settings → Privacy & Security → Web Content" and "Accept cookies from sites". I haven't seen those exact labels on screen — a message that names a UI path is only useful if the path is right.

## Tests added

- `cookieAccess.test.ts` — 14 cases. The important ones are the negatives: an expired token and a missing-cookie-with-no-live-session must **never** be reported as "blocked."
- `uploadReadiness.test.ts` — the precedence logic (blocked > signed-out > unknown > needs-setup > ready).
- `PopupView.test.ts` — which message renders for each state, and the anti-flap guard.
- `validations.test.ts` — the wiring, plus a guard pinning the "no extra requests" promise.
- `manifest-match-patterns.test.ts` — asserts the backend host permission exists, no permission carries a port, and the dev localhost permissions stay portless.
- Backend: the new error codes are asserted on the existing `requireJWT` tests.

## Known limitations / follow-ups

- **Not yet verified in Thunderbird** — see the manual checklist above.
- **Stage builds** still need their own host permission added (production-only for now).
- Local dev can't reproduce this (dev backend is `https://localhost:8088`, no localhost host permission is granted there).
- The new backend error codes should reach production before an add-on build relies on them. A message-substring fallback covers older backends, so it's not a hard ordering requirement.
- Follow-up #1191 would make `requireJWT` accept the Bearer token, removing the cookie dependency entirely (and would retire `cookieAccess.ts` — cross-referenced in both directions).

## AI disclosure

Agent-written (Claude) and human-directed throughout — scope, the production-only permission call, and the no-new-permission/no-new-endpoint detection approach were all human decisions and reviewed step by step. An automated review pass caught a real correctness bug in the first version of the classifier (it keyed on HTTP status and would have falsely blamed Thunderbird on any hour-old session); mutation testing caught two more weak spots. All three are fixed and pinned.

## Closes

Closes #1192. Follow-up in #1191.
