### PR TITLE
[SEND] Re-enable encrypted-files E2E test on BrowserStack Android

### DIFF
--- a/packages/send/e2e/pages/encrypted-files-page.ts
+++ b/packages/send/e2e/pages/encrypted-files-page.ts
@@ -33,7 +33,10 @@ export class EncryptedFilesPage {
   constructor(page: Page) {
     this.page = page;
     this.sendHdrLogoLink = this.page.locator('header img[alt="Send"]');
-    this.signedInUsername = this.page.locator('#send-page main > header span');
+    // The username is the header's direct-child span. Restricting this to a
+    // direct child avoids matching implementation-detail spans inside adjacent
+    // header controls, which causes Playwright strict-mode failures.
+    this.signedInUsername = this.page.locator('#send-page main > header > span');
     this.yourFilesHeading = this.page.getByRole('heading', { name: 'Your Files' });
     this.userAvatar = this.page.getByTestId('avatar-default');
     this.userAvatarMenuBtn = this.page.locator('aside.avatar.regular');
@@ -179,28 +182,71 @@ export class EncryptedFilesPage {
     );
   }
 
-  async downloadFileFromInfoPanelAndExpectDownload(uploadFixture: UploadFixture) {
+  async downloadFileFromInfoPanelAndExpectDownload(
+    uploadFixture: UploadFixture,
+    useBrowserStackAndroidSignal = false
+  ) {
     const { fileName } = uploadFixture;
     const fileRow = this.fileRow(fileName);
 
     await expect(fileRow).toBeVisible();
-    await fileRow.scrollIntoViewIfNeeded();
-    await fileRow.click({ force: true });
+    // MOBILE PATH: the upload area is fixed to the bottom of narrow viewports.
+    // Playwright's scrollIntoViewIfNeeded() treats a row behind that overlay as
+    // visible, so always move it to the unobscured center before tapping it.
+    await this.scrollFileRowClearOfUploadBar(fileRow);
+    // Do not force this click. If the upload area still covers the row, a normal
+    // click reports the overlap instead of opening the native file chooser.
+    await fileRow.click();
 
-    const fileInfoPanel = this.page.locator('#send-page > aside').last();
+    const fileInfoPanel = this.fileInfoPanel();
     await expect(fileInfoPanel.getByText(fileName, { exact: true })).toBeVisible({
       timeout: TIMEOUT_30_SECONDS,
     });
 
-    const downloadPromise = this.page.waitForEvent('download');
-    await fileInfoPanel.locator('footer button svg').last().click({ force: true });
+    // The deployed app does not expose a test ID or accessible name for this
+    // control. Download is the first footer icon and Delete is the last, so
+    // target the first SVG; its click handler starts the download directly.
+    const downloadButton = fileInfoPanel.locator('footer button svg').first();
+    await expect(downloadButton).toBeVisible();
 
-    await this.expectDownloadMatchesFixture(await downloadPromise, uploadFixture);
+    if (useBrowserStackAndroidSignal) {
+      // BROWSERSTACK ANDROID PATH: real Android Chrome downloads the file, but
+      // BrowserStack does not forward that device download as Playwright's
+      // `download` event. Android's native "File downloaded" notification is
+      // outside the web page and cannot be located by Playwright, so observe
+      // Send clicking its generated <a download> link instead. That is the
+      // page-side action which immediately hands the file to Android Chrome.
+      await this.expectGeneratedDownloadIsTriggered(downloadButton);
+    } else {
+      // PIXEL VIEWPORT PATH: the emulated browser reports Playwright download
+      // events normally. Send must first fetch and decrypt the complete file,
+      // so allow longer than the suite's 10-second action timeout.
+      // Register the listener before the single click; clicking twice would
+      // start duplicate downloads and hide a real application failure.
+      const [download] = await Promise.all([
+        this.page.waitForEvent('download', { timeout: TIMEOUT_60_SECONDS }),
+        downloadButton.click(),
+      ]);
+
+      await this.expectDownloadMatchesFixture(download, uploadFixture);
+    }
+
+    // The mobile info panel is a full-screen overlay. Close it after the
+    // download so the file list is available to the cleanup path below.
+    await fileInfoPanel.getByTestId('close-file-info').click();
+    await expect(fileInfoPanel).not.toBeVisible();
   }
 
-  async deleteUploadedFiles(fileNames: string[]) {
+  async deleteUploadedFiles(fileNames: string[], useInfoPanel = false) {
     for (const fileName of fileNames) {
-      await this.deleteUploadedFileIfVisible(fileName);
+      if (useInfoPanel) {
+        // MOBILE PATH: row action buttons are intentionally not rendered on
+        // narrow viewports, so delete from the full-screen file info panel.
+        await this.deleteUploadedFileFromInfoPanelIfVisible(fileName);
+      } else {
+        // DESKTOP PATH: retain the existing direct row-action workflow.
+        await this.deleteUploadedFileIfVisible(fileName);
+      }
     }
   }
 
@@ -214,6 +260,39 @@ export class EncryptedFilesPage {
     await fileRow.scrollIntoViewIfNeeded();
     await fileRow.getByTestId('delete-file').click({ force: true });
 
+    await this.confirmFileDeletion(fileRow);
+  }
+
+  async deleteUploadedFileFromInfoPanelIfVisible(fileName: string) {
+    const fileRow = this.fileRow(fileName);
+
+    // Cleanup may begin after a failed assertion left another file's mobile
+    // info panel open. Dismiss it first so it cannot intercept the row click.
+    const openFileInfoPanel = this.fileInfoPanel();
+    if (await openFileInfoPanel.isVisible()) {
+      await openFileInfoPanel.getByTestId('close-file-info').click();
+      await expect(openFileInfoPanel).not.toBeVisible();
+    }
+
+    if (!(await fileRow.isVisible())) {
+      return;
+    }
+
+    // MOBILE PATH: explicitly position the row above the fixed upload area,
+    // then open the info panel where mobile file actions are exposed.
+    await this.scrollFileRowClearOfUploadBar(fileRow);
+    await fileRow.click();
+
+    const fileInfoPanel = this.fileInfoPanel();
+    await expect(fileInfoPanel.getByText(fileName, { exact: true })).toBeVisible({
+      timeout: TIMEOUT_30_SECONDS,
+    });
+    await fileInfoPanel.getByTestId('delete-file-info').click();
+
+    await this.confirmFileDeletion(fileRow);
+  }
+
+  private async confirmFileDeletion(fileRow: Locator) {
     await this.page.waitForTimeout(TIMEOUT_1_SECOND); // mostly so captured on browserstack video
     const deleteModal = this.page.getByTestId('delete-modal');
     await expect(deleteModal).toBeVisible();
@@ -223,6 +302,70 @@ export class EncryptedFilesPage {
     await confirmDeleteButton.click();
 
     await expect(fileRow).not.toBeVisible({ timeout: TIMEOUT_60_SECONDS });
+  }
+
+  private async scrollFileRowClearOfUploadBar(fileRow: Locator) {
+    // The mobile upload bar is fixed and therefore does not affect whether
+    // Playwright considers the row in the viewport. scrollIntoViewIfNeeded()
+    // can consequently do nothing while the bar still intercepts the click.
+    // The page reserves bottom padding equal to the bar's measured height, so
+    // explicitly centering the row moves it into the usable part of the screen.
+    await fileRow.evaluate((element) => {
+      element.scrollIntoView({ block: 'center', inline: 'nearest' });
+    });
+    await expect(fileRow).toBeVisible();
+  }
+
+  private async expectGeneratedDownloadIsTriggered(downloadButton: Locator) {
+    // Send downloads and decrypts the file before creating a blob URL and
+    // programmatically clicking a temporary <a download> element. Install this
+    // test-only hook before the user-facing click so the BrowserStack Android
+    // path can observe that final handoff even though the native browser message
+    // and Playwright Download object are unavailable to the page. The original
+    // anchor click still runs, so Android downloads the file normally.
+    await this.page.evaluate(() => {
+      const captureWindow = window as typeof window & {
+        __tbSendE2EDownloadTriggered?: boolean;
+      };
+      const originalClick = HTMLAnchorElement.prototype.click;
+      captureWindow.__tbSendE2EDownloadTriggered = false;
+
+      HTMLAnchorElement.prototype.click = function () {
+        if (this.download && this.href.startsWith('blob:')) {
+          captureWindow.__tbSendE2EDownloadTriggered = true;
+
+          // Restore immediately after intercepting Send's generated link so the
+          // hook cannot affect any later anchor interactions in this test.
+          HTMLAnchorElement.prototype.click = originalClick;
+        }
+
+        return originalClick.call(this);
+      };
+    });
+
+    await downloadButton.click();
+
+    await expect
+      .poll(
+        () =>
+          this.page.evaluate(() => {
+            const captureWindow = window as typeof window & {
+              __tbSendE2EDownloadTriggered?: boolean;
+            };
+            return captureWindow.__tbSendE2EDownloadTriggered;
+          }),
+        { timeout: TIMEOUT_60_SECONDS }
+      )
+      .toBe(true);
+  }
+
+  private fileInfoPanel() {
+    // Select by panel content instead of using `#send-page > aside:last-child`.
+    // Once the mobile panel closes, the upload bar becomes the last aside and a
+    // dynamic `.last()` locator would unexpectedly start pointing at that bar.
+    return this.page.locator('#send-page > aside').filter({
+      has: this.page.getByTestId('close-file-info'),
+    });
   }
 
   completedUploadListItem(fileName: string) {

--- a/packages/send/e2e/tests/encrypted-files.spec.ts
+++ b/packages/send/e2e/tests/encrypted-files.spec.ts
@@ -17,7 +17,7 @@ test.describe('encrypted files', () => {
     tag: [PLAYWRIGHT_TAG_DESKTOP_NIGHTLY, PLAYWRIGHT_TAG_MOBILE_NIGHTLY],
   }, async ({ page }, testInfo) => {
     const isMobile = isMobileProject(testInfo.project.name);
-    test.skip(isMobile, 'Skipping on mobile until issue 977 (file info panel covers delete button on mobile) is resolved');
+    const isBrowserStackAndroid = testInfo.project.name === 'android-chrome';
 
     if (isMobile) {
       test.setTimeout(FIVE_MINUTES);
@@ -50,13 +50,18 @@ test.describe('encrypted files', () => {
       await encryptedFilesPage.uploadFileWithFilePicker(filePickerFixture);
       await encryptedFilesPage.uploadFileWithDragAndDrop(dragDropFixture);
       if (isMobile) {
-        await encryptedFilesPage.downloadFileFromInfoPanelAndExpectDownload(filePickerFixture);
+        await encryptedFilesPage.downloadFileFromInfoPanelAndExpectDownload(
+          filePickerFixture,
+          isBrowserStackAndroid
+        );
       } else {
         await encryptedFilesPage.downloadFileAndExpectDownload(filePickerFixture);
       }
     } finally {
       // Keep the shared test account tidy even if a later upload assertion fails.
-      await encryptedFilesPage.deleteUploadedFiles(uploadedFileNames);
+      // Mobile exposes delete in the full-screen file info panel; desktop keeps
+      // using the action button rendered directly in each file row.
+      await encryptedFilesPage.deleteUploadedFiles(uploadedFileNames, isMobile);
     }
   });
 });


### PR DESCRIPTION
## What Changed

Enabled the encrypted-files E2E test on mobile by removing its mobile skip. There were several issues that needed to be addressed in order to get the test working on Android in BrowserStack (and the playwright android viewport):

- Added mobile-specific file-row positioning that explicitly centres rows above the fixed upload area.
- Removed forced mobile row clicks so Playwright can detect genuine overlap problems instead of accidentally clicking the upload zone.
- Added separate file-action paths:
  - Mobile uses the full-screen file info panel.
  - Desktop continues using the existing file-row actions.
- Updated mobile downloads to target the existing Download SVG rather than the adjacent Delete action.
- Increased the Pixel viewport download-event timeout to account for fetching and decrypting the file before the browser download begins.
- Added a BrowserStack Android-specific download signal:
  - Does not wait for the unsupported Playwright download event.
  - Observes Send clicking its generated blob-backed `<a download>` element.
  - Allows the original click to continue so Android Chrome downloads the file normally.
- Updated mobile cleanup to delete uploaded files through the info panel.
- Extracted shared deletion-confirmation logic for desktop and mobile.
- Hardened cleanup by closing any info panel left open after an earlier assertion failure.
- Replaced the dynamic “last aside” info-panel locator with a stable content-based locator.
- Narrowed the signed-in username selector to the header’s direct-child span, preventing Playwright strict-mode failures caused by unrelated nested spans.
- Added comments explaining the mobile, Pixel viewport, BrowserStack Android, and desktop paths.

## Why

On narrow viewports, the upload area is fixed to the bottom of the screen and can cover file rows. Playwright’s `scrollIntoViewIfNeeded()` considers those rows visible even when the fixed upload area obscures them. Forced clicks then bypass overlap protection and can open the native file chooser instead of the file info panel.

Mobile layouts also intentionally omit row-level download and delete controls. Those actions must be performed through the file info panel, while desktop browsers can continue using the existing row controls.

The Playwright Pixel viewport reports browser download events normally, but downloading and decrypting the test file can exceed the default 10-second action timeout.

BrowserStack’s real Android Chrome session successfully downloads the file and displays its native “File downloaded” notification, but it does not forward that download as a Playwright `download` event. The Android-specific signal therefore observes the page-side blob download trigger instead.

The username selector also matched nested spans inside other header controls, causing a strict-mode violation when more than one matching element was rendered.

## Limitations

- BrowserStack Android cannot use Playwright’s `Download` object for this workflow. Its test path verifies that Send completes processing and triggers the generated blob download, but it does not independently inspect the downloaded device file.
- Exact filename, byte-length, and SHA-256 verification remains enabled for the Playwright Pixel viewport and desktop browser paths.
- The Android native “File downloaded” notification is browser UI rather than webpage content, so it cannot be asserted with a Playwright page locator.
- The mobile scrolling helper relies on the application continuing to reserve bottom padding corresponding to the fixed upload area’s measured height.

## Notes
No application code was changed. All changes are confined to the E2E test and page-object code. I worked with ChatGPT's Codex to devleop this patch. I reviewed and thoroughly tested all code changes.

## Applicable Issues
Fixes #1201.

## QA Log
Ran the updated encrypted-files E2E test on:

- Firefox desktop on my local machine ✅ 
- The Playwright Google Pixel Android viewport simulator on my local machine ✅ 
- Android Chrome on a Google Pixel 10 device [in BrowserStack](https://automate.browserstack.com/projects/Thunderbird+Send/builds/TB+Send+Nightly+Tests+Android+Chrome/276?tab=sessions&bls_localTimezone=true) ✅ 
- Firefox desktop [in BrowserStack](https://automate.browserstack.com/projects/Thunderbird+Send/builds/TB+Send+Nightly+Tests+Firefox+Desktop/260?tab=sessions&bls_localTimezone=true) ✅ 
- Chromium desktop [in BrowserStack](https://automate.browserstack.com/projects/Thunderbird+Send/builds/TB+Send+Nightly+Tests+Chromium+Desktop/234?tab=sessions&bls_localTimezone=true) ✅ 
- Safari desktop [in BrowserStack](https://automate.browserstack.com/projects/Thunderbird+Send/builds/TB+Send+Nightly+Tests+Safari+Desktop/245?tab=sessions&bls_localTimezone=true) ✅ 
- Ran the updated test on mobile with zero files preexisting in the TB Send encrypted files list, and with 20 files already existing ✅ 