### PR TITLE
fix(send/backend): let older Thunderbird add-on versions upload again

### DIFF
--- a/packages/send/backend/src/origins.ts
+++ b/packages/send/backend/src/origins.ts
@@ -5,7 +5,9 @@ import cors from 'cors';
 
 // Resolved lazily (not at module load) so importing this module — e.g. for
 // `isAddonRequest` in route files — has no side effects and doesn't require
-// `getAllowedOrigins` to be wired up.
+// `getAllowedOrigins` to be wired up. Assumes the allowed-origins list is static
+// config for the process lifetime; if it ever becomes runtime-mutable this
+// memoization needs invalidation.
 let cachedAllowedOrigins: string[] | undefined;
 function allowedOriginsList(): string[] {
   if (!cachedAllowedOrigins) {
@@ -14,7 +16,7 @@ function allowedOriginsList(): string[] {
   return cachedAllowedOrigins;
 }
 
-// The Thunderbird add-on is told apart from the webmail frontend so we can gate
+// The Thunderbird add-on is told apart from the web client so we can gate
 // add-on-only backwards-compat behaviour — e.g. skipping the required `size` on
 // /uploads/signed until the add-on is patched (private #36 regression).
 //
@@ -23,7 +25,7 @@ function allowedOriginsList(): string[] {
 //      engine, so the UA carries `Thunderbird/<version>`. This is the reliable
 //      "this is really Thunderbird" signal (a normal web page can't set it).
 //   2. Origin: the add-on runs from an extension origin (`moz-extension://...`)
-//      while the webmail frontend does not. Kept as a secondary signal and used
+//      while the web client does not. Kept as a secondary signal and used
 //      for CORS below.
 // Either match counts as an add-on request, so a UA override that drops the
 // Thunderbird token still falls back to the extension origin.
@@ -48,11 +50,11 @@ export function isThunderbirdUserAgent(userAgent: string | undefined): boolean {
  * (`Thunderbird/...`, primary) or, as a fallback, the extension origin.
  */
 export function isAddonRequest(req: Request): boolean {
-  const userAgent = req.headers['user-agent'] ?? req.headers['User-Agent'];
+  // `req.get` is Express's case-insensitive header accessor and joins any
+  // repeated header values, so a forged second UA value can't hide the token.
+  const userAgent = req.get('user-agent');
   return (
-    isThunderbirdUserAgent(
-      Array.isArray(userAgent) ? userAgent[0] : userAgent
-    ) || isExtensionOrigin(req.headers.origin)
+    isThunderbirdUserAgent(userAgent) || isExtensionOrigin(req.headers.origin)
   );
 }
 
@@ -63,7 +65,11 @@ export const originsHandler = (
 ) => {
   const origin = req.headers.origin;
 
-  const allowedOrigins = allowedOriginsList();
+  // Copy the cached list before mutating: `allowedOriginsList()` now returns a
+  // memoized reference, so pushing per-request extension origins straight onto
+  // it would permanently grow the shared cache (each unique `moz-extension://`
+  // origin accumulates forever). Work on a per-request copy instead.
+  const allowedOrigins = [...allowedOriginsList()];
 
   // Check if it's a Thunderbird extension origin
   if (isExtensionOrigin(origin)) {

--- a/packages/send/backend/src/origins.ts
+++ b/packages/send/backend/src/origins.ts
@@ -3,7 +3,58 @@ import { getAllowedOrigins } from './auth/client';
 import { X_LOGOUT_HEADER } from './config';
 import cors from 'cors';
 
-const allowedOrigins = getAllowedOrigins();
+// Resolved lazily (not at module load) so importing this module — e.g. for
+// `isAddonRequest` in route files — has no side effects and doesn't require
+// `getAllowedOrigins` to be wired up.
+let cachedAllowedOrigins: string[] | undefined;
+function allowedOriginsList(): string[] {
+  if (!cachedAllowedOrigins) {
+    cachedAllowedOrigins = getAllowedOrigins();
+  }
+  return cachedAllowedOrigins;
+}
+
+// The Thunderbird add-on is told apart from the webmail frontend so we can gate
+// add-on-only backwards-compat behaviour — e.g. skipping the required `size` on
+// /uploads/signed until the add-on is patched (private #36 regression).
+//
+// Two signals, primary first:
+//   1. User-Agent: the add-on's HTTP requests run inside Thunderbird's Gecko
+//      engine, so the UA carries `Thunderbird/<version>`. This is the reliable
+//      "this is really Thunderbird" signal (a normal web page can't set it).
+//   2. Origin: the add-on runs from an extension origin (`moz-extension://...`)
+//      while the webmail frontend does not. Kept as a secondary signal and used
+//      for CORS below.
+// Either match counts as an add-on request, so a UA override that drops the
+// Thunderbird token still falls back to the extension origin.
+export const EXTENSION_ORIGIN_PREFIX = 'moz-extension://';
+const THUNDERBIRD_UA_TOKEN = 'thunderbird';
+
+export function isExtensionOrigin(origin: string | undefined): boolean {
+  return (
+    typeof origin === 'string' && origin.startsWith(EXTENSION_ORIGIN_PREFIX)
+  );
+}
+
+export function isThunderbirdUserAgent(userAgent: string | undefined): boolean {
+  return (
+    typeof userAgent === 'string' &&
+    userAgent.toLowerCase().includes(THUNDERBIRD_UA_TOKEN)
+  );
+}
+
+/**
+ * True when the request came from the Thunderbird add-on — by User-Agent
+ * (`Thunderbird/...`, primary) or, as a fallback, the extension origin.
+ */
+export function isAddonRequest(req: Request): boolean {
+  const userAgent = req.headers['user-agent'] ?? req.headers['User-Agent'];
+  return (
+    isThunderbirdUserAgent(
+      Array.isArray(userAgent) ? userAgent[0] : userAgent
+    ) || isExtensionOrigin(req.headers.origin)
+  );
+}
 
 export const originsHandler = (
   req: Request,
@@ -12,8 +63,10 @@ export const originsHandler = (
 ) => {
   const origin = req.headers.origin;
 
+  const allowedOrigins = allowedOriginsList();
+
   // Check if it's a Thunderbird extension origin
-  if (origin && origin.startsWith('moz-extension://')) {
+  if (isExtensionOrigin(origin)) {
     allowedOrigins.push(origin);
   }
 

--- a/packages/send/backend/src/routes/uploads.ts
+++ b/packages/send/backend/src/routes/uploads.ts
@@ -171,11 +171,11 @@ router.post(
 // BACKWARDS COMPAT (private #36 regression): the size requirement is not
 // backwards compatible with add-ons already installed in Thunderbird, which
 // call this endpoint with `{ type }` and no `size` and cannot be force-updated.
-// We tell the add-on apart from the webmail frontend with `isAddonRequest`,
+// We tell the add-on apart from the web client with `isAddonRequest`,
 // which checks the User-Agent for `Thunderbird/...` (primary) and falls back to
-// the extension origin (`moz-extension://...`); the webmail frontend matches
+// the extension origin (`moz-extension://...`); the web client matches
 // neither.
-//   - WEBMAIL frontend (non-extension origin): STRICT. `size` is required; a
+//   - WEB CLIENT (non-extension origin): STRICT. `size` is required; a
 //     missing/invalid size is a 400. This client is deployed with the backend,
 //     so it always sends a valid size and full pre-check enforcement holds.
 //   - ADD-ON (extension origin): LENIENT until patched. `size` is optional; a
@@ -188,25 +188,34 @@ router.post(
 //     path again (sign the exact ciphertext content-length).
 // A `size` that IS supplied but is non-positive/non-integer is always a 400,
 // for either client — that is a malformed request, not a legacy one.
+// Both schemas share the same `size` constraints; they differ only in whether
+// `size` is required (web client) or optional (add-on lenient path). Derive the
+// lenient one from the strict field so the constraint/message stay in lockstep.
+// The strict field keeps its custom `required_error` for the missing-size case.
+const strictSizeField = z
+  .number({ required_error: 'size is required' })
+  .int()
+  .positive('size must be greater than 0');
 const signedSchemaStrict = z.object({
   type: z.string(),
-  size: z
-    .number({ required_error: 'size is required' })
-    .int()
-    .positive('size must be greater than 0'),
+  size: strictSizeField,
 });
 const signedSchemaLenient = z.object({
   type: z.string(),
-  size: z.number().int().positive('size must be greater than 0').optional(),
+  size: strictSizeField.optional(),
 });
 
 router.post(
   '/signed',
   requireJWT,
+  // Rate-limit URL minting like the other sensitive upload endpoints, so a
+  // client (including one spoofing the add-on lenient path) can't mint
+  // unbounded presigned URLs in a tight loop.
+  createRateLimiter('sensitive'),
   addErrorHandling(UPLOAD_ERRORS.INVALID_SIZE),
   wrapAsyncHandler(async (req, res, next) => {
     // The add-on (extension origin) may omit size until it is patched; the
-    // webmail frontend must always send it.
+    // web client must always send it.
     const schema = isAddonRequest(req)
       ? signedSchemaLenient
       : signedSchemaStrict;

--- a/packages/send/backend/src/routes/uploads.ts
+++ b/packages/send/backend/src/routes/uploads.ts
@@ -33,6 +33,7 @@ import {
   requireWritePermission,
 } from '../middleware';
 import { calculateEncryptedSize } from '../utils/encryptedSize';
+import { isAddonRequest } from '../origins';
 
 const router: Router = Router();
 
@@ -163,16 +164,40 @@ router.post(
  *       500:
  *         description: Failed to generate pre-signed URL
  */
-// The client must state the (plaintext) size up front so the quota check runs
-// against a real number, not the `|| 0` default that let any request pass
-// (private #36). `checkStorageLimit` reads `req.body.size`, so validation has
-// to run before it.
-const signedSchema = z.object({
+// Clients state the (plaintext) size up front so the quota check runs against a
+// real number, not the `|| 0` default that let any request pass (private #36).
+// `checkStorageLimit` reads `req.body.size`, so validation has to run before it.
+//
+// BACKWARDS COMPAT (private #36 regression): the size requirement is not
+// backwards compatible with add-ons already installed in Thunderbird, which
+// call this endpoint with `{ type }` and no `size` and cannot be force-updated.
+// We tell the add-on apart from the webmail frontend with `isAddonRequest`,
+// which checks the User-Agent for `Thunderbird/...` (primary) and falls back to
+// the extension origin (`moz-extension://...`); the webmail frontend matches
+// neither.
+//   - WEBMAIL frontend (non-extension origin): STRICT. `size` is required; a
+//     missing/invalid size is a 400. This client is deployed with the backend,
+//     so it always sends a valid size and full pre-check enforcement holds.
+//   - ADD-ON (extension origin): LENIENT until patched. `size` is optional; a
+//     request without it mints an unbound URL (no signed content-length). This
+//     is not a reopening of the bypass: the independent provider-ground-truth
+//     check in `createUpload` (/report) still verifies the stored object
+//     against `calculateEncryptedSize(size)` using the size the add-on reliably
+//     sends to /report, and only the reported row counts toward quota. When a
+//     patched add-on starts sending `size`, it transparently gets the strict
+//     path again (sign the exact ciphertext content-length).
+// A `size` that IS supplied but is non-positive/non-integer is always a 400,
+// for either client — that is a malformed request, not a legacy one.
+const signedSchemaStrict = z.object({
   type: z.string(),
   size: z
     .number({ required_error: 'size is required' })
     .int()
     .positive('size must be greater than 0'),
+});
+const signedSchemaLenient = z.object({
+  type: z.string(),
+  size: z.number().int().positive('size must be greater than 0').optional(),
 });
 
 router.post(
@@ -180,14 +205,21 @@ router.post(
   requireJWT,
   addErrorHandling(UPLOAD_ERRORS.INVALID_SIZE),
   wrapAsyncHandler(async (req, res, next) => {
-    const result = signedSchema.safeParse(req.body);
+    // The add-on (extension origin) may omit size until it is patched; the
+    // webmail frontend must always send it.
+    const schema = isAddonRequest(req)
+      ? signedSchemaLenient
+      : signedSchemaStrict;
+    const result = schema.safeParse(req.body);
     if (!result.success) {
       return res.status(400).json({
         message: result.error.issues[0]?.message ?? 'Invalid request body',
       });
     }
     // Normalize so `checkStorageLimit` (which reads `req.body.size`) gates on
-    // the validated value.
+    // the validated value when present. A lenient no-size request falls through
+    // with size undefined; checkStorageLimit then treats it as 0 (pre-#36
+    // behaviour) and the /report ground-truth check is the backstop.
     req.body.size = result.data.size;
     return next();
   }),
@@ -196,11 +228,13 @@ router.post(
   wrapAsyncHandler(async (req, res) => {
     const uploadId = uuidv4();
     const { type, size } = req.body;
-    // Sign the exact ciphertext content-length into the URL. `size` is the
-    // plaintext size the client stated (validated above); storage holds ECE
-    // ciphertext, which is deterministically larger, so we sign the encrypted
-    // size, not the plaintext claim (private #36).
-    const contentLength = calculateEncryptedSize(size);
+    // Sign the exact ciphertext content-length into the URL only when the
+    // client stated a size (new clients). `size` is the plaintext size; storage
+    // holds ECE ciphertext, which is deterministically larger, so we sign the
+    // encrypted size, not the plaintext claim (private #36). Legacy no-size
+    // requests get an unbound URL and are enforced at /report time instead.
+    const contentLength =
+      typeof size === 'number' ? calculateEncryptedSize(size) : undefined;
     try {
       const url = await storage.getUploadBucketUrl(
         uploadId,

--- a/packages/send/backend/src/test/routes/uploads.signed.routes.test.ts
+++ b/packages/send/backend/src/test/routes/uploads.signed.routes.test.ts
@@ -68,9 +68,11 @@ describe('POST /api/uploads/signed (quota bypass, private #36)', () => {
   const TB_UA =
     'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:128.0) Gecko/20100101 Thunderbird/128.0';
 
-  // WEBMAIL frontend (non-extension origin): strict. A missing size is the old
+  const WEB_ORIGIN = 'https://send.tb.pro';
+
+  // WEB CLIENT (non-extension origin): strict. A missing size is the old
   // bypass and must 400.
-  it('rejects a webmail request with no size with 400', async () => {
+  it('rejects a web client request with no size with 400', async () => {
     const res = await request(app)
       .post('/api/uploads/signed')
       .send({ type: 'application/octet-stream' })
@@ -78,6 +80,49 @@ describe('POST /api/uploads/signed (quota bypass, private #36)', () => {
 
     expect(res.status).toBe(400);
     expect(mockGetUploadBucketUrl).not.toHaveBeenCalled();
+  });
+
+  // Explicit real web-client traffic (a normal https Origin, no Thunderbird UA)
+  // must be rejected — pins the strict path independently of supertest's
+  // default User-Agent so a future default change can't silently mask it.
+  it('rejects a web-origin request with no size with 400', async () => {
+    const res = await request(app)
+      .post('/api/uploads/signed')
+      .send({ type: 'application/octet-stream' })
+      .set('Content-Type', 'application/json')
+      .set('Origin', WEB_ORIGIN);
+
+    expect(res.status).toBe(400);
+    expect(mockGetUploadBucketUrl).not.toHaveBeenCalled();
+  });
+
+  // The web client with a size still binds the signed content-length (guards the
+  // `typeof size === 'number'` branch for the strict, non-add-on path).
+  it('signs the encrypted content-length for a web-origin request that sends size', async () => {
+    const plaintext = 4096;
+    const res = await request(app)
+      .post('/api/uploads/signed')
+      .send({ type: 'application/octet-stream', size: plaintext })
+      .set('Content-Type', 'application/json')
+      .set('Origin', WEB_ORIGIN);
+
+    expect(res.status).toBe(200);
+    const [, , contentLength] = mockGetUploadBucketUrl.mock.calls[0];
+    expect(contentLength).toBeGreaterThan(plaintext);
+  });
+
+  // UA matching is case-insensitive: an uppercase Thunderbird token still counts
+  // as the add-on (lenient no-size path).
+  it('treats an uppercase THUNDERBIRD user-agent as the add-on', async () => {
+    const res = await request(app)
+      .post('/api/uploads/signed')
+      .send({ type: 'application/octet-stream' })
+      .set('Content-Type', 'application/json')
+      .set('User-Agent', 'SomeClient THUNDERBIRD/128.0');
+
+    expect(res.status).toBe(200);
+    const [, , contentLength] = mockGetUploadBucketUrl.mock.calls[0];
+    expect(contentLength).toBeUndefined();
   });
 
   // BACKWARDS COMPAT (private #36 regression): the add-on (extension origin) may
@@ -130,7 +175,7 @@ describe('POST /api/uploads/signed (quota bypass, private #36)', () => {
   });
 
   // A malformed explicit size is a 400 for EITHER client — even the add-on.
-  it('rejects an explicit size: 0 with 400 (webmail)', async () => {
+  it('rejects an explicit size: 0 with 400 (web client)', async () => {
     const res = await request(app)
       .post('/api/uploads/signed')
       .send({ type: 'application/octet-stream', size: 0 })

--- a/packages/send/backend/src/test/routes/uploads.signed.routes.test.ts
+++ b/packages/send/backend/src/test/routes/uploads.signed.routes.test.ts
@@ -64,22 +64,88 @@ describe('POST /api/uploads/signed (quota bypass, private #36)', () => {
     mockGetUploadBucketUrl.mockResolvedValue('https://bucket/signed-url');
   });
 
-  it('rejects a request with no size (the old bypass) with 400', async () => {
+  const EXT_ORIGIN = 'moz-extension://abcd-1234';
+  const TB_UA =
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:128.0) Gecko/20100101 Thunderbird/128.0';
+
+  // WEBMAIL frontend (non-extension origin): strict. A missing size is the old
+  // bypass and must 400.
+  it('rejects a webmail request with no size with 400', async () => {
     const res = await request(app)
       .post('/api/uploads/signed')
       .send({ type: 'application/octet-stream' })
       .set('Content-Type', 'application/json');
 
     expect(res.status).toBe(400);
-    // No URL is minted for an unsized request.
     expect(mockGetUploadBucketUrl).not.toHaveBeenCalled();
   });
 
-  it('rejects size: 0 with 400', async () => {
+  // BACKWARDS COMPAT (private #36 regression): the add-on (extension origin) may
+  // omit size until it is patched. It must keep working — the
+  // provider-ground-truth check in createUpload (/report) is the backstop — so a
+  // no-size add-on request mints an UNBOUND url (no signed content-length)
+  // instead of 400ing.
+  it('accepts an add-on request (extension origin) with no size and mints an unbound url', async () => {
+    const res = await request(app)
+      .post('/api/uploads/signed')
+      .send({ type: 'application/octet-stream' })
+      .set('Content-Type', 'application/json')
+      .set('Origin', EXT_ORIGIN);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ url: 'https://bucket/signed-url' });
+    // No content-length is signed for an unsized add-on request.
+    const [, , contentLength] = mockGetUploadBucketUrl.mock.calls[0];
+    expect(contentLength).toBeUndefined();
+  });
+
+  // The primary add-on signal is the Thunderbird User-Agent, even with no
+  // extension origin present.
+  it('accepts an add-on request (Thunderbird User-Agent) with no size and mints an unbound url', async () => {
+    const res = await request(app)
+      .post('/api/uploads/signed')
+      .send({ type: 'application/octet-stream' })
+      .set('Content-Type', 'application/json')
+      .set('User-Agent', TB_UA);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ url: 'https://bucket/signed-url' });
+    const [, , contentLength] = mockGetUploadBucketUrl.mock.calls[0];
+    expect(contentLength).toBeUndefined();
+  });
+
+  // A patched add-on that DOES send size transparently gets the strict path:
+  // the signed content-length is the ciphertext size.
+  it('signs the encrypted content-length for an add-on request that sends size', async () => {
+    const plaintext = 2048;
+    const res = await request(app)
+      .post('/api/uploads/signed')
+      .send({ type: 'application/octet-stream', size: plaintext })
+      .set('Content-Type', 'application/json')
+      .set('Origin', EXT_ORIGIN);
+
+    expect(res.status).toBe(200);
+    const [, , contentLength] = mockGetUploadBucketUrl.mock.calls[0];
+    expect(contentLength).toBeGreaterThan(plaintext);
+  });
+
+  // A malformed explicit size is a 400 for EITHER client — even the add-on.
+  it('rejects an explicit size: 0 with 400 (webmail)', async () => {
     const res = await request(app)
       .post('/api/uploads/signed')
       .send({ type: 'application/octet-stream', size: 0 })
       .set('Content-Type', 'application/json');
+
+    expect(res.status).toBe(400);
+    expect(mockGetUploadBucketUrl).not.toHaveBeenCalled();
+  });
+
+  it('rejects an explicit size: 0 with 400 (add-on origin)', async () => {
+    const res = await request(app)
+      .post('/api/uploads/signed')
+      .send({ type: 'application/octet-stream', size: 0 })
+      .set('Content-Type', 'application/json')
+      .set('Origin', EXT_ORIGIN);
 
     expect(res.status).toBe(400);
     expect(mockGetUploadBucketUrl).not.toHaveBeenCalled();


### PR DESCRIPTION
## What changed?

Uploading a file from the Thunderbird add-on works again.

A recent change required the file size to be sent up front when starting an upload. That broke older versions of the add-on, which don't send the size and can't be auto-updated on people's machines. This change lets the add-on keep uploading without that requirement, while the web app stays on the stricter rules.

The add-on is recognized by its Thunderbird identity on the request. Storage limits stay enforced: a separate check already re-confirms the real file size after the upload finishes, so nothing can slip past the quota.

_AI disclosure: written with an AI agent under close human direction and review; every change was reviewed and verified by a human._

## Why?

Older add-ons are already installed in people's Thunderbird and can't be forced to update. After the size requirement was added, those users couldn't upload files at all. This restores uploads for them without weakening protections for everyone else.

## Limitations and Notes

- The web app is unchanged and still requires the size up front.
- Once the add-on is updated to send the size, it automatically gets the stricter path again. The temporary allowance can be retired later once almost no old add-ons remain; full design note and long-term plan: thunderbird/private-issue-tracking#52.

## Applicable Issues

Closes thunderbird/private-issue-tracking#51

## How to test manually

1. Start an upload the way an older add-on does (no size, with a Thunderbird identity) and confirm it succeeds:
   ```
   curl -sS -X POST "$BACKEND/api/uploads/signed" \
     -H "Authorization: Bearer $JWT" \
     -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:128.0) Gecko/20100101 Thunderbird/128.0' \
     -H 'Content-Type: application/json' \
     -d '{"type":"application/octet-stream"}' -i
   ```
   Expected: `200` with an upload id and URL (before this change it returned `400`).

2. Confirm the web app still requires a size (should be rejected):
   ```
   curl -sS -X POST "$BACKEND/api/uploads/signed" \
     -H "Authorization: Bearer $JWT" \
     -H 'Origin: https://send.tb.pro' \
     -H 'Content-Type: application/json' \
     -d '{"type":"application/octet-stream"}' -i
   ```
   Expected: `400`.

3. Confirm a clearly-invalid size is still rejected for anyone:
   ```
   curl -sS ... -d '{"type":"application/octet-stream","size":0}' -i
   ```
   Expected: `400`.

4. End to end: run a real upload from an older add-on build against a backend with this change and confirm the file uploads, and that quota limits are still enforced.

