### PR TITLE
feat(send): detect blocked cookies and tell the user before the app fails to load

### DIFF
--- a/packages/send/backend/src/routes/index.ts
+++ b/packages/send/backend/src/routes/index.ts
@@ -132,6 +132,9 @@ const COOKIE_PROBE_MAX_AGE_MS = 60_000;
  *                   example: true
  */
 router.get('/api/cookie-check/set', (_, res) => {
+  // Never from cache: a replayed answer without its Set-Cookie would make
+  // `verify` report a block that never happened.
+  res.set('Cache-Control', 'no-store');
   res.cookie(COOKIE_PROBE_NAME, '1', {
     maxAge: COOKIE_PROBE_MAX_AGE_MS,
     // Matches the session cookie's attributes as closely as possible so the
@@ -167,6 +170,7 @@ router.get('/api/cookie-check/set', (_, res) => {
  *                   example: true
  */
 router.get('/api/cookie-check/verify', (req, res) => {
+  res.set('Cache-Control', 'no-store');
   res.status(200).json({
     cookiesEnabled: Boolean(req.cookies?.[COOKIE_PROBE_NAME]),
   });

--- a/packages/send/backend/src/routes/index.ts
+++ b/packages/send/backend/src/routes/index.ts
@@ -98,4 +98,78 @@ router.get('/api/health', (_, res) => {
   });
 });
 
+// Bugzilla 2064458: when Thunderbird refuses third-party cookies, the httpOnly
+// SameSite=None session cookie (see auth/client.ts registerAuthToken) never
+// reaches the backend and the entire app is non-functional. Pre-login there is
+// no session to infer from, so the frontend performs a positive round-trip
+// probe: `set` plants a throwaway cookie with the *same* SameSite=None; Secure
+// attributes as the real session cookie, and `verify` reports whether it came
+// back. Both routes are unauthenticated by design.
+const COOKIE_PROBE_NAME = 'send_cookie_probe';
+const COOKIE_PROBE_MAX_AGE_MS = 60_000;
+
+/**
+ * @openapi
+ * /api/cookie-check/set:
+ *   get:
+ *     tags:
+ *       - Health
+ *     summary: Set the cookie probe
+ *     description: >
+ *       Sets a short-lived probe cookie with the same SameSite=None; Secure
+ *       attributes as the session cookie, so the client can verify whether
+ *       cookies for this backend are being blocked (Bugzilla 2064458).
+ *     responses:
+ *       200:
+ *         description: Probe cookie set
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 ok:
+ *                   type: boolean
+ *                   example: true
+ */
+router.get('/api/cookie-check/set', (_, res) => {
+  res.cookie(COOKIE_PROBE_NAME, '1', {
+    maxAge: COOKIE_PROBE_MAX_AGE_MS,
+    // Matches the session cookie's attributes as closely as possible so the
+    // probe faithfully tests the same blocking behavior.
+    httpOnly: true,
+    sameSite: 'none',
+    secure: true,
+  });
+  res.status(200).json({ ok: true });
+});
+
+/**
+ * @openapi
+ * /api/cookie-check/verify:
+ *   get:
+ *     tags:
+ *       - Health
+ *     summary: Verify the cookie probe round-trip
+ *     description: >
+ *       Reports whether the probe cookie set by /api/cookie-check/set was sent
+ *       back by the client, i.e. whether cookies for this backend are enabled
+ *       (Bugzilla 2064458).
+ *     responses:
+ *       200:
+ *         description: Probe result
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 cookiesEnabled:
+ *                   type: boolean
+ *                   example: true
+ */
+router.get('/api/cookie-check/verify', (req, res) => {
+  res.status(200).json({
+    cookiesEnabled: Boolean(req.cookies?.[COOKIE_PROBE_NAME]),
+  });
+});
+
 export default router;

--- a/packages/send/backend/src/test/routes/cookie-check.routes.test.ts
+++ b/packages/send/backend/src/test/routes/cookie-check.routes.test.ts
@@ -25,6 +25,7 @@ describe('GET /api/cookie-check', () => {
 
     expect(response.status).toBe(200);
     expect(response.body).toEqual({ ok: true });
+    expect(response.headers['cache-control']).toBe('no-store');
 
     const setCookie = response.headers['set-cookie'];
     expect(setCookie).toBeDefined();
@@ -45,6 +46,7 @@ describe('GET /api/cookie-check', () => {
       .set('Cookie', 'send_cookie_probe=1');
 
     expect(response.status).toBe(200);
+    expect(response.headers['cache-control']).toBe('no-store');
     expect(response.body).toEqual({ cookiesEnabled: true });
   });
 

--- a/packages/send/backend/src/test/routes/cookie-check.routes.test.ts
+++ b/packages/send/backend/src/test/routes/cookie-check.routes.test.ts
@@ -1,0 +1,57 @@
+import cookieParser from 'cookie-parser';
+import express from 'express';
+import request from 'supertest';
+import { describe, expect, it } from 'vitest';
+
+import router from '../../routes';
+
+// Mirrors the real app: cookieParser is applied app-wide (src/index.ts) and the
+// index router is mounted at '/'. These routes need no DB, auth or storage.
+const app = express();
+app.use(cookieParser());
+app.use('/', router);
+
+/**
+ * Bugzilla 2064458: pre-login there is no session to infer blocked cookies
+ * from, so the frontend runs a positive round-trip probe against these two
+ * unauthenticated routes. The probe cookie must carry the same SameSite=None;
+ * Secure attributes as the real session cookie (auth/client.ts
+ * registerAuthToken) or it would not test the same blocking behavior — the
+ * attribute assertions below pin that.
+ */
+describe('GET /api/cookie-check', () => {
+  it('set plants the probe cookie with the session cookie attributes', async () => {
+    const response = await request(app).get('/api/cookie-check/set');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ ok: true });
+
+    const setCookie = response.headers['set-cookie'];
+    expect(setCookie).toBeDefined();
+    const probeCookie = [setCookie]
+      .flat()
+      .find((cookie) => cookie.startsWith('send_cookie_probe='));
+    expect(probeCookie).toBeDefined();
+    // Same attributes as the real session cookie, so the probe faithfully
+    // tests the same blocking behavior.
+    expect(probeCookie).toContain('SameSite=None');
+    expect(probeCookie).toContain('Secure');
+    expect(probeCookie).toContain('HttpOnly');
+  });
+
+  it('verify answers cookiesEnabled:true when the probe cookie comes back', async () => {
+    const response = await request(app)
+      .get('/api/cookie-check/verify')
+      .set('Cookie', 'send_cookie_probe=1');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ cookiesEnabled: true });
+  });
+
+  it('verify answers cookiesEnabled:false when no probe cookie arrives', async () => {
+    const response = await request(app).get('/api/cookie-check/verify');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ cookiesEnabled: false });
+  });
+});

--- a/packages/send/frontend/src/apps/common/CookiesBlockedBanner.test.ts
+++ b/packages/send/frontend/src/apps/common/CookiesBlockedBanner.test.ts
@@ -1,0 +1,94 @@
+import { getByTestId } from '@send-frontend/lib/testUtils';
+import { mount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import CookiesBlockedBanner from './CookiesBlockedBanner.vue';
+
+const { probeResult, refetchMock } = vi.hoisted(() => {
+  return { probeResult: vi.fn(), refetchMock: vi.fn() };
+});
+
+vi.mock('@send-frontend/stores/api-store', () => ({
+  default: () => ({
+    api: { call: vi.fn() },
+  }),
+}));
+
+// Mock vue-query — the component only reads `data` and calls `refetch`.
+vi.mock('@tanstack/vue-query', () => ({
+  useQuery: () => {
+    return {
+      data: { value: probeResult() },
+      refetch: refetchMock,
+    };
+  },
+}));
+
+/**
+ * Bugzilla 2064458: the banner must only ever appear on a *positive* 'blocked'
+ * probe answer. 'unknown' (offline user, older backend) and loading states
+ * stay hidden — a false blocked-cookies warning sends users to change a
+ * Thunderbird setting that was never the problem.
+ */
+describe('CookiesBlockedBanner.vue', () => {
+  beforeEach(() => {
+    probeResult.mockReturnValue('blocked');
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows the banner when the probe answers blocked', () => {
+    const wrapper = mount(CookiesBlockedBanner);
+
+    expect(wrapper.find(getByTestId('cookies-blocked-banner')).exists()).toBe(
+      true
+    );
+    expect(
+      wrapper.find(getByTestId('cookies-blocked-banner-body')).exists()
+    ).toBe(true);
+  });
+
+  it('hides the banner when the probe answers enabled', () => {
+    probeResult.mockReturnValue('enabled');
+    const wrapper = mount(CookiesBlockedBanner);
+
+    expect(wrapper.find(getByTestId('cookies-blocked-banner')).exists()).toBe(
+      false
+    );
+  });
+
+  it('hides the banner when the probe is inconclusive (unknown)', () => {
+    probeResult.mockReturnValue('unknown');
+    const wrapper = mount(CookiesBlockedBanner);
+
+    expect(wrapper.find(getByTestId('cookies-blocked-banner')).exists()).toBe(
+      false
+    );
+  });
+
+  it('hides the banner while the probe is still loading', () => {
+    probeResult.mockReturnValue(undefined);
+    const wrapper = mount(CookiesBlockedBanner);
+
+    expect(wrapper.find(getByTestId('cookies-blocked-banner')).exists()).toBe(
+      false
+    );
+  });
+
+  it('is not dismissible (no close button)', () => {
+    const wrapper = mount(CookiesBlockedBanner);
+
+    expect(wrapper.find(getByTestId('close-button')).exists()).toBe(false);
+  });
+
+  it('retry button refetches the probe query', async () => {
+    const wrapper = mount(CookiesBlockedBanner);
+
+    await wrapper
+      .find(getByTestId('cookies-blocked-banner-retry'))
+      .trigger('click');
+
+    expect(refetchMock).toHaveBeenCalled();
+  });
+});

--- a/packages/send/frontend/src/apps/common/CookiesBlockedBanner.vue
+++ b/packages/send/frontend/src/apps/common/CookiesBlockedBanner.vue
@@ -1,0 +1,68 @@
+<script lang="ts" setup>
+/**
+ * Login-screen banner for blocked cookies (Bugzilla 2064458).
+ *
+ * The Send backend keeps the session in an httpOnly, SameSite=None cookie;
+ * when the browser/Thunderbird refuses it, the entire app is non-functional.
+ * The post-login detection in `cookieAccess.ts` needs a live session to infer
+ * from, so this banner runs the positive pre-login round-trip probe in
+ * `cookieProbe.ts` instead and warns before the user even attempts to log in.
+ *
+ * Deliberately NOT dismissible: unlike the update prompt in
+ * CompatibilityBanner, there is nothing useful the user can do in the app
+ * while cookies are blocked. The banner only shows on a *positive* 'blocked'
+ * answer — 'unknown' and loading states stay hidden, so an offline user or an
+ * older backend never sees a false warning.
+ */
+import { probeCookiesEnabled } from '@send-frontend/lib/cookieProbe';
+import { CLIENT_MESSAGES } from '@send-frontend/lib/messages';
+import useApiStore from '@send-frontend/stores/api-store';
+import { useQuery } from '@tanstack/vue-query';
+import { computed } from 'vue';
+
+const { api } = useApiStore();
+
+const { data, refetch } = useQuery({
+  queryKey: ['cookie-probe'],
+  queryFn: async () => await probeCookiesEnabled(api),
+});
+
+const isBlocked = computed(() => data?.value === 'blocked');
+</script>
+
+<template>
+  <header v-if="isBlocked" data-testid="cookies-blocked-banner">
+    <div class="warning">
+      <p class="title">{{ CLIENT_MESSAGES.COOKIES_BLOCKED_TITLE }}</p>
+      <p data-testid="cookies-blocked-banner-body">
+        {{ CLIENT_MESSAGES.COOKIES_BLOCKED_BANNER_BODY }}
+      </p>
+      <button
+        type="button"
+        data-testid="cookies-blocked-banner-retry"
+        @click="refetch()"
+      >
+        Retry
+      </button>
+    </div>
+  </header>
+</template>
+
+<style scoped>
+header {
+  position: relative;
+}
+.warning {
+  background: var(--colour-warning-default);
+  padding: 1rem;
+}
+.title {
+  font-weight: bold;
+}
+button {
+  margin-top: 0.5rem;
+  padding: 0.25rem 0.75rem;
+  font-weight: bold;
+  cursor: pointer;
+}
+</style>

--- a/packages/send/frontend/src/apps/common/CookiesBlockedBanner.vue
+++ b/packages/send/frontend/src/apps/common/CookiesBlockedBanner.vue
@@ -4,9 +4,14 @@
  *
  * The Send backend keeps the session in an httpOnly, SameSite=None cookie;
  * when the browser/Thunderbird refuses it, the entire app is non-functional.
- * The post-login detection in `cookieAccess.ts` needs a live session to infer
- * from, so this banner runs the positive pre-login round-trip probe in
- * `cookieProbe.ts` instead and warns before the user even attempts to log in.
+ * Post-login detection (cookie-gated routes failing while Bearer routes
+ * succeed) needs a live session to infer from, so this banner runs the
+ * positive pre-login round-trip probe in `cookieProbe.ts` instead and warns
+ * before the user even attempts to log in.
+ *
+ * The same probe also runs in the pre-app boot check (BootDiagnostics.vue),
+ * which is what a user sees first: this banner covers the case where they
+ * chose "Continue anyway" there, or navigated here later.
  *
  * Deliberately NOT dismissible: unlike the update prompt in
  * CompatibilityBanner, there is nothing useful the user can do in the app

--- a/packages/send/frontend/src/apps/send/BootDiagnostics.test.ts
+++ b/packages/send/frontend/src/apps/send/BootDiagnostics.test.ts
@@ -1,0 +1,247 @@
+import {
+  runBootChecks,
+  type BootBlocker,
+  type BootStepId,
+  type BootStepResult,
+} from '@send-frontend/lib/bootDiagnostics';
+import { CLIENT_MESSAGES } from '@send-frontend/lib/messages';
+import { getByTestId } from '@send-frontend/lib/testUtils';
+import { flushPromises, mount } from '@vue/test-utils';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import BootDiagnostics from './BootDiagnostics.vue';
+
+vi.mock('@send-frontend/lib/bootDiagnostics', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@send-frontend/lib/bootDiagnostics')>();
+  return { ...actual, runBootChecks: vi.fn() };
+});
+
+const passed = (id: BootStepId, detail = 'ok'): BootStepResult => ({
+  id,
+  outcome: 'passed',
+  detail,
+});
+
+/** Scripts runBootChecks: reports each result in order, then returns the blocker. */
+function scriptChecks(results: BootStepResult[], blocker: BootBlocker | null) {
+  vi.mocked(runBootChecks).mockImplementation(async (_url, onProgress) => {
+    for (const result of results) {
+      onProgress({ id: result.id, status: 'running' });
+      onProgress({ id: result.id, status: 'done', result });
+    }
+    return blocker;
+  });
+}
+
+const ALL_PASSED: BootStepResult[] = [
+  passed('storage'),
+  passed('firstPartyCookie'),
+  passed('backend'),
+  passed('crossSiteCookie'),
+];
+
+async function mountPanel({
+  start = vi.fn().mockResolvedValue(undefined),
+  preload = vi.fn(),
+} = {}) {
+  const wrapper = mount(BootDiagnostics, { props: { start, preload } });
+  await flushPromises();
+  return { wrapper, start, preload };
+}
+
+const status = (wrapper: ReturnType<typeof mount>, id: string) =>
+  wrapper.find(getByTestId(`boot-step-${id}`)).attributes('data-status');
+
+describe('BootDiagnostics.vue', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows only a spinner while the checks run and the app loads', async () => {
+    scriptChecks(ALL_PASSED, null);
+    // Never resolves: keeps the panel in its "loading the app" state.
+    const { wrapper } = await mountPanel({
+      start: vi.fn(() => new Promise<void>(() => {})),
+    });
+
+    expect(wrapper.find(getByTestId('boot-spinner')).exists()).toBe(true);
+    expect(wrapper.find(getByTestId('boot-steps')).exists()).toBe(false);
+    expect(wrapper.find(getByTestId('boot-failure')).exists()).toBe(false);
+  });
+
+  it('hands off to the app when nothing blocks, without ever showing the checklist', async () => {
+    scriptChecks(ALL_PASSED, null);
+    const { wrapper, start } = await mountPanel();
+
+    expect(start).toHaveBeenCalledTimes(1);
+    expect(wrapper.find(getByTestId('boot-steps')).exists()).toBe(false);
+    expect(wrapper.find(getByTestId('boot-failure')).exists()).toBe(false);
+  });
+
+  it('preloads the app bundle right after storage passes, and not before', async () => {
+    const order: string[] = [];
+    vi.mocked(runBootChecks).mockImplementation(async (_url, onProgress) => {
+      for (const result of ALL_PASSED) {
+        onProgress({ id: result.id, status: 'running' });
+        order.push(result.id);
+        onProgress({ id: result.id, status: 'done', result });
+      }
+      return null;
+    });
+    const { preload } = await mountPanel({
+      preload: vi.fn(() => {
+        order.push('preload');
+      }),
+    });
+    expect(preload).toHaveBeenCalledTimes(1);
+    expect(order).toEqual([
+      'storage',
+      'preload',
+      'firstPartyCookie',
+      'backend',
+      'crossSiteCookie',
+    ]);
+
+    scriptChecks(
+      [{ id: 'storage', outcome: 'failed', detail: 'denied' }],
+      'storage'
+    );
+    const denied = await mountPanel();
+    expect(denied.preload).not.toHaveBeenCalled();
+  });
+
+  it('stops on denied storage with the storage message and no way to continue', async () => {
+    scriptChecks(
+      [
+        {
+          id: 'storage',
+          outcome: 'failed',
+          detail: 'SecurityError: The operation is insecure.',
+        },
+      ],
+      'storage'
+    );
+    const { wrapper, start } = await mountPanel();
+
+    expect(start).not.toHaveBeenCalled();
+    expect(wrapper.find(getByTestId('boot-spinner')).exists()).toBe(false);
+    expect(status(wrapper, 'storage')).toBe('failed');
+    expect(wrapper.find(getByTestId('boot-step-storage-detail')).text()).toBe(
+      'SecurityError: The operation is insecure.'
+    );
+    // Later steps never ran: the panel must say so rather than show them green.
+    expect(status(wrapper, 'crossSiteCookie')).toBe('pending');
+    expect(status(wrapper, 'app')).toBe('pending');
+
+    const failure = wrapper.find(getByTestId('boot-failure'));
+    expect(failure.text()).toContain(CLIENT_MESSAGES.STORAGE_BLOCKED_TITLE);
+    expect(wrapper.find(getByTestId('boot-retry')).exists()).toBe(true);
+    expect(wrapper.find(getByTestId('boot-continue')).exists()).toBe(false);
+  });
+
+  it('stops on blocked cross-site cookies but lets the user continue anyway, once', async () => {
+    scriptChecks(
+      [
+        passed('storage'),
+        passed('firstPartyCookie'),
+        passed('backend'),
+        { id: 'crossSiteCookie', outcome: 'failed', detail: 'not sent back' },
+      ],
+      'crossSiteCookie'
+    );
+    let finishStart: () => void;
+    const start = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishStart = resolve;
+        })
+    );
+    const { wrapper } = await mountPanel({ start });
+
+    expect(start).not.toHaveBeenCalled();
+    expect(wrapper.find(getByTestId('boot-failure')).text()).toContain(
+      CLIENT_MESSAGES.COOKIES_BLOCKED_TITLE
+    );
+
+    const continueButton = wrapper.find(getByTestId('boot-continue'));
+    await continueButton.trigger('click');
+    // A second click while the bundle is still loading must not start a
+    // second app.
+    await continueButton.trigger('click');
+    expect(start).toHaveBeenCalledTimes(1);
+    // Back to the spinner while the bundle loads.
+    expect(wrapper.find(getByTestId('boot-spinner')).exists()).toBe(true);
+    expect(wrapper.find(getByTestId('boot-failure')).exists()).toBe(false);
+
+    finishStart();
+    await flushPromises();
+    expect(wrapper.find(getByTestId('boot-failure')).exists()).toBe(false);
+  });
+
+  it('does not surface warnings: the app starts as if all had passed', async () => {
+    scriptChecks(
+      [
+        passed('storage'),
+        { id: 'firstPartyCookie', outcome: 'warning', detail: 'dropped' },
+        { id: 'backend', outcome: 'warning', detail: 'HTTP 503' },
+        { id: 'crossSiteCookie', outcome: 'warning', detail: 'no answer' },
+      ],
+      null
+    );
+    const { wrapper, start } = await mountPanel();
+
+    expect(start).toHaveBeenCalledTimes(1);
+    expect(wrapper.find(getByTestId('boot-steps')).exists()).toBe(false);
+  });
+
+  it('reports a failed app load as the last step, with the error text', async () => {
+    scriptChecks(ALL_PASSED, null);
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const { wrapper } = await mountPanel({
+      start: vi
+        .fn()
+        .mockRejectedValue(new Error('Importing a module script failed.')),
+    });
+
+    expect(status(wrapper, 'app')).toBe('failed');
+    // The earlier steps are shown too, so the report says how far boot got.
+    expect(status(wrapper, 'storage')).toBe('passed');
+    expect(wrapper.find(getByTestId('boot-step-app-detail')).text()).toBe(
+      'Importing a module script failed.'
+    );
+    expect(wrapper.find(getByTestId('boot-failure')).text()).toContain(
+      CLIENT_MESSAGES.APP_LOAD_FAILED_TITLE
+    );
+    expect(wrapper.find(getByTestId('boot-continue')).exists()).toBe(false);
+    consoleError.mockRestore();
+  });
+
+  it('still starts the app when the diagnostics themselves throw', async () => {
+    vi.mocked(runBootChecks).mockRejectedValue(new Error('unexpected'));
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const { start } = await mountPanel();
+
+    expect(start).toHaveBeenCalledTimes(1);
+    consoleError.mockRestore();
+  });
+
+  it('retry reloads the page', async () => {
+    scriptChecks(
+      [{ id: 'storage', outcome: 'failed', detail: 'denied' }],
+      'storage'
+    );
+    const reload = vi
+      .spyOn(window.location, 'reload')
+      .mockImplementation(() => {});
+    const { wrapper } = await mountPanel();
+
+    await wrapper.find(getByTestId('boot-retry')).trigger('click');
+
+    expect(reload).toHaveBeenCalledTimes(1);
+    reload.mockRestore();
+  });
+});

