### PR TITLE
feat(analytics): standardize event naming + central catalog + structured page-load (#1076)

### DIFF
--- a/packages/send/backend/src/metrics/events.ts
+++ b/packages/send/backend/src/metrics/events.ts
@@ -1,0 +1,16 @@
+/**
+ * Central analytics event catalog (backend).
+ *
+ * Naming convention: `object_action` in snake_case, e.g. `upload_completed`,
+ * `access_link_created`. Property keys must also be snake_case. Keep names
+ * consistent with the frontend catalog in
+ * packages/send/frontend/src/lib/analytics/events.ts.
+ */
+export const ANALYTICS_EVENTS = {
+  ACCESS_LINK_CREATED: 'access_link_created',
+  UPLOAD_COMPLETED: 'upload_completed',
+  PAGE_LOADED: 'page_loaded',
+} as const;
+
+export type AnalyticsEventName =
+  (typeof ANALYTICS_EVENTS)[keyof typeof ANALYTICS_EVENTS];

--- a/packages/send/backend/src/routes/metrics.ts
+++ b/packages/send/backend/src/routes/metrics.ts
@@ -4,6 +4,7 @@ import {
 } from '@send-backend/auth/client';
 import { Router } from 'express';
 import { useMetrics } from '../metrics';
+import { ANALYTICS_EVENTS } from '../metrics/events';
 import { getUniqueHashFromAnonId } from '../utils/session';
 
 const router: Router = Router();
@@ -19,7 +20,7 @@ router.post('/api/metrics/page-load', (req, res) => {
     // will use anon_id
   }
 
-  const data = req.body;
+  const data = req.body ?? {};
 
   const metrics = useMetrics();
 
@@ -27,11 +28,22 @@ router.post('/api/metrics/page-load', (req, res) => {
 
   anon_id = getUniqueHashFromAnonId(anon_id);
 
-  const event = 'page-load';
-  const properties = {
-    ...data,
-    service: 'send',
-  };
+  const event = ANALYTICS_EVENTS.PAGE_LOADED;
+
+  // Only forward an explicit allow-list of properties; never spread req.body.
+  const ALLOWED_PROPERTIES = [
+    'browser_version',
+    'os_version',
+    'path',
+    'page',
+  ] as const;
+
+  const properties: Record<string, unknown> = { service: 'send' };
+  for (const key of ALLOWED_PROPERTIES) {
+    if (data[key] !== undefined) {
+      properties[key] = data[key];
+    }
+  }
 
   if (uniqueHash) {
     metrics.capture({

--- a/packages/send/backend/src/routes/sharing.ts
+++ b/packages/send/backend/src/routes/sharing.ts
@@ -25,6 +25,7 @@ import {
 
 import { getDataFromAuthenticatedRequest } from '@send-backend/auth/client';
 import { useMetrics } from '@send-backend/metrics';
+import { ANALYTICS_EVENTS } from '@send-backend/metrics/events';
 import {
   addExpiryToContainer,
   formatAccessLinkWithPasswordHash,
@@ -128,7 +129,7 @@ router.post(
     );
 
     Metrics.capture({
-      event: 'accessLink.created',
+      event: ANALYTICS_EVENTS.ACCESS_LINK_CREATED,
       distinctId: uniqueHash,
       properties: {
         id: accessLink.id,

--- a/packages/send/backend/src/routes/uploads.ts
+++ b/packages/send/backend/src/routes/uploads.ts
@@ -26,6 +26,7 @@ import { deleteUploadsByIds, reportUpload } from '@send-backend/models';
 import storage from '@send-backend/storage';
 import { createRateLimiter } from '../middleware/rate-limit';
 import { useMetrics } from '../metrics';
+import { ANALYTICS_EVENTS } from '../metrics/events';
 import {
   checkStorageLimit,
   getGroupMemberPermissions,
@@ -109,7 +110,7 @@ router.post(
       );
       // Capture metrics
       Metrics.capture({
-        event: 'upload.size',
+        event: ANALYTICS_EVENTS.UPLOAD_COMPLETED,
         properties: { size, type },
         distinctId,
       });

--- a/packages/send/backend/src/test/routes/metrics.test.ts
+++ b/packages/send/backend/src/test/routes/metrics.test.ts
@@ -51,7 +51,7 @@ describe('POST /api/metrics/page-load', () => {
 
     const expectedResponse = {
       distinctId: 'hash',
-      event: 'page-load',
+      event: 'page_loaded',
       properties: {
         ...mockPayload,
         service: 'send',
@@ -87,7 +87,7 @@ describe('POST /api/metrics/page-load', () => {
 
     const expectedResponse = {
       distinctId: mockedHash,
-      event: 'page-load',
+      event: 'page_loaded',
       properties: {
         ...mockPayload,
         service: 'send',
@@ -104,5 +104,51 @@ describe('POST /api/metrics/page-load', () => {
     expect(mockcapture).toBeCalledWith(expectedResponse);
 
     expect(response.status).toBe(200);
+  });
+
+  it('only forwards allow-listed properties and drops arbitrary keys', async () => {
+    mockcapture.mockClear();
+    mockAuth.mockImplementation(() => {
+      throw new Error('no token');
+    });
+
+    const mockPayload = {
+      browser_version: '2.0',
+      os_version: '3.0',
+      path: '/share',
+      page: 'share',
+      // These must NOT leak through:
+      email: 'evil@example.com',
+      $set: { admin: true },
+      random_junk: 'nope',
+    };
+
+    const response = await request(app)
+      .post('/api/metrics/page-load')
+      .send(mockPayload)
+      .set('Content-Type', 'application/json')
+      .set('Accept', 'application/json');
+
+    expect(response.status).toBe(200);
+    expect(mockcapture).toBeCalledWith({
+      distinctId: 'hash',
+      event: 'page_loaded',
+      properties: {
+        service: 'send',
+        browser_version: '2.0',
+        os_version: '3.0',
+        path: '/share',
+        page: 'share',
+      },
+    });
+
+    const captured =
+      mockcapture.mock.calls[mockcapture.mock.calls.length - 1][0];
+    expect(Object.keys(captured.properties).sort()).toEqual(
+      ['browser_version', 'os_version', 'page', 'path', 'service'].sort()
+    );
+    expect(captured.properties).not.toHaveProperty('email');
+    expect(captured.properties).not.toHaveProperty('$set');
+    expect(captured.properties).not.toHaveProperty('random_junk');
   });
 });

--- a/packages/send/frontend/src/apps/common/KeyRecovery.vue
+++ b/packages/send/frontend/src/apps/common/KeyRecovery.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import ButtonComponent from '@send-frontend/apps/send/elements/BtnComponent.vue';
+import { ANALYTICS_EVENTS } from '@send-frontend/lib/analytics/events';
 import useMetricsStore from '@send-frontend/stores/metrics';
 import {
   CopyIcon,
@@ -63,7 +64,7 @@ const onCopy = (text: string) => {
 };
 
 const submit = async () => {
-  metrics.capture('send.restore_keys_attempt', { type: 'attempt' });
+  metrics.capture(ANALYTICS_EVENTS.KEYS_RESTORE_ATTEMPTED, { type: 'attempt' });
   setPassphrase(userSetPassword.value);
   restoreFromBackup();
 };

--- a/packages/send/frontend/src/apps/send/components/ReportContent.vue
+++ b/packages/send/frontend/src/apps/send/components/ReportContent.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { ANALYTICS_EVENTS } from '@send-frontend/lib/analytics/events';
 import useApiStore from '@send-frontend/stores/api-store';
 import useMetricsStore from '@send-frontend/stores/metrics';
 import { ref } from 'vue';
@@ -18,7 +19,10 @@ const hasReported = ref(false);
 async function reportContent({ uploadId, containerId }: ReportProps) {
   console.log('reporting content', { uploadId, containerId });
   await api.call(`containers/${containerId}/report`, { uploadId }, 'POST');
-  metrics.capture('report_content_confirm', { uploadId, containerId });
+  metrics.capture(ANALYTICS_EVENTS.CONTENT_REPORT_COMPLETED, {
+    upload_id: uploadId,
+    container_id: containerId,
+  });
 
   hasReported.value = true;
   setTimeout(() => {
@@ -27,12 +31,15 @@ async function reportContent({ uploadId, containerId }: ReportProps) {
 }
 
 function handleClickReport({ uploadId, containerId }: ReportProps) {
-  metrics.capture('report_content_attempt', { uploadId, containerId });
+  metrics.capture(ANALYTICS_EVENTS.CONTENT_REPORT_STARTED, {
+    upload_id: uploadId,
+    container_id: containerId,
+  });
   hasClicked.value = true;
 }
 
 async function markAsSuspicious({ uploadId }: ReportProps) {
-  metrics.capture('report_suspicious_content');
+  metrics.capture(ANALYTICS_EVENTS.CONTENT_REPORT_FLAGGED);
   await api.call('uploads/report', { uploadId }, 'POST');
   hasReported.value = true;
   setTimeout(() => {

--- a/packages/send/frontend/src/apps/send/composables/useBackupAndRestore.ts
+++ b/packages/send/frontend/src/apps/send/composables/useBackupAndRestore.ts
@@ -1,6 +1,7 @@
 import { computed, onMounted, watchEffect } from 'vue';
 import { storeToRefs } from 'pinia';
 
+import { ANALYTICS_EVENTS } from '@send-frontend/lib/analytics/events';
 import useBackupStore from '@send-frontend/stores/backup-store';
 import useKeychainStore from '@send-frontend/stores/keychain-store';
 
@@ -231,7 +232,7 @@ export const useBackupAndRestore = () => {
       keychain.storePassPhrase(passphraseString.value);
       sendMessageToBridge(passphraseString.value);
     } catch (e) {
-      metrics.capture('send.restoreKeys.error', {
+      metrics.capture(ANALYTICS_EVENTS.KEYS_RESTORE_FAILED, {
         message: errorMessage.value,
       });
       backupStore.setErrorMessage(String(e));

--- a/packages/send/frontend/src/apps/send/router.passphraseChanged.test.ts
+++ b/packages/send/frontend/src/apps/send/router.passphraseChanged.test.ts
@@ -67,7 +67,7 @@ const guard: NavigationGuardWithThis<undefined> = async (to, _from, next) => {
   if (requiresValidToken) {
     const isTokenValid = await validateToken();
     if (!isTokenValid) {
-      captureMetric('send.invalid.token');
+      captureMetric('token_invalid');
       return next('/login');
     }
   }
@@ -157,7 +157,7 @@ describe('router guard -> /passphrase-changed (trigger path #1)', () => {
 
     // Ordering guarantee: invalid token => /login, NOT /passphrase-changed.
     expect(router.currentRoute.value.path).toBe('/login');
-    expect(captureMetric).toHaveBeenCalledWith('send.invalid.token');
+    expect(captureMetric).toHaveBeenCalledWith('token_invalid');
     expect(validateBackedUpKeys).not.toHaveBeenCalled();
   });
 

--- a/packages/send/frontend/src/apps/send/router.ts
+++ b/packages/send/frontend/src/apps/send/router.ts
@@ -27,6 +27,7 @@ import {
   useKeychainStore,
   useUserStore,
 } from '@send-frontend/stores';
+import { ANALYTICS_EVENTS } from '@send-frontend/lib/analytics/events';
 import useMetricsStore from '@send-frontend/stores/metrics';
 import { storeToRefs } from 'pinia';
 
@@ -284,7 +285,7 @@ router.beforeEach(async (to, from, next) => {
   if (requiresValidToken) {
     const isTokenValid = await validateToken(api);
     if (!isTokenValid) {
-      metrics.capture('send.invalid.token');
+      metrics.capture(ANALYTICS_EVENTS.TOKEN_INVALID);
       return next('/login');
     }
   }

--- a/packages/send/frontend/src/lib/analytics/events.test.ts
+++ b/packages/send/frontend/src/lib/analytics/events.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { ANALYTICS_EVENTS } from './events';
+
+const SNAKE_CASE = /^[a-z]+(_[a-z]+)*$/;
+
+describe('ANALYTICS_EVENTS catalog', () => {
+  const names = Object.values(ANALYTICS_EVENTS);
+
+  it('uses object_action snake_case names (no dots, no camelCase)', () => {
+    for (const name of names) {
+      expect(name, `event "${name}" must be snake_case`).toMatch(SNAKE_CASE);
+      expect(name).not.toContain('.');
+      expect(name).not.toMatch(/[A-Z]/);
+    }
+  });
+
+  it('has unique event names', () => {
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it('has at least one _ separator per name (object_action)', () => {
+    for (const name of names) {
+      expect(name.includes('_'), `event "${name}" must be object_action`).toBe(
+        true
+      );
+    }
+  });
+});

--- a/packages/send/frontend/src/lib/analytics/events.ts
+++ b/packages/send/frontend/src/lib/analytics/events.ts
@@ -1,0 +1,20 @@
+/**
+ * Central analytics event catalog (frontend).
+ *
+ * Naming convention: `object_action` in snake_case, e.g. `file_downloaded`,
+ * `access_link_created`. Property keys must also be snake_case
+ * (e.g. `upload_id`, not `uploadId`). Add new events here — never hardcode
+ * event-name strings at call sites.
+ */
+export const ANALYTICS_EVENTS = {
+  FILE_DOWNLOADED: 'file_downloaded',
+  KEYS_RESTORE_ATTEMPTED: 'keys_restore_attempted',
+  KEYS_RESTORE_FAILED: 'keys_restore_failed',
+  TOKEN_INVALID: 'token_invalid',
+  CONTENT_REPORT_STARTED: 'content_report_started',
+  CONTENT_REPORT_COMPLETED: 'content_report_completed',
+  CONTENT_REPORT_FLAGGED: 'content_report_flagged',
+} as const;
+
+export type AnalyticsEventName =
+  (typeof ANALYTICS_EVENTS)[keyof typeof ANALYTICS_EVENTS];

--- a/packages/send/frontend/src/lib/download.ts
+++ b/packages/send/frontend/src/lib/download.ts
@@ -1,4 +1,5 @@
 import { ProgressTracker } from '@send-frontend/apps/send/stores/status-store';
+import { ANALYTICS_EVENTS } from '@send-frontend/lib/analytics/events';
 import { ApiConnection } from '@send-frontend/lib/api';
 import { getBlob } from '@send-frontend/lib/filesync';
 import { Keychain } from '@send-frontend/lib/keychain';
@@ -73,7 +74,7 @@ export default class Downloader {
         progressTracker
       );
 
-      metrics.capture('download.size', { size, type });
+      metrics.capture(ANALYTICS_EVENTS.FILE_DOWNLOADED, { size, type });
       return true;
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
     } catch (e) {

--- a/packages/send/frontend/src/test/lib/download.test.ts
+++ b/packages/send/frontend/src/test/lib/download.test.ts
@@ -102,7 +102,7 @@ describe('Downloader', () => {
       expect(mockProgressTracker.setProcessStage).toHaveBeenCalledWith(
         'downloading'
       );
-      expect(mockMetrics.capture).toHaveBeenCalledWith('download.size', {
+      expect(mockMetrics.capture).toHaveBeenCalledWith('file_downloaded', {
         size: 1024,
         type: 'text/plain',
       });


### PR DESCRIPTION
## What changed?

We tidied up the foundation of our product analytics so the data we collect is trustworthy and consistent.

- Every usage event now follows **one consistent naming style**, kept in a single shared list so future events stay tidy too.
- The one general "page load" event used to accept whatever information it was handed. It now only records a **defined, predictable set of details**, so no unexpected or messy data slips in.

This is the groundwork the rest of the analytics milestone builds on.

## Why?

Our analytics had two quality problems: event names were written in several different styles, and one event collected arbitrary information with no structure. That made the data messy, hard to group, and easy to distrust. Cleaning this up first means every later piece of analytics work is built on solid, consistent data.

## Limitations and Notes

- This is intentionally the first, foundational step. The other issues in the milestone stack on top of it.
- No change to what user data we store — this is purely about naming and structure.

## Applicable Issues

Closes #1076

## Screenshots

_Not applicable — no user-facing UI changes._

<sub>Written by an AI agent (fully agent-authored), reviewed and verified by the repo owner before opening.</sub>