--- a/packages/send/frontend/src/apps/send/BootDiagnostics.vue
+++ b/packages/send/frontend/src/apps/send/BootDiagnostics.vue
@@ -1,0 +1,306 @@
+<script lang="ts" setup>
+/**
+ * Boot-time checklist shown before the Send app loads (Bugzilla 2064458).
+ *
+ * Mounted by send.js as its own tiny Vue app, on its own element, before the
+ * real one. It must stay free of stores, the router and anything that touches
+ * browser storage while loading: the whole point is to still render when
+ * Thunderbird's "block all cookies" makes storage access throw and the main
+ * bundle cannot be evaluated (see lib/bootDiagnostics.ts).
+ *
+ * While the checks run — and while the app bundle loads — only a spinner is
+ * shown. When nothing blocks, `start` is awaited: it imports and mounts the
+ * real app, then removes this one, so a healthy boot shows no checklist at all.
+ * Only when a step blocks does the checklist appear, with the failing step's
+ * detail, so a user, or a screenshot in a bug report, can say exactly where
+ * boot stopped.
+ */
+import config from '@send-frontend/config';
+import {
+  BOOT_STEPS,
+  describeError,
+  runBootChecks,
+  type BootBlocker,
+  type BootStepId,
+  type BootStepOutcome,
+} from '@send-frontend/lib/bootDiagnostics';
+import { CLIENT_MESSAGES } from '@send-frontend/lib/messages';
+import { computed, onMounted, reactive, ref } from 'vue';
+
+const props = defineProps<{
+  /**
+   * Loads and mounts the real app. A rejection is shown as the final step
+   * failing, with the error text, instead of a blank page.
+   */
+  start: () => Promise<void>;
+  /**
+   * Optional: begin downloading the app bundle. Called the moment browser
+   * storage passes — the one check that must precede evaluating that bundle —
+   * so the download overlaps the network checks instead of following them.
+   */
+  preload?: () => void;
+}>();
+
+type StepId = BootStepId | 'app';
+type StepStatus = 'pending' | 'running' | BootStepOutcome;
+type Step = { id: StepId; label: string; status: StepStatus; detail: string };
+
+const STATUS_MARKS: Record<StepStatus, string> = {
+  pending: '○',
+  running: '…',
+  passed: '✓',
+  warning: '!',
+  failed: '✕',
+};
+
+const steps = reactive<Step[]>(
+  BOOT_STEPS.map(({ id, label }) => ({
+    id,
+    label,
+    status: 'pending',
+    detail: '',
+  }))
+);
+const blockedBy = ref<BootBlocker | 'app' | null>(null);
+const starting = ref(false);
+
+function setStep(id: StepId, status: StepStatus, detail = '') {
+  const step = steps.find((candidate) => candidate.id === id);
+  if (step) {
+    step.status = status;
+    step.detail = detail;
+  }
+}
+
+const failure = computed(() => {
+  switch (blockedBy.value) {
+    case 'storage':
+      return {
+        title: CLIENT_MESSAGES.STORAGE_BLOCKED_TITLE,
+        body: CLIENT_MESSAGES.STORAGE_BLOCKED_BODY,
+      };
+    case 'crossSiteCookie':
+      return {
+        title: CLIENT_MESSAGES.COOKIES_BLOCKED_TITLE,
+        body: CLIENT_MESSAGES.COOKIES_BLOCKED_BANNER_BODY,
+      };
+    case 'app':
+      return {
+        title: CLIENT_MESSAGES.APP_LOAD_FAILED_TITLE,
+        body: CLIENT_MESSAGES.APP_LOAD_FAILED_BODY,
+      };
+    default:
+      return null;
+  }
+});
+
+// Only a cross-site cookie block is safe to override (share links, for one,
+// work without a session). Denied storage breaks the bundle itself, and a
+// failed import cannot be retried in place.
+const canContinue = computed(() => blockedBy.value === 'crossSiteCookie');
+
+async function handOffToApp() {
+  if (starting.value) {
+    return;
+  }
+  starting.value = true;
+  blockedBy.value = null;
+  setStep('app', 'running');
+  try {
+    await props.start();
+    setStep('app', 'passed');
+  } catch (error) {
+    console.error('[boot] the application failed to load:', error);
+    setStep('app', 'failed', describeError(error));
+    blockedBy.value = 'app';
+    starting.value = false;
+  }
+}
+
+async function runDiagnostics() {
+  let blocker: BootBlocker | null = null;
+  try {
+    blocker = await runBootChecks(config.sendServerUrl ?? '', (progress) => {
+      if (progress.status === 'running') {
+        setStep(progress.id, 'running');
+        return;
+      }
+      const { outcome, detail } = progress.result;
+      setStep(progress.id, outcome, detail);
+      if (progress.id === 'storage' && outcome === 'passed') {
+        props.preload?.();
+      }
+    });
+  } catch (error) {
+    // The diagnostics are advisory: they must never be the reason the app
+    // does not start.
+    console.error('[boot] diagnostics failed:', error);
+  }
+  if (blocker) {
+    blockedBy.value = blocker;
+    return;
+  }
+  await handOffToApp();
+}
+
+// A reload rather than an in-page rerun: a module whose evaluation threw cannot
+// be imported again, and a changed Thunderbird setting is picked up cleanly on
+// a fresh load.
+function retry() {
+  window.location.reload();
+}
+
+onMounted(runDiagnostics);
+</script>
+
+<template>
+  <section class="boot" data-testid="boot-diagnostics">
+    <div
+      v-if="!failure"
+      class="spinner"
+      role="status"
+      aria-label="Starting Thunderbird Send"
+      data-testid="boot-spinner"
+    ></div>
+
+    <template v-else>
+      <p class="heading">Startup check failed</p>
+      <ol class="steps" data-testid="boot-steps">
+        <li
+          v-for="step in steps"
+          :key="step.id"
+          :class="step.status"
+          :data-testid="`boot-step-${step.id}`"
+          :data-status="step.status"
+        >
+          <span class="mark" aria-hidden="true">
+            {{ STATUS_MARKS[step.status] }}
+          </span>
+          <span>{{ step.label }}</span>
+          <span
+            v-if="step.detail"
+            class="detail"
+            :data-testid="`boot-step-${step.id}-detail`"
+          >
+            {{ step.detail }}
+          </span>
+        </li>
+      </ol>
+
+      <div class="failure" role="alert" data-testid="boot-failure">
+        <p class="title">{{ failure.title }}</p>
+        <p>{{ failure.body }}</p>
+        <div class="actions">
+          <button type="button" data-testid="boot-retry" @click="retry">
+            Retry
+          </button>
+          <button
+            v-if="canContinue"
+            type="button"
+            class="secondary"
+            data-testid="boot-continue"
+            :disabled="starting"
+            @click="handOffToApp"
+          >
+            Continue anyway
+          </button>
+        </div>
+      </div>
+    </template>
+  </section>
+</template>
+
+<style scoped>
+/* Self-contained on purpose: the app stylesheet ships with the app bundle,
+   which this panel exists to render without. */
+.boot {
+  max-width: 40rem;
+  margin: 2rem auto;
+  padding: 1rem 1.5rem;
+  font-family: system-ui, sans-serif;
+  font-size: 14px;
+  color: #1a1a1a;
+}
+.spinner {
+  width: 2rem;
+  height: 2rem;
+  margin: 4rem auto;
+  border: 3px solid #d4d4d8;
+  border-top-color: #1a1a1a;
+  border-radius: 50%;
+  animation: boot-spin 0.8s linear infinite;
+}
+@keyframes boot-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+.heading {
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+}
+.steps {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.35rem;
+}
+.steps li {
+  display: grid;
+  grid-template-columns: 1.25rem 1fr;
+  column-gap: 0.5rem;
+  align-items: baseline;
+}
+.mark {
+  font-weight: 700;
+  text-align: center;
+}
+.pending {
+  opacity: 0.55;
+}
+.passed .mark {
+  color: #15803d;
+}
+.warning .mark {
+  color: #a16207;
+}
+.failed .mark {
+  color: #b91c1c;
+}
+.detail {
+  grid-column: 2;
+  font-size: 12px;
+  opacity: 0.75;
+}
+.failure {
+  margin-top: 1rem;
+  padding: 1rem;
+  border-radius: 0.375rem;
+  background: #facc15;
+}
+.title {
+  font-weight: 700;
+  margin-bottom: 0.25rem;
+}
+.actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+button {
+  padding: 0.35rem 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  border: 1px solid #1a1a1a;
+  border-radius: 0.25rem;
+  background: #fff;
+}
+button.secondary {
+  background: transparent;
+}
+button:disabled {
+  cursor: progress;
+  opacity: 0.6;
+}
+</style>

--- a/packages/send/frontend/src/apps/send/LoginPage.vue
+++ b/packages/send/frontend/src/apps/send/LoginPage.vue
@@ -98,17 +98,21 @@ async function _loginToOIDC() {
 </script>
 <template>
   <main class="container">
-    <div v-if="!isPublicLogin">
-      <CookiesBlockedBanner />
-      <p>Redirecting to TB Pro login...</p>
-    </div>
-    <div v-else>
+    <!--
+      In extension mode we immediately signinRedirect() on mount (see onMounted),
+      which navigates away before the banner's async probe can resolve. The
+      pre-app boot check (BootDiagnostics.vue) already covers that path, so the
+      banner only belongs on the public-login screen where the user actually
+      stays and can act on it.
+    -->
+    <p v-if="!isPublicLogin">Redirecting to TB Pro login...</p>
+    <template v-else>
       <CookiesBlockedBanner />
       <TBBanner />
-      <PublicLogin v-if="isPublicLogin" :on-success="onSuccess" />
+      <PublicLogin :on-success="onSuccess" />
       <FeedbackBox />
       <SecureSendIcon />
-    </div>
+    </template>
   </main>
 </template>
 

--- a/packages/send/frontend/src/apps/send/LoginPage.vue
+++ b/packages/send/frontend/src/apps/send/LoginPage.vue
@@ -37,6 +37,7 @@ import useKeychainStore from '@send-frontend/stores/keychain-store';
 import useUserStore from '@send-frontend/stores/user-store';
 import { onMounted, ref } from 'vue';
 import { useRouter } from 'vue-router';
+import CookiesBlockedBanner from '../common/CookiesBlockedBanner.vue';
 import FeedbackBox from '../common/FeedbackBox.vue';
 
 import PublicLogin from '../common/PublicLogin.vue';
@@ -98,9 +99,11 @@ async function _loginToOIDC() {
 <template>
   <main class="container">
     <div v-if="!isPublicLogin">
+      <CookiesBlockedBanner />
       <p>Redirecting to TB Pro login...</p>
     </div>
     <div v-else>
+      <CookiesBlockedBanner />
       <TBBanner />
       <PublicLogin v-if="isPublicLogin" :on-success="onSuccess" />
       <FeedbackBox />

--- a/packages/send/frontend/src/apps/send/send.boot.test.ts
+++ b/packages/send/frontend/src/apps/send/send.boot.test.ts
@@ -1,0 +1,123 @@
+import { denyStorage, getByTestId } from '@send-frontend/lib/testUtils';
+import { flushPromises } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Drives the real send.js entry (Bugzilla 2064458).
+ *
+ * The regression this guards: a static import in the entry pulling a module
+ * that touches browser storage while being evaluated. With Thunderbird set to
+ * block all cookies that access throws, and a static import would hoist the
+ * throw ahead of anything that could render an explanation — the page would
+ * be blank again. So the entry must render its checklist and stop, with the
+ * app bundle never loaded, when storage is denied; and load it exactly once,
+ * then clean up after itself, when it is not.
+ */
+
+const startApp = vi.hoisted(() => vi.fn());
+vi.mock('@send-frontend/apps/send/startApp', () => ({ startApp }));
+
+function stubBackend(cookiesEnabled: boolean) {
+  const json = (body: unknown) =>
+    new Response(JSON.stringify(body), { status: 200 });
+  vi.stubGlobal(
+    'fetch',
+    vi.fn<typeof fetch>(async (input) => {
+      const url = String(input);
+      if (url.endsWith('/api/cookie-check/verify')) {
+        return json({ cookiesEnabled });
+      }
+      if (url.endsWith('/api/cookie-check/set')) {
+        return json({ ok: true });
+      }
+      return json({});
+    })
+  );
+}
+
+async function loadEntry() {
+  vi.resetModules();
+  await import('@send-frontend/apps/send/send');
+  await flushPromises();
+}
+
+const query = (testId: string) =>
+  document.querySelector<HTMLElement>(getByTestId(testId));
+
+describe('send.js two-stage boot', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="app"></div>';
+    startApp.mockReset();
+    startApp.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    document.body.innerHTML = '';
+  });
+
+  it('with storage denied, still renders the checklist and never loads the app', async () => {
+    stubBackend(true);
+    const restore = denyStorage('localStorage', 'sessionStorage');
+    try {
+      await loadEntry();
+    } finally {
+      restore();
+    }
+
+    expect(query('boot-diagnostics')).not.toBeNull();
+    expect(query('boot-step-storage')?.dataset.status).toBe('failed');
+    expect(query('boot-step-storage-detail')?.textContent).toContain(
+      'SecurityError: The operation is insecure.'
+    );
+    expect(startApp).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+    // `#app` is left untouched for the real app; the panel lives beside it.
+    expect(document.getElementById('app')?.childElementCount).toBe(0);
+  });
+
+  it('when the checks pass, loads the app once and removes the panel', async () => {
+    stubBackend(true);
+    await loadEntry();
+
+    await vi.waitFor(() => expect(startApp).toHaveBeenCalledTimes(1));
+    await flushPromises();
+    expect(query('boot-diagnostics')).toBeNull();
+  });
+
+  it('when the app bundle fails to evaluate, reports it as the last step', async () => {
+    stubBackend(true);
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    vi.doMock('@send-frontend/apps/send/startApp', () => {
+      throw new Error('Importing a module script failed.');
+    });
+    try {
+      await loadEntry();
+      await vi.waitFor(() =>
+        expect(query('boot-step-app')?.dataset.status).toBe('failed')
+      );
+      // vitest wraps a throwing factory in its own message; the point is that
+      // *some* error text reaches the user instead of a blank page.
+      expect(query('boot-step-app-detail')?.textContent).toMatch(/error/i);
+      expect(query('boot-continue')).toBeNull();
+    } finally {
+      // Restore the file-level mock: doUnmock alone would make the next test
+      // load the real module.
+      vi.doMock('@send-frontend/apps/send/startApp', () => ({ startApp }));
+      consoleError.mockRestore();
+    }
+  });
+
+  it('on blocked cross-site cookies, holds the app until the user continues', async () => {
+    stubBackend(false);
+    await loadEntry();
+
+    await vi.waitFor(() => expect(query('boot-continue')).not.toBeNull());
+    expect(startApp).not.toHaveBeenCalled();
+
+    query('boot-continue')?.click();
+    await vi.waitFor(() => expect(startApp).toHaveBeenCalledTimes(1));
+  });
+});

--- a/packages/send/frontend/src/apps/send/send.js
+++ b/packages/send/frontend/src/apps/send/send.js
@@ -1,14 +1,6 @@
 import { assertConfigured } from '@send-frontend/config';
-import { closeSentry, initSentry } from '@send-frontend/lib/sentry';
-import {
-  isTelemetryAllowed,
-  onTelemetryChanged,
-} from '@send-frontend/lib/telemetryConsent';
-import { setPosthogConsent } from '@send-frontend/plugins/posthog';
 import { createApp } from 'vue';
-import Send from './SendPage.vue';
-import router from './router';
-import { mountApp, setupApp } from './setup';
+import BootDiagnostics from './BootDiagnostics.vue';
 
 // Web-app entry ONLY (index.html), which is the one entry point that loads
 // /config.js. Fail loud here rather than booting an SPA that renders and then
@@ -17,27 +9,45 @@ import { mountApp, setupApp } from './setup';
 // /config.js and is configured by the baked VITE_* values instead.
 assertConfigured();
 
-const app = createApp(Send);
+// Boot in two stages (Bugzilla 2064458). Everything behind `startApp` — the
+// router, the Pinia stores, oidc-client-ts, services-ui — is imported
+// dynamically, AFTER the diagnostics pass, because some of it touches
+// localStorage/sessionStorage while being evaluated, and Firefox makes those
+// getters throw when Thunderbird blocks all cookies. A static import here would
+// hoist that evaluation ahead of this file's own code and the page would die
+// blank before anything could explain why — which is exactly what happened to
+// the login-screen banner. See lib/bootDiagnostics.ts.
 
-// Resolve the Thunderbird telemetry opt-out before initializing any telemetry,
-// so nothing is sent when the user has opted out. Outside Thunderbird this
-// resolves to allowed, preserving existing website behavior. See issue #892.
-(async () => {
-  const telemetryAllowed = await isTelemetryAllowed();
-  if (telemetryAllowed) {
-    initSentry(app);
+let appModule;
+
+// Starts downloading the app bundle. The panel calls this as soon as browser
+// storage passes, so the download overlaps the network checks — and never
+// earlier, because evaluating the bundle with storage denied is the very crash
+// this bootstrap exists to explain.
+function loadApp() {
+  if (!appModule) {
+    appModule = import('./startApp');
+    // Nothing awaits this until `start`; mark a rejection as observed so the
+    // browser does not report it as unhandled in the meantime. `start` awaits
+    // the original promise and still receives the error.
+    appModule.catch(() => {});
   }
-  app.use(router);
-  setupApp(app, telemetryAllowed);
-  mountApp(app, '#app');
+  return appModule;
+}
 
-  // React to runtime pref changes without requiring a reinstall/reload.
-  onTelemetryChanged((enabled) => {
-    setPosthogConsent(enabled);
-    if (enabled) {
-      initSentry(app);
-    } else {
-      closeSentry();
-    }
-  });
-})();
+// The panel gets its own element rather than `#app`: the real app owns `#app`
+// outright (no "app already mounted" warning, no shared `__vue_app__`), and
+// the panel is still on screen to report a failure anywhere in `startApp`.
+const bootRoot = document.createElement('div');
+document.body.prepend(bootRoot);
+
+const boot = createApp(BootDiagnostics, {
+  preload: loadApp,
+  start: async () => {
+    const { startApp } = await loadApp();
+    await startApp();
+    boot.unmount();
+    bootRoot.remove();
+  },
+});
+boot.mount(bootRoot);

--- a/packages/send/frontend/src/apps/send/send.telemetry.test.ts
+++ b/packages/send/frontend/src/apps/send/send.telemetry.test.ts
@@ -10,8 +10,10 @@ import {
  *
  * The dashboard runs as a plain web page inside Thunderbird (no direct
  * experiment API), so it learns the telemetry state over the token-bridge.
- * This exercises the *real* send.js entry, the *real* telemetryConsent bridge
- * path, and the *real* sentry.ts gate — only `@sentry/vue` and the heavy Vue
+ * This exercises the *real* startApp() (the app-start half of the send.js
+ * entry; the boot diagnostics that gate it live in send.js and are tested in
+ * BootDiagnostics.test.ts), the *real* telemetryConsent bridge path, and the
+ * *real* sentry.ts gate — only `@sentry/vue` and the heavy Vue
  * wiring are mocked — to lock in the scenario:
  *
  *   pref OFF → open dashboard → Sentry never initializes (zero network calls)
@@ -111,10 +113,11 @@ function installFakeBridge(enabled: boolean) {
   return () => window.removeEventListener('message', handler);
 }
 
-/** Runs the entry's IIFE fresh (module state, sentry.ts `initialized`, reset). */
+/** Runs startApp() fresh (module state, sentry.ts `initialized`, reset). */
 async function loadDashboardEntry() {
   vi.resetModules();
-  await import('@send-frontend/apps/send/send');
+  const { startApp } = await import('@send-frontend/apps/send/startApp');
+  await startApp();
 }
 
 describe('Send dashboard telemetry gate (bridge → initSentry)', () => {

--- a/packages/send/frontend/src/apps/send/startApp.js
+++ b/packages/send/frontend/src/apps/send/startApp.js
@@ -1,0 +1,41 @@
+import { closeSentry, initSentry } from '@send-frontend/lib/sentry';
+import {
+  isTelemetryAllowed,
+  onTelemetryChanged,
+} from '@send-frontend/lib/telemetryConsent';
+import { setPosthogConsent } from '@send-frontend/plugins/posthog';
+import { createApp } from 'vue';
+import Send from './SendPage.vue';
+import router from './router';
+import { mountApp, setupApp } from './setup';
+
+/**
+ * Creates and mounts the real Send web app into `#app`.
+ *
+ * Imported dynamically by send.js once the boot diagnostics pass; see the
+ * comment there for why this is not simply the body of the entry file.
+ */
+export async function startApp() {
+  const app = createApp(Send);
+
+  // Resolve the Thunderbird telemetry opt-out before initializing any telemetry,
+  // so nothing is sent when the user has opted out. Outside Thunderbird this
+  // resolves to allowed, preserving existing website behavior. See issue #892.
+  const telemetryAllowed = await isTelemetryAllowed();
+  if (telemetryAllowed) {
+    initSentry(app);
+  }
+  app.use(router);
+  setupApp(app, telemetryAllowed);
+  mountApp(app, '#app');
+
+  // React to runtime pref changes without requiring a reinstall/reload.
+  onTelemetryChanged((enabled) => {
+    setPosthogConsent(enabled);
+    if (enabled) {
+      initSentry(app);
+    } else {
+      closeSentry();
+    }
+  });
+}

--- a/packages/send/frontend/src/lib/bootDiagnostics.test.ts
+++ b/packages/send/frontend/src/lib/bootDiagnostics.test.ts
@@ -1,0 +1,223 @@
+import { denyStorage } from '@send-frontend/lib/testUtils';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  checkBackendReachable,
+  checkCrossSiteCookie,
+  checkFirstPartyCookie,
+  checkStorage,
+  describeError,
+  runBootChecks,
+  type BootProgress,
+} from './bootDiagnostics';
+
+const SERVER_URL = 'https://localhost:8088';
+
+/** A browser that silently drops cookie writes for this site. */
+function dropCookies() {
+  Object.defineProperty(document, 'cookie', {
+    configurable: true,
+    get: () => '',
+    set: () => {},
+  });
+  return () => {
+    delete (document as { cookie?: string }).cookie;
+  };
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+/** fetch stub answering the health and cookie-probe routes. */
+function stubBackend({
+  health = 200,
+  set = { ok: true } as unknown,
+  verify = { cookiesEnabled: true } as unknown,
+} = {}) {
+  const fetchMock = vi.fn<typeof fetch>(async (input) => {
+    const url = String(input);
+    if (url.endsWith('/api/health')) return jsonResponse({}, health);
+    if (url.endsWith('/api/cookie-check/set')) return jsonResponse(set);
+    if (url.endsWith('/api/cookie-check/verify')) return jsonResponse(verify);
+    return jsonResponse({}, 404);
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+describe('bootDiagnostics', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe('describeError', () => {
+    it('keeps the DOMException name, which is the part users search for', () => {
+      expect(
+        describeError(
+          new DOMException('The operation is insecure.', 'SecurityError')
+        )
+      ).toBe('SecurityError: The operation is insecure.');
+    });
+
+    it('drops the generic Error name and stringifies non-errors', () => {
+      expect(describeError(new Error('boom'))).toBe('boom');
+      expect(describeError('plain')).toBe('plain');
+    });
+  });
+
+  describe('checkStorage', () => {
+    it('passes when both stores round-trip a value', () => {
+      const result = checkStorage();
+      expect(result.outcome).toBe('passed');
+      expect(localStorage.getItem('send_boot_probe')).toBeNull();
+    });
+
+    it('fails, with the browser error text, when the storage getter throws', () => {
+      const restore = denyStorage('localStorage');
+      try {
+        const result = checkStorage();
+        expect(result.outcome).toBe('failed');
+        expect(result.detail).toBe('SecurityError: The operation is insecure.');
+      } finally {
+        restore();
+      }
+    });
+
+    it('fails when only sessionStorage is denied', () => {
+      const restore = denyStorage('sessionStorage');
+      try {
+        expect(checkStorage().outcome).toBe('failed');
+      } finally {
+        restore();
+      }
+    });
+  });
+
+  describe('checkFirstPartyCookie', () => {
+    it('passes when a cookie can be written and read back, and cleans it up', () => {
+      const result = checkFirstPartyCookie();
+      expect(result.outcome).toBe('passed');
+      expect(document.cookie).not.toContain('send_boot_probe=1');
+    });
+
+    it('only warns (never blocks) when the browser drops the cookie', () => {
+      const restore = dropCookies();
+      try {
+        expect(checkFirstPartyCookie().outcome).toBe('warning');
+      } finally {
+        restore();
+      }
+    });
+  });
+
+  describe('checkBackendReachable', () => {
+    it('passes on a 200 from /api/health', async () => {
+      const fetchMock = stubBackend();
+      const result = await checkBackendReachable(SERVER_URL);
+      expect(result.outcome).toBe('passed');
+      expect(result.detail).toContain('https://localhost:8088');
+      expect(String(fetchMock.mock.calls[0][0])).toBe(
+        'https://localhost:8088/api/health'
+      );
+    });
+
+    it('warns with the status on a non-2xx answer', async () => {
+      stubBackend({ health: 503 });
+      const result = await checkBackendReachable(SERVER_URL);
+      expect(result.outcome).toBe('warning');
+      expect(result.detail).toContain('503');
+    });
+
+    it('warns with the error text when fetch throws', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockRejectedValue(new TypeError('Failed to fetch'))
+      );
+      const result = await checkBackendReachable(SERVER_URL);
+      expect(result.outcome).toBe('warning');
+      expect(result.detail).toBe('TypeError: Failed to fetch');
+    });
+  });
+
+  describe('checkCrossSiteCookie', () => {
+    it('passes when the probe cookie comes back, sending credentials', async () => {
+      const fetchMock = stubBackend();
+      const result = await checkCrossSiteCookie(SERVER_URL);
+      expect(result.outcome).toBe('passed');
+      const urls = fetchMock.mock.calls.map((call) => String(call[0]));
+      expect(urls).toEqual([
+        'https://localhost:8088/api/cookie-check/set',
+        'https://localhost:8088/api/cookie-check/verify',
+      ]);
+      // Without this the probe cookie would never ride along, and neither
+      // would the real session cookie.
+      expect(fetchMock.mock.calls[0][1]).toMatchObject({
+        credentials: 'include',
+        cache: 'no-store',
+      });
+    });
+
+    it('fails only on a positive "blocked" answer from the backend', async () => {
+      stubBackend({ verify: { cookiesEnabled: false } });
+      expect((await checkCrossSiteCookie(SERVER_URL)).outcome).toBe('failed');
+    });
+
+    it('warns, never fails, when the probe is inconclusive', async () => {
+      stubBackend({ set: { ok: false } });
+      expect((await checkCrossSiteCookie(SERVER_URL)).outcome).toBe('warning');
+
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockRejectedValue(new TypeError('Failed to fetch'))
+      );
+      expect((await checkCrossSiteCookie(SERVER_URL)).outcome).toBe('warning');
+    });
+  });
+
+  describe('runBootChecks', () => {
+    function collect() {
+      const events: BootProgress[] = [];
+      return {
+        events,
+        onProgress: (event: BootProgress) => events.push(event),
+      };
+    }
+    const done = (events: BootProgress[]) =>
+      events
+        .filter((event) => event.status === 'done')
+        .map((event) => event.id);
+
+    it('stops at storage, before any network call, when storage is denied', async () => {
+      const fetchMock = stubBackend();
+      const restore = denyStorage('localStorage');
+      const { events, onProgress } = collect();
+      try {
+        expect(await runBootChecks(SERVER_URL, onProgress)).toBe('storage');
+      } finally {
+        restore();
+      }
+      expect(done(events)).toEqual(['storage']);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('runs every step and blocks on a cross-site cookie block', async () => {
+      stubBackend({ verify: { cookiesEnabled: false } });
+      const { events, onProgress } = collect();
+      expect(await runBootChecks(SERVER_URL, onProgress)).toBe(
+        'crossSiteCookie'
+      );
+      expect(done(events).sort()).toEqual(
+        ['backend', 'crossSiteCookie', 'firstPartyCookie', 'storage'].sort()
+      );
+    });
+
+    it('lets the app start when nothing blocks, even with warnings', async () => {
+      stubBackend({ health: 503, set: { ok: false } });
+      const { onProgress } = collect();
+      expect(await runBootChecks(SERVER_URL, onProgress)).toBeNull();
+    });
+  });
+});

--- a/packages/send/frontend/src/lib/bootDiagnostics.ts
+++ b/packages/send/frontend/src/lib/bootDiagnostics.ts
@@ -1,0 +1,268 @@
+import { buildApiUrl } from './api';
+import { probeCookiesEnabled, type CookieProbeTransport } from './cookieProbe';
+
+/**
+ * Boot-time diagnostics for the Send web app (Bugzilla 2064458).
+ *
+ * When Thunderbird is set to block all cookies, Firefox denies every kind of
+ * storage access for the page: the `window.localStorage` and
+ * `window.sessionStorage` getters THROW a SecurityError ("The operation is
+ * insecure") instead of returning a store. Several modules in the app graph
+ * touch storage while they are being *evaluated* — oidc-client-ts builds its
+ * default stores inside `new UserManager()` at the top of stores/auth-store.ts,
+ * and @thunderbirdops/services-ui reads localStorage on load — so the bundle
+ * dies before a single Vue component mounts and the user sees a blank page: no
+ * banner, no message, only a console warning.
+ *
+ * These checks therefore run from a tiny bootstrap (apps/send/send.js) that
+ * imports nothing store-related, shows a spinner while they run
+ * (apps/send/BootDiagnostics.vue), and only then dynamically imports the real
+ * app. A healthy boot shows nothing else; when a step blocks, the panel shows
+ * the checklist with the failing step's detail. Each check is a plain function
+ * returning a {@link BootStepResult} so it can be unit-tested and so the panel
+ * can say *which* step failed.
+ */
+
+export type BootStepId =
+  | 'storage'
+  | 'firstPartyCookie'
+  | 'backend'
+  | 'crossSiteCookie';
+
+/** The only steps whose failure stops the app from starting. */
+export type BootBlocker = Extract<BootStepId, 'storage' | 'crossSiteCookie'>;
+
+export type BootStepOutcome = 'passed' | 'warning' | 'failed';
+
+export type BootStepResult = {
+  id: BootStepId;
+  outcome: BootStepOutcome;
+  /** User-visible one-liner: what was verified, or why it failed. */
+  detail: string;
+};
+
+export type BootProgress =
+  | { id: BootStepId; status: 'running' }
+  | { id: BootStepId; status: 'done'; result: BootStepResult };
+
+/**
+ * The checklist as the panel shows it, in the order the steps run. `app` is
+ * the final hand-off step (loading the real bundle), owned by the panel.
+ */
+export const BOOT_STEPS: ReadonlyArray<{
+  id: BootStepId | 'app';
+  label: string;
+}> = [
+  { id: 'storage', label: 'Browser storage is available' },
+  { id: 'firstPartyCookie', label: 'This site can set cookies' },
+  { id: 'backend', label: 'Send server is reachable' },
+  { id: 'crossSiteCookie', label: 'Send server cookies are accepted' },
+  { id: 'app', label: 'Application loaded' },
+];
+
+/**
+ * Upper bound for each network *call*, so a hung backend cannot stall boot
+ * indefinitely. The cross-site probe makes two sequential calls, so that step
+ * can spend twice this before it gives up.
+ */
+const NETWORK_TIMEOUT_MS = 5_000;
+
+const PROBE_KEY = 'send_boot_probe';
+
+/** `SecurityError: The operation is insecure.` rather than `[object DOMException]`. */
+export function describeError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.name && error.name !== 'Error'
+      ? `${error.name}: ${error.message}`
+      : error.message;
+  }
+  return String(error);
+}
+
+/**
+ * Blocking. With "block all cookies" the storage getters throw, and the app
+ * bundle cannot even be evaluated in that state (see module header), so this
+ * must run first and stop everything on failure.
+ */
+export function checkStorage(): BootStepResult {
+  const id = 'storage';
+  try {
+    for (const store of [window.localStorage, window.sessionStorage]) {
+      store.setItem(PROBE_KEY, '1');
+      const roundTrip = store.getItem(PROBE_KEY);
+      store.removeItem(PROBE_KEY);
+      if (roundTrip !== '1') {
+        throw new Error('a stored value did not read back');
+      }
+    }
+    return {
+      id,
+      outcome: 'passed',
+      detail: 'localStorage and sessionStorage are readable and writable',
+    };
+  } catch (error) {
+    return { id, outcome: 'failed', detail: describeError(error) };
+  }
+}
+
+/**
+ * Informational. Send sets no cookie on its own origin — the session cookie
+ * belongs to the backend origin — but whether a plain first-party cookie sticks
+ * tells "all cookies blocked" apart from "only cross-site cookies blocked" when
+ * reading the panel.
+ */
+export function checkFirstPartyCookie(): BootStepResult {
+  const id = 'firstPartyCookie';
+  try {
+    const secure = window.location.protocol === 'https:' ? '; Secure' : '';
+    document.cookie = `${PROBE_KEY}=1; path=/; SameSite=Lax${secure}`;
+    const stored = document.cookie
+      .split(';')
+      .some((cookie) => cookie.trim() === `${PROBE_KEY}=1`);
+    document.cookie = `${PROBE_KEY}=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT${secure}`;
+    return stored
+      ? { id, outcome: 'passed', detail: 'A first-party cookie was stored' }
+      : {
+          id,
+          outcome: 'warning',
+          detail: 'The browser silently dropped a first-party cookie',
+        };
+  } catch (error) {
+    return { id, outcome: 'warning', detail: describeError(error) };
+  }
+}
+
+/**
+ * Runs `task` with an abort signal that fires after {@link NETWORK_TIMEOUT_MS}.
+ * The whole task — reading the body included — has to finish inside the
+ * window; a timer cleared as soon as headers arrive would let a stalled body
+ * hang boot without bound.
+ */
+async function withTimeout<T>(
+  task: (signal: AbortSignal) => Promise<T>
+): Promise<T> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), NETWORK_TIMEOUT_MS);
+  try {
+    return await task(controller.signal);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Informational. Unreachable is a warning, not a block: the app's own
+ * CompatibilityBoundary already explains a dead backend (including the
+ * self-signed-certificate hint for local dev), so blocking here would only
+ * duplicate that with a worse message.
+ */
+export async function checkBackendReachable(
+  serverUrl: string
+): Promise<BootStepResult> {
+  const id = 'backend';
+  try {
+    const origin = new URL(serverUrl).origin;
+    const response = await withTimeout((signal) =>
+      fetch(buildApiUrl(serverUrl, 'health'), { cache: 'no-store', signal })
+    );
+    return response.ok
+      ? { id, outcome: 'passed', detail: `Reached ${origin}` }
+      : {
+          id,
+          outcome: 'warning',
+          detail: `${origin} answered HTTP ${response.status}`,
+        };
+  } catch (error) {
+    return { id, outcome: 'warning', detail: describeError(error) };
+  }
+}
+
+/**
+ * A bare-`fetch` transport for {@link probeCookiesEnabled}. `credentials:
+ * 'include'` is what makes the probe cookie ride along, exactly as it does for
+ * the real session cookie in `ApiConnection`. `cache: 'no-store'` because a
+ * replayed `set` answer without its Set-Cookie would make `verify` report a
+ * block that never happened — and a false block here stops the app.
+ */
+export function createProbeTransport(serverUrl: string): CookieProbeTransport {
+  return {
+    call<T>(path: string): Promise<T | null> {
+      return withTimeout(async (signal) => {
+        const response = await fetch(buildApiUrl(serverUrl, path), {
+          credentials: 'include',
+          mode: 'cors',
+          cache: 'no-store',
+          signal,
+        });
+        return response.ok ? ((await response.json()) as T) : null;
+      });
+    },
+  };
+}
+
+/**
+ * Blocking on a positive 'blocked' answer only. 'unknown' (offline, older
+ * backend, timeout) is a warning: the app must not be held back on a guess.
+ */
+export async function checkCrossSiteCookie(
+  serverUrl: string
+): Promise<BootStepResult> {
+  const id = 'crossSiteCookie';
+  const result = await probeCookiesEnabled(createProbeTransport(serverUrl));
+  switch (result) {
+    case 'enabled':
+      return {
+        id,
+        outcome: 'passed',
+        detail: 'A cookie set by the Send server came back on the next request',
+      };
+    case 'blocked':
+      return {
+        id,
+        outcome: 'failed',
+        detail:
+          'The Send server set a cookie, but the browser did not send it back',
+      };
+    default:
+      return {
+        id,
+        outcome: 'warning',
+        detail: 'Could not tell: the Send server did not answer the probe',
+      };
+  }
+}
+
+/**
+ * Runs every check in order, reporting progress as it goes.
+ *
+ * @returns the step that blocks the app from starting, or null when it may
+ * start. Stops at the first blocker: with storage denied the later steps would
+ * only add noise under the one line that matters.
+ */
+export async function runBootChecks(
+  serverUrl: string,
+  onProgress: (progress: BootProgress) => void
+): Promise<BootBlocker | null> {
+  const report = (result: BootStepResult): BootStepResult => {
+    onProgress({ id: result.id, status: 'done', result });
+    return result;
+  };
+
+  onProgress({ id: 'storage', status: 'running' });
+  const storage = report(checkStorage());
+  if (storage.outcome === 'failed') {
+    return 'storage';
+  }
+
+  onProgress({ id: 'firstPartyCookie', status: 'running' });
+  report(checkFirstPartyCookie());
+
+  onProgress({ id: 'backend', status: 'running' });
+  onProgress({ id: 'crossSiteCookie', status: 'running' });
+  // Informational: report it whenever it lands, but never hold the app behind
+  // it — a slow /api/health cannot block, so it must not delay either.
+  void checkBackendReachable(serverUrl).then(report);
+  const crossSite = report(await checkCrossSiteCookie(serverUrl));
+
+  return crossSite.outcome === 'failed' ? 'crossSiteCookie' : null;
+}

--- a/packages/send/frontend/src/lib/cookieProbe.ts
+++ b/packages/send/frontend/src/lib/cookieProbe.ts
@@ -1,27 +1,36 @@
-import type { ApiConnection } from './api';
-
 /**
  * Result of the pre-login cookie round-trip probe.
  *
  * Bugzilla 2064458: the Send backend keeps the session in an httpOnly,
  * SameSite=None cookie. When Thunderbird (or a browser) is set to refuse
  * third-party cookies, that cookie never reaches the backend and the entire
- * app is non-functional — not just uploads. After login, `cookieAccess.ts`
- * can infer a block from the disagreement between the cookie-gated route and
- * the Bearer route; before login there is no session to infer from, so this
- * module performs a *positive* round trip instead: ask the backend to set a
- * throwaway probe cookie with the same SameSite=None; Secure attributes
- * (`GET /api/cookie-check/set`), then ask whether it came back
- * (`GET /api/cookie-check/verify`).
+ * app is non-functional — not just uploads. After login a block can be inferred
+ * from the cookie-gated routes failing while the Bearer routes succeed; before
+ * login there is no session to infer from, so this module performs a *positive*
+ * round trip instead: ask the backend to set a throwaway probe cookie with the
+ * same SameSite=None; Secure attributes (`GET /api/cookie-check/set`), then ask
+ * whether it came back (`GET /api/cookie-check/verify`).
  *
- * `unknown` exists for the same reason it does in `cookieAccess.ts`: "we could
- * not tell" must never be surfaced to the user as "your cookies are blocked",
- * or we send someone off to change a Thunderbird setting that was never the
- * problem. An offline user, a rate-limited user and a backend too old to have
- * the probe endpoints all land on 'unknown', and callers must hide the
- * blocked-cookies warning for it.
+ * `unknown` exists because "we could not tell" must never be surfaced to the
+ * user as "your cookies are blocked", or we send someone off to change a
+ * Thunderbird setting that was never the problem. An offline user, a
+ * rate-limited user and a backend too old to have the probe endpoints all land
+ * on 'unknown', and callers must hide the blocked-cookies warning for it.
  */
 export type CookieProbeResult = 'enabled' | 'blocked' | 'unknown';
+
+/**
+ * The one thing the probe needs from its caller: a GET that resolves to parsed
+ * JSON, or to null on a failed request. It may also reject; the probe treats a
+ * rejection and a null alike, as inconclusive. `ApiConnection` satisfies this
+ * as-is (the login-screen banner passes the store's `api`); the boot-time
+ * diagnostics in `bootDiagnostics.ts` pass a bare `fetch` wrapper instead,
+ * because they run before any store — and the module graph behind it — may be
+ * loaded.
+ */
+export type CookieProbeTransport = {
+  call<T>(path: string): Promise<T | null>;
+};
 
 /**
  * Positively determine whether cookies for the Send backend round-trip.
@@ -31,7 +40,7 @@ export type CookieProbeResult = 'enabled' | 'blocked' | 'unknown';
  * inconclusive call. See {@link CookieProbeResult} for why.
  */
 export async function probeCookiesEnabled(
-  api: ApiConnection
+  api: CookieProbeTransport
 ): Promise<CookieProbeResult> {
   try {
     const setResponse = await api.call<{ ok: boolean }>('cookie-check/set');

--- a/packages/send/frontend/src/lib/cookieProbe.ts
+++ b/packages/send/frontend/src/lib/cookieProbe.ts
@@ -1,0 +1,56 @@
+import type { ApiConnection } from './api';
+
+/**
+ * Result of the pre-login cookie round-trip probe.
+ *
+ * Bugzilla 2064458: the Send backend keeps the session in an httpOnly,
+ * SameSite=None cookie. When Thunderbird (or a browser) is set to refuse
+ * third-party cookies, that cookie never reaches the backend and the entire
+ * app is non-functional — not just uploads. After login, `cookieAccess.ts`
+ * can infer a block from the disagreement between the cookie-gated route and
+ * the Bearer route; before login there is no session to infer from, so this
+ * module performs a *positive* round trip instead: ask the backend to set a
+ * throwaway probe cookie with the same SameSite=None; Secure attributes
+ * (`GET /api/cookie-check/set`), then ask whether it came back
+ * (`GET /api/cookie-check/verify`).
+ *
+ * `unknown` exists for the same reason it does in `cookieAccess.ts`: "we could
+ * not tell" must never be surfaced to the user as "your cookies are blocked",
+ * or we send someone off to change a Thunderbird setting that was never the
+ * problem. An offline user, a rate-limited user and a backend too old to have
+ * the probe endpoints all land on 'unknown', and callers must hide the
+ * blocked-cookies warning for it.
+ */
+export type CookieProbeResult = 'enabled' | 'blocked' | 'unknown';
+
+/**
+ * Positively determine whether cookies for the Send backend round-trip.
+ *
+ * Answers 'blocked' only when both probe calls succeeded and the backend
+ * affirmatively reported the probe cookie missing — never on a failed or
+ * inconclusive call. See {@link CookieProbeResult} for why.
+ */
+export async function probeCookiesEnabled(
+  api: ApiConnection
+): Promise<CookieProbeResult> {
+  try {
+    const setResponse = await api.call<{ ok: boolean }>('cookie-check/set');
+    if (!setResponse?.ok) {
+      // The set call failed or answered unexpectedly (e.g. an older backend
+      // without the endpoint): the probe is inconclusive, not a block.
+      return 'unknown';
+    }
+
+    const verifyResponse = await api.call<{ cookiesEnabled: boolean }>(
+      'cookie-check/verify'
+    );
+    if (verifyResponse === null || verifyResponse === undefined) {
+      return 'unknown';
+    }
+
+    return verifyResponse.cookiesEnabled ? 'enabled' : 'blocked';
+  } catch {
+    // Network failures and thrown errors are inconclusive by definition.
+    return 'unknown';
+  }
+}

--- a/packages/send/frontend/src/lib/messages.ts
+++ b/packages/send/frontend/src/lib/messages.ts
@@ -15,10 +15,24 @@ export const CLIENT_MESSAGES = {
   // between production, staging and local builds, and the setting path is the
   // part the user can act on.
   COOKIES_BLOCKED_TITLE: `Thunderbird is blocking cookies for Send`,
-  // Login-banner copy: the banner offers a "Retry" button.
+  // Shown by the login banner and the boot panel; both offer a "Retry" button.
   COOKIES_BLOCKED_BANNER_BODY:
     `Send stores a cookie to keep you signed in, and your browser is currently ` +
     `refusing it. Open Settings → Privacy & Security → Web Content and turn on ` +
     `"Accept cookies from sites". If that is already on, also set "Accept ` +
     `third-party cookies" to "From visited". Then choose "Retry".`,
+
+  // Boot diagnostics (apps/send/BootDiagnostics.vue). With "block all
+  // cookies" Firefox denies browser storage too, and the app bundle cannot
+  // load at all, so this is shown by the pre-app bootstrap.
+  STORAGE_BLOCKED_TITLE: `Thunderbird is blocking storage for Send`,
+  STORAGE_BLOCKED_BODY:
+    `Send keeps your sign-in state and encryption keys in browser storage, ` +
+    `and your browser is refusing access to it. This happens when all cookies ` +
+    `are blocked. Open Settings → Privacy & Security → Web Content and turn on ` +
+    `"Accept cookies from sites", then choose "Retry".`,
+  APP_LOAD_FAILED_TITLE: `Send could not start`,
+  APP_LOAD_FAILED_BODY:
+    `The application failed to load. Choose "Retry" to reload the page. ` +
+    `If this keeps happening, please let us know.`,
 };

--- a/packages/send/frontend/src/lib/messages.ts
+++ b/packages/send/frontend/src/lib/messages.ts
@@ -10,4 +10,15 @@ export const CLIENT_MESSAGES = {
   FILE_TOO_BIG: `Your file size is not supported, please try with files smaller than ${MAX_FILE_SIZE_HUMAN_READABLE}`,
   UPLOAD_FAILED: `Upload failed. Please try again.`,
   STORAGE_LIMIT_EXCEEDED: `Uploading this file would exceed your storage limit. Please delete some files and try again.`,
+
+  // Bugzilla 2064458. The backend host is deliberately not named: it changes
+  // between production, staging and local builds, and the setting path is the
+  // part the user can act on.
+  COOKIES_BLOCKED_TITLE: `Thunderbird is blocking cookies for Send`,
+  // Login-banner copy: the banner offers a "Retry" button.
+  COOKIES_BLOCKED_BANNER_BODY:
+    `Send stores a cookie to keep you signed in, and your browser is currently ` +
+    `refusing it. Open Settings → Privacy & Security → Web Content and turn on ` +
+    `"Accept cookies from sites". If that is already on, also set "Accept ` +
+    `third-party cookies" to "From visited". Then choose "Retry".`,
 };

--- a/packages/send/frontend/src/lib/testUtils.ts
+++ b/packages/send/frontend/src/lib/testUtils.ts
@@ -1,3 +1,30 @@
 export function getByTestId(id) {
   return `[data-testid="${id}"]`;
 }
+
+type WebStorageName = 'localStorage' | 'sessionStorage';
+
+/**
+ * Simulates Firefox with "block all cookies" (network.cookie.cookieBehavior =
+ * 2), where the named storage getters THROW a SecurityError instead of
+ * returning a store. Returns a function that restores the originals.
+ */
+export function denyStorage(...names: ReadonlyArray<WebStorageName>) {
+  const restores = names.map((name) => {
+    const original = Object.getOwnPropertyDescriptor(window, name);
+    Object.defineProperty(window, name, {
+      configurable: true,
+      get() {
+        throw new DOMException('The operation is insecure.', 'SecurityError');
+      },
+    });
+    return () => {
+      if (original) {
+        Object.defineProperty(window, name, original);
+      } else {
+        delete (window as Partial<Record<WebStorageName, Storage>>)[name];
+      }
+    };
+  });
+  return () => restores.forEach((restore) => restore());
+}


### PR DESCRIPTION
## What changed?

When Thunderbird is set to block cookies, Send now tells the user what is wrong and how to fix it, instead of showing a blank page.

There are two layers:

- **A boot check that runs before the app loads.** The web app entry now starts with a tiny, self-contained check, shown as a spinner. It verifies that browser storage works, that a cookie set by the Send server comes back, and that the server is reachable. If everything passes, nothing is shown: the spinner is replaced by the app. If a check blocks, the user sees a short checklist marking exactly which step failed (with the browser's own error text) and a plain-language message with the setting to change, plus a **Retry** button. When only cross-site cookies are blocked, there is also **Continue anyway**, so share links still work.
- **The login-screen banner** from the first commit, kept for users who chose "Continue anyway" or navigated to login later.

To make the check possible before anyone logs in, the backend gained a small "cookie check": it hands the browser a throwaway cookie and asks whether it came back. The warning shows only when we are certain; an inconclusive answer (offline, older server) never blocks and is never shown as "cookies blocked".

Nothing about how the app signs users in was changed, and no new browser permissions were added.

Key files: `apps/send/send.js` (two-stage entry), `apps/send/startApp.js` (the old entry body), `apps/send/BootDiagnostics.vue` (spinner / checklist), `lib/bootDiagnostics.ts` (the checks), `lib/cookieProbe.ts`, and the two `/api/cookie-check/*` routes.

AI disclosure: agent-written, human-directed. The scope (detection and message only, no changes to sign-in), the "positive check" approach, and the spinner-only-until-failure presentation were human decisions. The root-cause investigation, code, and tests were written by the agent and reviewed step by step.

## Why?

Send keeps you signed in with a cookie. When Thunderbird is set to refuse cookies, that cookie never reaches the server and the app quietly stops working, with no explanation. (Bugzilla 2064458.)

The first attempt, a banner on the login screen, could not work on its own. With "block all cookies", Firefox makes `localStorage` and `sessionStorage` *throw* rather than return an empty store, and two libraries in the app touch storage while their modules load. The whole bundle failed before Vue mounted anything, so no in-app banner could ever appear. The only place a warning can live is code that runs before that bundle, which is what the boot check is.

## Limitations and Notes

- The message names the Thunderbird settings path ("Settings → Privacy & Security → Web Content" → "Accept cookies from sites"). Please double-check those labels against the live Settings screen.
- The cookie check needs to be live on the server; against an older server the check is inconclusive and the app simply starts.
- Local dev cannot reproduce the *third-party-only* block: `localhost:5173` and `localhost:8088` are same-site, so only the "block all cookies" case is verifiable locally. The cross-site path is covered by unit tests.
- The login screen probes once more when it renders (the banner reuses the same endpoints). That is two small requests on the login page only, left as is.
- Removing the cookie dependency from sign-in entirely is separate, larger work.

## Applicable Issues

Closes #1191.

## Screenshots

This is a blocked state error message

<img width="662" height="494" alt="Screenshot 2026-09-04 at 10 48 08 AM" src="https://github.com/user-attachments/assets/434d94e8-ce00-4fc7-856b-1f2caca962d2" />


## Manual testing

### Prerequisites

Before you do anything you should have a local copy of Thunderbird built and ready to run on your machine. You can follow [this guide](https://developer.thunderbird.net/thunderbird-development/getting-started) to get that set up.

You also need the tbpro-add-on project running in dev mode so the backend and frontend work on web locally. Check the docs for that.

1. Build the add-on for local testing by running `cd packages/addon && pnpm run build:dev:system:local` this will create an xpi for local testing.
2. Copy the path from the resulting xpi that lives in `packages/addon/tbpro-addon-2-0-11.xpi`
3. cd into the scripts folder `cd packages/addon/scripts`
4. Point the script to your thunderbird source path, for example`export TB_COMM_SRC=/Users/you/tb-build/source`
5. Run the script and pass the xpi path as an argument `./sync-to-builtin.sh '/Users/you/tbpro-add-on/packages/addon/tbpro-addon-2-0-11.xpi'
6. After successfully running it will suggest a command to run that looks like this `cd "$TB_COMM_SRC" && ./mach build faster && ./mach run --temp-profile` It will build and run Thunderbird for you. Note that the `--temp-profile` flag is optional.

**Note**: Now you can test, but you might need to run build commands from the Thunderbird source to make sure the build works correctly. Refer to the Thunderbird documentation for that. After running `../mach build` sometimes the console will ask you to run other commands, you should do that so that everything works. The ultimate goal is to run `../mach run` and open an instance of Thunderbird`

To make sure Thunderbird works well with the local environment, you should go to `Settings -> Privacy & Security -> Security` and click on the `Manage Certificates` button. Click on the `Servers` tab and then `Add Exception..` add `https://localhost:8088` to the input and click `Get Certificate`


### Golden path for users who block cookies

Users who block cookies should make these exceptions:
`https://tb.pro` (auth and frontend)
`https://send.backend.tb.pro` (backend)

If you're testing locally you should allow
`https://tb.pro` (auth)
`http://localhost:5173/` (frontend)
`https://localhost:8088/` (backend)


1. Make sure you're logged in before you turn off cookies. If you don't, you'll be actually testing accounts being blocked (out of scope yet reported).
2. **Cookies off (the case this fixes):**  In Thunderbird, go to  `Settings -> Privacy & Security -> Privacy` and uncheck the `Accept cookies from sites` box. Then click the `Exceptions...` button. Here you should add`http://localhost:5173/` (refer to the golden path list so you can remove or add what you need.
2. Click on the hamburger menu -> your username -> manage send files. Expected: a brief spinner, then the checklist with "Browser storage is available" marked failed and the storage warning with a **Retry** button. No blank page.
8. **Fix it live:** change the cookie setting to allow cookies, then click **Retry**. Expected: the page reloads and the app opens normally.
9. **Normal case (no false alarm):** with cookies allowed, reload. Expected: only a spinner, then the app. No checklist, no banner.
10. **Offline (inconclusive, no false alarm):** allow cookies but disconnect from the network, then load Send. Expected: the app starts as usual (the existing "server unreachable" handling applies); nothing says "cookies blocked".
11. **Third-party cookies only (needs a deployed environment):** set `cookieBehavior` to `1` against staging. Expected: the checklist with "Send server cookies are accepted" failed, the cookie warning, **Retry** and **Continue anyway**. Continuing opens the login screen with its banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
